### PR TITLE
feat: :sparkles: introduce cluster managment frontend

### DIFF
--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -17,6 +17,7 @@ FROM base AS dev
 
 USER node
 RUN pnpm install --no-optional
+RUN pnpm --filter shared run build 
 ENTRYPOINT [ "pnpm", "--filter", "client", "run", "dev" ]
 
 

--- a/apps/client/cypress/components/specs/cluster-form.ct.js
+++ b/apps/client/cypress/components/specs/cluster-form.ct.js
@@ -1,0 +1,90 @@
+import VueDsfr from '@gouvminint/vue-dsfr'
+import { createPinia } from 'pinia'
+import '@gouvfr/dsfr/dist/dsfr.min.css'
+import '@gouvfr/dsfr/dist/utility/icons/icons.min.css'
+import '@gouvfr/dsfr/dist/utility/utility.main.min.css'
+import '@gouvminint/vue-dsfr/styles'
+import '@/main.css'
+import * as icons from '@/icons.js'
+import ClusterForm from '@/components/ClusterForm.vue'
+import { getRandomCluster, getRandomProject, repeatFn } from 'test-utils'
+import { useSnackbarStore } from '@/stores/snackbar.js'
+import { useAdminClusterStore } from '@/stores/admin/cluster.js'
+
+describe('ClusterForm.vue', () => {
+  it('Should mount a new cluster ClusterForm', () => {
+    const pinia = createPinia()
+
+    useSnackbarStore(pinia)
+
+    const allProjects = repeatFn(5)(getRandomProject)
+
+    const props = {
+      allProjects,
+    }
+
+    const extensions = {
+      use: [
+        [
+          VueDsfr, { icons: Object.values(icons) },
+        ],
+      ],
+      global: {
+        plugins: [pinia],
+      },
+    }
+
+    cy.mount(ClusterForm, { extensions, props })
+    cy.getByDataTestid('user-json').should('not.be.visible')
+    cy.getByDataTestid('cluster-json').should('not.be.visible')
+    cy.getByDataTestid('labelInput')
+      .type('label')
+    cy.getByDataTestid('clusterResourcesCbx').find('input[type=checkbox]')
+      .check({ force: true })
+    cy.get('#privacySelect')
+      .select('public')
+    cy.get('#element-select')
+      .select(allProjects[0].name)
+    cy.getByDataTestid('addClusterBtn').should('be.disabled')
+  })
+  it('Should mount an update cluster ClusterForm', () => {
+    const pinia = createPinia()
+
+    useSnackbarStore(pinia)
+    const adminClusterStore = useAdminClusterStore(pinia)
+
+    const allProjects = repeatFn(5)(getRandomProject)
+    adminClusterStore.clusters = [getRandomCluster([allProjects[0].id])]
+
+    const props = {
+      cluster: adminClusterStore.clusters[0],
+      allProjects,
+      isNewCluster: false,
+    }
+
+    const extensions = {
+      use: [
+        [
+          VueDsfr, { icons: Object.values(icons) },
+        ],
+      ],
+      global: {
+        plugins: [pinia],
+      },
+    }
+
+    cy.mount(ClusterForm, { extensions, props })
+
+    cy.getByDataTestid('user-json').should('be.visible')
+    cy.getByDataTestid('cluster-json').should('be.visible')
+    cy.getByDataTestid('labelInput')
+      .should('have.value', props.cluster.label)
+      .and('be.disabled')
+    cy.getByDataTestid('clusterResourcesCbx').find('input[type=checkbox]')
+      .should(props.cluster.clusterResources ? 'be.checked' : 'not.be.checked')
+    cy.get('#privacySelect')
+      .should('have.value', props.cluster.privacy)
+    cy.get('[data-testid$="-tag"]').should('have.length', props.cluster.projectsId.length)
+    cy.getByDataTestid('updateClusterBtn').should('be.enabled')
+  })
+})

--- a/apps/client/cypress/components/specs/multi-selector.ct.js
+++ b/apps/client/cypress/components/specs/multi-selector.ct.js
@@ -1,0 +1,49 @@
+import VueDsfr from '@gouvminint/vue-dsfr'
+import '@gouvfr/dsfr/dist/dsfr.min.css'
+import '@gouvfr/dsfr/dist/utility/icons/icons.min.css'
+import '@gouvfr/dsfr/dist/utility/utility.main.min.css'
+import '@gouvminint/vue-dsfr/styles'
+import '@/main.css'
+import * as icons from '@/icons.js'
+import MultiSelector from '@/components/MultiSelector.vue'
+
+describe('MultiSelector.vue', () => {
+  it('Should mount a MultiSelector', () => {
+    const props = {
+      options: [
+        {
+          name: 'name1',
+          id: '1',
+        }, {
+          name: 'name2',
+          id: '2',
+        },
+      ],
+    }
+
+    const extensions = {
+      use: [
+        [
+          VueDsfr, { icons: Object.values(icons) },
+        ],
+      ],
+    }
+
+    cy.mount(MultiSelector, { extensions, props })
+    cy.get('[data-testid$="-tag"]').should('not.exist')
+    cy.get('option')
+      .should('have.length', props.options.length + 1)
+    cy.get('#element-select')
+      .select(props.options[1].name)
+    cy.getByDataTestid(`${props.options[1].name}-tag`)
+      .should('be.visible')
+    cy.get('#element-select')
+      .select(props.options[0].name)
+    cy.getByDataTestid(`${props.options[0].name}-tag`)
+      .should('be.visible')
+    cy.get('[data-testid$="-tag"]').should('have.length', 2)
+    cy.getByDataTestid(`${props.options[0].name}-tag`)
+      .click()
+    cy.get('[data-testid$="-tag"]').should('have.length', 1)
+  })
+})

--- a/apps/client/cypress/e2e/specs/admin/clusters.e2e.js
+++ b/apps/client/cypress/e2e/specs/admin/clusters.e2e.js
@@ -1,0 +1,20 @@
+describe.skip('Administration clusters', () => {
+  let clusters
+
+  beforeEach(() => {
+    cy.intercept('GET', 'api/v1/admin/clusters').as('getAllClusters')
+
+    cy.kcLogin('tcolin')
+    cy.visit('/admin/logs')
+    cy.url().should('contain', '/admin/clusters')
+    cy.wait('@getAllClusters', { timeout: 10000 }).its('response').then(response => {
+      clusters = response?.body
+    })
+  })
+
+  it('Should display clusters list, loggedIn as admin', () => {
+    clusters.forEach(cluster => {
+      cy.getByDataTestid(`clusterTile-${cluster.id}`)
+    })
+  })
+})

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -27,6 +27,7 @@
     "@gouvminint/vue-dsfr": "^3.6.0",
     "@vue/tsconfig": "^0.4.0",
     "axios": "^1.4.0",
+    "js-yaml": "^4.1.0",
     "jszip": "^3.10.1",
     "keycloak-js": "^21.1.1",
     "nanoid": "4.0.2",

--- a/apps/client/src/api/api.js
+++ b/apps/client/src/api/api.js
@@ -166,3 +166,19 @@ export const countAllLogs = async () => {
   const response = await apiClient.get('/admin/logs/count')
   return response.data
 }
+
+// Admin - Clusters
+export const getAllClusters = async () => {
+  const response = await apiClient.get('/admin/clusters')
+  return response.data
+}
+
+export const addCluster = async (data) => {
+  const response = await apiClient.post('/admin/clusters', data)
+  return response.data
+}
+
+export const updateCluster = async (id, data) => {
+  const response = await apiClient.put(`/admin/clusters/${id}`, data)
+  return response.data
+}

--- a/apps/client/src/components/ClusterForm.vue
+++ b/apps/client/src/components/ClusterForm.vue
@@ -1,0 +1,233 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { clusterSchema, schemaValidator, isValid, instanciateSchema } from 'shared'
+import MultiSelector from './MultiSelector.vue'
+
+const props = defineProps({
+  cluster: {
+    type: Object,
+    default: () => ({
+      name: '',
+      server: '',
+      config: '',
+      secretName: undefined,
+      projects: [],
+      clusterResources: false,
+    }),
+  },
+  isNewCluster: {
+    type: Boolean,
+    default: true,
+  },
+  allProjects: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const localCluster = ref(props.cluster)
+const updatedValues = ref({})
+// const clusterToDelete = ref('')
+// const isDeletingCluster = ref(false)
+
+const errorSchema = computed(() => schemaValidator(clusterSchema, localCluster.value))
+const isClusterValid = computed(() => Object.keys(errorSchema.value).length === 0)
+
+const updateValues = (key, value) => {
+  localCluster.value[key] = value
+  updatedValues.value[key] = true
+}
+
+const emit = defineEmits(['add', 'update', 'delete', 'cancel'])
+
+const addCluster = () => {
+  updatedValues.value = instanciateSchema({ schema: clusterSchema }, true)
+  if (isClusterValid.value) emit('add', localCluster.value)
+}
+
+const updateCluster = () => {
+  updatedValues.value = instanciateSchema({ schema: clusterSchema }, true)
+  if (isClusterValid.value) emit('update', localCluster.value)
+}
+
+const cancel = (event) => {
+  emit('cancel', event)
+}
+
+</script>
+
+<template>
+  <div
+    data-testid="cluster-form"
+  >
+    <h1
+      class="fr-h1"
+    >
+      Ajouter un cluster
+    </h1>
+    <div class="fr-mb-2w w-full">
+      <DsfrInputGroup
+        v-model="localCluster.name"
+        data-testid="nameInput"
+        type="text"
+        required="required"
+        :error-message="!!updatedValues.name && !isValid(clusterSchema, localCluster, 'name') ? 'Le nom du cluster ne doit contenir ni espaces ni caractères spéciaux': undefined"
+        label="Nom du cluster applicatif"
+        label-visible
+        hint="Nom du cluster applicatif utilisable lors des déploiements Argocd"
+        placeholder="erpc-ovh"
+        @update:model-value="updateValues('name', $event)"
+      />
+    </div>
+    <div class="fr-mb-2w">
+      <DsfrInputGroup
+        v-model="localCluster.server"
+        data-testid="serverInput"
+        type="text"
+        required="required"
+        :error-message="!!updatedValues.server && !isValid(clusterSchema, localCluster, 'server') ? 'L\'url du cluster doit commencer par https': undefined"
+        label="Serveur"
+        label-visible
+        hint="Url de l'api server du cluster (clé 'server' de la kubeconfig)"
+        placeholder="https://my-cluster.com:6443"
+        class="fr-mb-2w"
+        @update:model-value="updateValues('server', $event)"
+      />
+    </div>
+    <div class="fr-mb-2w">
+      <DsfrInput
+        v-model="localCluster.config"
+        data-testid="configInput"
+        required="required"
+        :is-textarea="true"
+        label="Config du cluster"
+        label-visible
+        class="h-50"
+        hint="Configuration de connexion entre Argocd et le cluster."
+        :placeholder="JSON.stringify({
+          bearerToken: '<authentication token>',
+          tlsClientConfig: {
+            insecure: false,
+            caData: '<base64 encoded certificate>'
+          }
+        })"
+        @update:model-value="updateValues('config', $event)"
+      />
+    </div>
+    <div
+      v-if="!isNewCluster"
+      class="fr-mb-2w"
+    >
+      <DsfrInput
+        v-model="localCluster.secretName"
+        data-testid="secretNameInput"
+        label="Nom du secret"
+        label-visible
+        disabled
+        hint="Nom du secret kubernetes portant les infos du cluster."
+        placeholder="secret-name"
+        @update:model-value="updateValues('secretName', $event)"
+      />
+    </div>
+    <DsfrCheckbox
+      v-model="localCluster.clusterResources"
+      data-testid="clusterResourcesCbx"
+      label="Ressources cluster"
+      hint="Cochez la case si des ressources de type cluster peuvent être déployése par Argocd."
+      name="isClusterResources"
+      @update:model-value="updateValues('clusterResources', $event)"
+    />
+    <div class="fr-mb-2w">
+      <MultiSelector
+        :options="allProjects"
+        :array="localCluster.projects"
+        label="Nom du projet"
+        description="Ajouter à la liste des projets autorisés à utiliser ce cluster."
+        @update="updateValues('projects', $event)"
+      />
+    </div>
+    <div
+      class="flex space-x-10 mt-5"
+    >
+      <DsfrButton
+        v-if="isNewCluster"
+        label="Ajouter le cluster"
+        data-testid="addClusterBtn"
+        :disabled="!isClusterValid"
+        primary
+        icon="ri-upload-cloud-line"
+        @click="addCluster()"
+      />
+      <DsfrButton
+        v-else
+        label="Mettre à jour le cluster"
+        data-testid="updateClusterBtn"
+        :disabled="!isClusterValid"
+        primary
+        icon="ri-upload-cloud-line"
+        @click="updateCluster()"
+      />
+      <DsfrButton
+        label="Annuler"
+        data-testid="cancelClusterBtn"
+        secondary
+        icon="ri-close-line"
+        @click="cancel()"
+      />
+    </div>
+    <!-- TODO: Activer la suppression de cluster -->
+    <div
+      v-if="false"
+      data-testid="deleteClusterZone"
+      class="danger-zone"
+    >
+      <div class="flex justify-between items-center <md:flex-col">
+        <DsfrButton
+          v-show="!isDeletingCluster"
+          data-testid="showDeleteClusterBtn"
+          :label="`Supprimer le cluster ${localCluster.name}`"
+          secondary
+          icon="ri-delete-bin-7-line"
+          @click="isDeletingCluster = true"
+        />
+        <DsfrAlert
+          class="<md:mt-2"
+          description="Le retrait d'un cluster est irréversible."
+          type="warning"
+          small
+        />
+      </div>
+      <div
+        v-if="isDeletingCluster"
+        class="fr-mt-4w"
+      >
+        <DsfrInput
+          v-model="clusterToDelete"
+          data-testid="deletClusterInput"
+          :label="`Veuillez taper '${localCluster.name}' pour confirmer la suppression du cluster`"
+          label-visible
+          :placeholder="localCluster.name"
+          class="fr-mb-2w"
+        />
+        <div
+          class="flex justify-between"
+        >
+          <DsfrButton
+            data-testid="deleteClusterBtn"
+            :label="`Supprimer définitivement le cluster ${localCluster.name}`"
+            :disabled="clusterToDelete !== localCluster.name"
+            :title="`Supprimer définitivement le cluster ${localCluster.name}`"
+            secondary
+            icon="ri-delete-bin-7-line"
+            @click="$emit('delete', localCluster.id)"
+          />
+          <DsfrButton
+            label="Annuler"
+            primary
+            @click="isDeletingCluster = false"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/client/src/components/EnvironmentForm.vue
+++ b/apps/client/src/components/EnvironmentForm.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { environmentSchema, schemaValidator, instanciateSchema, allEnv, projectIsLockedInfo } from 'shared'
 import PermissionForm from './PermissionForm.vue'
 import { useSnackbarStore } from '@/stores/snackbar.js'
+import MultiSelector from './MultiSelector.vue'
 
 const props = defineProps({
   environment: {
@@ -24,6 +25,10 @@ const props = defineProps({
   isProjectLocked: {
     type: Boolean,
     default: false,
+  },
+  projectClusters: {
+    type: Array,
+    default: () => [{ id: 1, name: 'cluster1' }, { id: 2, name: 'cluster2' }],
   },
 })
 
@@ -107,6 +112,15 @@ onMounted(() => {
       @update:model-value="updateEnvironment('name', $event)"
     />
   </DsfrFieldset>
+  <div class="fr-mb-2w">
+    <MultiSelector
+      :options="projectClusters"
+      :array="localEnvironment.clusters"
+      label="Nom du cluster"
+      description="Ajouter un cluster cible pour le déploiement de cet environnement."
+      @update="updateEnvironment('clusters', $event)"
+    />
+  </div>
   <div v-if="localEnvironment.id">
     <PermissionForm
       v-if="!isDeletingEnvironment"

--- a/apps/client/src/components/MultiSelector.vue
+++ b/apps/client/src/components/MultiSelector.vue
@@ -1,0 +1,65 @@
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  options: {
+    type: Array,
+    default: () => [],
+  },
+  array: {
+    type: Array,
+    default: () => [],
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+})
+
+const localArray = ref(props.array)
+
+const arrayOptions = computed(() => props.options.map(element => ({
+  text: element.name,
+  value: element.name,
+  id: element.id,
+})))
+
+const emit = defineEmits(['update'])
+
+const addElementToArray = (element) => {
+  localArray.value.push(element)
+  emit('update', Array.from(new Set(localArray.value)))
+}
+
+const removeElementFromArray = (elementToDelete) => {
+  localArray.value = localArray.value.filter(element => element !== elementToDelete)
+  emit('update', Array.from(new Set(localArray.value)))
+}
+</script>
+
+<template>
+  <DsfrSelect
+    select-id="element-select"
+    :label="label"
+    :description="description"
+    label-visible
+    :options="arrayOptions"
+    @update:model-value="addElementToArray($event)"
+  />
+  <div
+    v-for="element in new Set(localArray)"
+    :key="element"
+    class="inline-block mr-1 ml-1"
+  >
+    <DsfrTag
+      :label="element"
+      tag-name="button"
+      class="fr-tag--dismiss"
+      @click="(event) => removeElementFromArray(event.target.outerText)"
+    />
+  </div>
+</template>

--- a/apps/client/src/components/MultiSelector.vue
+++ b/apps/client/src/components/MultiSelector.vue
@@ -57,6 +57,7 @@ const removeElementFromArray = (elementToDelete) => {
   >
     <DsfrTag
       :label="element"
+      :data-testid="`${element}-tag`"
       tag-name="button"
       class="fr-tag--dismiss"
       @click="(event) => removeElementFromArray(event.target.outerText)"

--- a/apps/client/src/components/SideMenu.vue
+++ b/apps/client/src/components/SideMenu.vue
@@ -241,6 +241,15 @@ onMounted(() => {
               Liste des logs
             </DsfrSideMenuLink>
           </DsfrSideMenuListItem>
+          <DsfrSideMenuListItem>
+            <DsfrSideMenuLink
+              data-testid="menuAdministrationClusters"
+              :active="routeName === 'ListClusters'"
+              to="/admin/clusters"
+            >
+              Liste des clusters
+            </DsfrSideMenuLink>
+          </DsfrSideMenuListItem>
         </DsfrSideMenuList>
       </DsfrSideMenuListItem>
 

--- a/apps/client/src/main.css
+++ b/apps/client/src/main.css
@@ -72,3 +72,14 @@ body,
   padding: 4rem 2rem;
   background-color: var(--background-alt-grey);
 }
+
+.json-box.jv-container span.jv-item.jv-object,
+.json-box.jv-container span.jv-key {
+  color: var(--text-default-grey);
+}
+
+.json-box.jv-container {
+  @apply my-6;
+
+  background-color: var(--background-default-grey);
+}

--- a/apps/client/src/router/index.js
+++ b/apps/client/src/router/index.js
@@ -3,7 +3,7 @@ import { useUserStore } from '@/stores/user.js'
 import { useProjectStore } from '@/stores/project.js'
 import { useSnackbarStore } from '@/stores/snackbar.js'
 
-const DsoHome = () => import('@/views/DsoHome.vue')
+import DsoHome from '@/views/DsoHome.vue'
 const ServicesHealth = () => import('@/views/ServicesHealth.vue')
 const CreateProject = () => import('@/views/CreateProject.vue')
 const ManageEnvironments = () => import('@/views/projects/ManageEnvironments.vue')
@@ -17,6 +17,7 @@ const ListUser = () => import('@/views/admin/ListUser.vue')
 const ListOrganizations = () => import('@/views/admin/ListOrganizations.vue')
 const ListProjects = () => import('@/views/admin/ListProjects.vue')
 const ListLogs = () => import('@/views/admin/ListLogs.vue')
+const ListClusters = () => import('@/views/admin/ListClusters.vue')
 
 const MAIN_TITLE = 'Console Cloud π Native'
 
@@ -106,6 +107,11 @@ const routes = [
     path: '/admin/logs',
     name: 'ListLogs',
     component: ListLogs,
+  },
+  {
+    path: '/admin/clusters',
+    name: 'ListClusters',
+    component: ListClusters,
   },
   {
     path: '/doc',

--- a/apps/client/src/stores/admin/cluster.js
+++ b/apps/client/src/stores/admin/cluster.js
@@ -1,0 +1,52 @@
+import { defineStore } from 'pinia'
+import api from '@/api/index.js'
+import { ref } from 'vue'
+
+export const useAdminClusterStore = defineStore('admin-cluster', () => {
+  const clusters = ref([])
+  const selectedCluster = ref(undefined)
+
+  const getAllClusters = async () => {
+    clusters.value = [
+      {
+        id: '1e4fdb28-f9ea-46d4-ad16-607c7f1aa8b6',
+        name: 'cluster1',
+        server: 'https://cluster1.com:6443',
+        secretName: 'jey7db28-f9ea-46d4-ad16-607c7f1aa8b6',
+        projects: [
+          'beta-app',
+        ],
+        config: JSON.stringify({
+          bearerToken: '<authentication token>',
+          tlsClientConfig: {
+            insecure: false,
+            caData: '<base64 encoded certificate>',
+          },
+        }),
+        clusterResources: true,
+      },
+    ]
+    // return api.getAllClusters()
+  }
+
+  const addCluster = async ({ name, server, secretName, projects, config, clusterResources }) => {
+    return api.addCluster({ name, server, secretName, projects, config, clusterResources })
+  }
+
+  const updateCluster = async ({ id, name, server, secretName, projects, config, clusterResources }) => {
+    return api.updateCluster(id, { name, server, secretName, projects, config, clusterResources })
+  }
+
+  // const removeCluster = async ({ name, label, active }) => {
+  //   return api.removeCluster(name, { label, active, source: 'dso-console' })
+  // }
+
+  return {
+    clusters,
+    selectedCluster,
+    getAllClusters,
+    addCluster,
+    updateCluster,
+    // removeCluster,
+  }
+})

--- a/apps/client/src/stores/admin/cluster.js
+++ b/apps/client/src/stores/admin/cluster.js
@@ -10,31 +10,45 @@ export const useAdminClusterStore = defineStore('admin-cluster', () => {
     clusters.value = [
       {
         id: '1e4fdb28-f9ea-46d4-ad16-607c7f1aa8b6',
-        name: 'cluster1',
-        server: 'https://cluster1.com:6443',
-        secretName: 'jey7db28-f9ea-46d4-ad16-607c7f1aa8b6',
-        projects: [
-          'beta-app',
+        label: 'cluster1',
+        projectsId: [
+          '22e7044f-8414-435d-9c4a-2df42a65034b',
         ],
-        config: JSON.stringify({
-          bearerToken: '<authentication token>',
-          tlsClientConfig: {
-            insecure: false,
-            caData: '<base64 encoded certificate>',
-          },
-        }),
+        user: {
+          certData: 'userCAD',
+          keyData: 'userCKD',
+        },
+        cluster: {
+          caData: 'clusterCAD',
+          server: 'https://coucou.com:5000',
+          tlsServerName: 'coucou.com',
+        },
         clusterResources: true,
+        privacy: 'dedicated',
+      },
+      {
+        id: '1e4fdb28-f9ea-46d4-ad16-607c7f1aa8b7',
+        label: 'cluster2',
+        projectsId: [
+          '22e7044f-8414-435d-9c4a-2df42a65034b',
+        ],
+        user: {
+          certData: 'userCAD',
+          keyData: 'userCKD',
+        },
+        clusterResources: true,
+        privacy: 'public',
       },
     ]
     // return api.getAllClusters()
   }
 
-  const addCluster = async ({ name, server, secretName, projects, config, clusterResources }) => {
-    return api.addCluster({ name, server, secretName, projects, config, clusterResources })
+  const addCluster = async ({ label, cluster, user, projectsId, clusterResources, privacy }) => {
+    return api.addCluster({ label, cluster, user, projectsId, clusterResources, privacy })
   }
 
-  const updateCluster = async ({ id, name, server, secretName, projects, config, clusterResources }) => {
-    return api.updateCluster(id, { name, server, secretName, projects, config, clusterResources })
+  const updateCluster = async ({ id, cluster, user, projectsId, clusterResources, privacy }) => {
+    return api.updateCluster(id, { cluster, user, projectsId, clusterResources, privacy })
   }
 
   // const removeCluster = async ({ name, label, active }) => {

--- a/apps/client/src/stores/admin/cluster.spec.js
+++ b/apps/client/src/stores/admin/cluster.spec.js
@@ -1,0 +1,121 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { apiClient } from '../../api/xhr-client.js'
+import { useAdminClusterStore } from './cluster.js'
+
+vi.spyOn(apiClient, 'get')
+vi.spyOn(apiClient, 'post')
+vi.spyOn(apiClient, 'put')
+vi.spyOn(apiClient, 'patch')
+vi.spyOn(apiClient, 'delete')
+
+// TODO : unskip
+describe.skip('Counter Store', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    // creates a fresh pinia and make it active so it's automatically picked
+    // up by any useStore() call without having to pass it to it: `useStore(pinia)`
+    setActivePinia(createPinia())
+  })
+
+  it('Should get clusters list by api call', async () => {
+    const data = [
+      {
+        id: '1e4fdb28-f9ea-46d4-ad16-607c7f1aa8b6',
+        label: 'cluster1',
+        projectsId: [
+          '22e7044f-8414-435d-9c4a-2df42a65034b',
+        ],
+        user: {
+          certData: 'userCAD',
+          keyData: 'userCKD',
+        },
+        cluster: {
+          caData: 'clusterCAD',
+          server: 'https://coucou.com:5000',
+          tlsServerName: 'coucou.com',
+        },
+        clusterResources: true,
+        privacy: 'dedicated',
+      },
+      {
+        id: '1e4fdb28-f9ea-46d4-ad16-607c7f1aa8b7',
+        label: 'cluster2',
+        projectsId: [
+          '22e7044f-8414-435d-9c4a-2df42a65034b',
+        ],
+        user: {
+          certData: 'userCAD',
+          keyData: 'userCKD',
+        },
+        clusterResources: true,
+        privacy: 'public',
+      },
+    ]
+    apiClient.get.mockReturnValueOnce(Promise.resolve({ data }))
+    const adminClusterStore = useAdminClusterStore()
+
+    const res = await adminClusterStore.getAllClusters()
+
+    expect(res).toBe(data)
+    expect(apiClient.get).toHaveBeenCalledTimes(1)
+    expect(apiClient.get.mock.calls[0][0]).toBe('/admin/clusters')
+  })
+
+  it('Should add cluster by api call', async () => {
+    const data = {
+      id: '1e4fdb28-f9ea-46d4-ad16-607c7f1aa8b6',
+      label: 'cluster1',
+      projectsId: [
+        '22e7044f-8414-435d-9c4a-2df42a65034b',
+      ],
+      user: {
+        certData: 'userCAD',
+        keyData: 'userCKD',
+      },
+      cluster: {
+        caData: 'clusterCAD',
+        server: 'https://coucou.com:5000',
+        tlsServerName: 'coucou.com',
+      },
+      clusterResources: true,
+      privacy: 'dedicated',
+    }
+    apiClient.get.mockReturnValueOnce(Promise.resolve({ data }))
+    const adminClusterStore = useAdminClusterStore()
+
+    const res = await adminClusterStore.addCluster(data)
+
+    expect(res).toBe(data)
+    expect(apiClient.post).toHaveBeenCalledTimes(1)
+    expect(apiClient.post.mock.calls[0][0]).toBe('/admin/clusters')
+  })
+
+  it('Should update cluster by api call', async () => {
+    const data = {
+      id: '1e4fdb28-f9ea-46d4-ad16-607c7f1aa8b6',
+      projectsId: [
+        '22e7044f-8414-435d-9c4a-2df42a65034b',
+      ],
+      user: {
+        certData: 'userCAD',
+        keyData: 'userCKD',
+      },
+      cluster: {
+        caData: 'clusterCAD',
+        server: 'https://coucou.com:5000',
+        tlsServerName: 'coucou.com',
+      },
+      clusterResources: true,
+      privacy: 'dedicated',
+    }
+    apiClient.get.mockReturnValueOnce(Promise.resolve({ data }))
+    const adminClusterStore = useAdminClusterStore()
+
+    const res = await adminClusterStore.updateCluster(data)
+
+    expect(res).toBe(data)
+    expect(apiClient.put).toHaveBeenCalledTimes(1)
+    expect(apiClient.put.mock.calls[0][0]).toBe('/admin/clusters/1e4fdb28-f9ea-46d4-ad16-607c7f1aa8b6')
+  })
+})

--- a/apps/client/src/views/admin/ListClusters.vue
+++ b/apps/client/src/views/admin/ListClusters.vue
@@ -1,0 +1,150 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useSnackbarStore } from '@/stores/snackbar.js'
+import { useAdminClusterStore } from '@/stores/admin/cluster.js'
+import { useAdminProjectStore } from '@/stores/admin/project.js'
+import ClusterForm from '@/components/ClusterForm.vue'
+
+const adminClusterStore = useAdminClusterStore()
+const adminProjectStore = useAdminProjectStore()
+const snackbarStore = useSnackbarStore()
+
+const clusters = computed(() => adminClusterStore?.clusters)
+const selectedCluster = ref({})
+const clusterList = ref([])
+const allProjects = ref([])
+
+const isNewClusterForm = ref(false)
+
+const setClusterTiles = (clusters) => {
+  clusterList.value = clusters
+    ?.sort((a, b) => (a.name >= b.name ? 1 : -1))
+    ?.map(cluster => ({
+      id: cluster.id,
+      title: cluster.name,
+      data: cluster,
+    }))
+}
+
+const setSelectedCluster = (cluster) => {
+  if (selectedCluster.value?.name === cluster.name) {
+    selectedCluster.value = {}
+    return
+  }
+  selectedCluster.value = cluster
+  cancel()
+}
+
+const showNewClusterForm = () => {
+  isNewClusterForm.value = !isNewClusterForm.value
+  selectedCluster.value = {}
+}
+
+const cancel = () => {
+  isNewClusterForm.value = false
+}
+
+const addCluster = async (cluster) => {
+  cancel()
+  try {
+    await adminClusterStore.addCluster(cluster)
+  } catch (error) {
+    snackbarStore.setMessage(error?.message, 'error')
+  }
+}
+
+const updateCluster = async (cluster) => {
+  cancel()
+  try {
+    await adminClusterStore.updateCluster(cluster)
+  } catch (error) {
+    snackbarStore.setMessage(error?.message, 'error')
+  }
+}
+
+const removeCluster = async (clusterId) => {
+  try {
+    await adminClusterStore.removeCluster(clusterId)
+  } catch (error) {
+    snackbarStore.setMessage(error?.message, 'error')
+  }
+  setClusterTiles(clusters.value)
+  selectedCluster.value = {}
+}
+
+const getAllProjects = async () => {
+  try {
+    allProjects.value = await adminProjectStore.getAllProjects()
+  } catch (error) {
+    snackbarStore.setMessage(error?.message, 'error')
+  }
+}
+
+onMounted(() => {
+  adminClusterStore.getAllClusters()
+  setClusterTiles(clusters.value)
+  getAllProjects()
+})
+
+watch(clusters, () => {
+  setClusterTiles(clusters.value)
+})
+
+</script>
+
+<template>
+  <div
+    class="flex <md:flex-col-reverse items-center justify-between pb-5"
+  >
+    <DsfrButton
+      label="Ajouter un nouveau cluster"
+      data-testid="addClusterLink"
+      tertiary
+      title="Ajouter un cluster"
+      class="fr-mt-2v <md:mb-2"
+      icon="ri-add-line"
+      @click="showNewClusterForm()"
+    />
+  </div>
+  <div
+    v-if="isNewClusterForm"
+    class="my-5 pb-10 border-grey-900 border-y-1"
+  >
+    <ClusterForm
+      :all-projects="allProjects"
+      class="w-full"
+      @add="(cluster) => addCluster(cluster)"
+      @cancel="cancel()"
+    />
+  </div>
+  <div
+    :class="{
+      'md:grid md:grid-cols-3 md:gap-3 items-center justify-between': !selectedCluster?.name,
+    }"
+  >
+    <div
+      v-for="cluster in clusterList"
+      :key="cluster.id"
+      class="fr-mt-2v fr-mb-4w w-full"
+    >
+      <div>
+        <DsfrTile
+          :title="cluster.title"
+          :data-testid="`clusterTile-${cluster.id}`"
+          :horizontal="!!selectedCluster?.name"
+          class="fr-mb-2w w-11/12"
+          @click="setSelectedCluster(cluster.data)"
+        />
+      </div>
+      <ClusterForm
+        v-if="Object.keys(selectedCluster).length && selectedCluster.id === cluster.id"
+        :cluster="selectedCluster"
+        :all-projects="allProjects"
+        class="w-full"
+        :is-new-cluster="false"
+        @update="(cluster) => updateCluster(cluster)"
+        @delete="(clusterId) => removeCluster(clusterId)"
+      />
+    </div>
+  </div>
+</template>

--- a/apps/client/src/views/admin/ListClusters.vue
+++ b/apps/client/src/views/admin/ListClusters.vue
@@ -21,18 +21,18 @@ const setClusterTiles = (clusters) => {
     ?.sort((a, b) => (a.name >= b.name ? 1 : -1))
     ?.map(cluster => ({
       id: cluster.id,
-      title: cluster.name,
+      title: cluster.label,
       data: cluster,
     }))
 }
 
 const setSelectedCluster = (cluster) => {
-  if (selectedCluster.value?.name === cluster.name) {
+  if (selectedCluster.value?.label === cluster.label) {
     selectedCluster.value = {}
     return
   }
   selectedCluster.value = cluster
-  cancel()
+  isNewClusterForm.value = false
 }
 
 const showNewClusterForm = () => {
@@ -42,6 +42,7 @@ const showNewClusterForm = () => {
 
 const cancel = () => {
   isNewClusterForm.value = false
+  selectedCluster.value = {}
 }
 
 const addCluster = async (cluster) => {
@@ -119,7 +120,7 @@ watch(clusters, () => {
   </div>
   <div
     :class="{
-      'md:grid md:grid-cols-3 md:gap-3 items-center justify-between': !selectedCluster?.name,
+      'md:grid md:grid-cols-3 md:gap-3 items-center justify-between': !selectedCluster?.label,
     }"
   >
     <div
@@ -131,7 +132,7 @@ watch(clusters, () => {
         <DsfrTile
           :title="cluster.title"
           :data-testid="`clusterTile-${cluster.id}`"
-          :horizontal="!!selectedCluster?.name"
+          :horizontal="!!selectedCluster?.label"
           class="fr-mb-2w w-11/12"
           @click="setSelectedCluster(cluster.data)"
         />
@@ -144,6 +145,7 @@ watch(clusters, () => {
         :is-new-cluster="false"
         @update="(cluster) => updateCluster(cluster)"
         @delete="(clusterId) => removeCluster(clusterId)"
+        @cancel="cancel()"
       />
     </div>
   </div>

--- a/apps/client/src/views/admin/ListLogs.vue
+++ b/apps/client/src/views/admin/ListLogs.vue
@@ -95,7 +95,7 @@ onMounted(async () => {
     :key="log.id"
     :data-testid="`${log.id}-json`"
     :value="log"
-    class="log-box"
+    class="json-box"
     copyable
     boxed
   />
@@ -146,12 +146,12 @@ onMounted(async () => {
 </template>
 
 <style>
-.log-box.jv-container span.jv-item.jv-object,
-.log-box.jv-container span.jv-key {
+.json-box.jv-container span.jv-item.jv-object,
+.json-box.jv-container span.jv-key {
   color: var(--text-default-grey);
 }
 
-.log-box.jv-container {
+.json-box.jv-container {
   @apply my-6;
 
   background-color: var(--background-default-grey);

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -17,6 +17,7 @@ FROM base AS dev
 
 USER node
 RUN pnpm install
+RUN pnpm --filter shared run build
 ENTRYPOINT [ "pnpm", "--filter", "server", "run", "dev" ]
 
 

--- a/apps/server/src/controllers/admin/cluster.ts
+++ b/apps/server/src/controllers/admin/cluster.ts
@@ -1,7 +1,7 @@
-import { createCluster, getClusterById, getClusterByLabel, getClusters, updateCluster } from '@/models/queries/cluster-queries'
+import { createCluster, getClusterById, getClusterByLabel, getClusters, updateCluster } from '@/models/queries/cluster-queries.js'
 import { EnhancedFastifyRequest } from '@/types'
-import { addReqLogs } from '@/utils/logger'
-import { sendBadRequest, sendCreated, sendNotFound, sendOk } from '@/utils/response'
+import { addReqLogs } from '@/utils/logger.js'
+import { sendBadRequest, sendCreated, sendNotFound, sendOk } from '@/utils/response.js'
 import { CreateClusterDto, UpdateClusterDto, clusterSchema } from 'shared'
 
 // GET

--- a/apps/server/src/routes/admin/cluster.ts
+++ b/apps/server/src/routes/admin/cluster.ts
@@ -10,7 +10,7 @@ const router = async (app, _opt) => {
   // Déclarer un nouveau cluster
   await app.post('/', createClusterController)
   // Mettre à jour un cluster
-  await app.post('/', updateClusterController)
+  await app.put('/', updateClusterController)
 }
 
 export default router

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,6 @@
     "test:cov": "vitest run --coverage",
     "test:watch": "vitest"
   },
-  "types": "./types",
   "dependencies": {
     "joi": "^17.9.2"
   },
@@ -25,6 +24,7 @@
     "@dso-console/tsconfig": "workspace:^",
     "@faker-js/faker": "^8.0.2",
     "@kubernetes/client-node": "^0.18.1",
+    "@types/node": "^18.16.16",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
     "@vitest/coverage-v8": "^0.32.0",

--- a/packages/shared/src/schemas/cluster.ts
+++ b/packages/shared/src/schemas/cluster.ts
@@ -15,12 +15,16 @@ export const clusterSchema = Joi.object({
   secretName: Joi.string()
     .max(50),
 
-  clusterResources: Joi.boolean(),
+  clusterResources: Joi.boolean()
+    .required(),
 
   privacy: Joi.string()
-    .valid('public', 'dedicated'),
+    .valid('public', 'dedicated')
+    .required(),
 
-  user: Joi.object(),
+  user: Joi.object()
+    .required(),
 
-  cluster: Joi.object(),
+  cluster: Joi.object()
+    .required(),
 })

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,7 +1,18 @@
-export { repoSchema } from './repository.js'
-export { environmentSchema } from './environment.js'
-export { permissionSchema } from './permission.js'
-export { projectSchema, descriptionMaxLength } from './project.js'
-export { userSchema } from './user.js'
-export { clusterSchema } from './cluster.js'
-export { organizationSchema } from './organization.js'
+import { repoSchema } from './repository.js'
+import { environmentSchema } from './environment.js'
+import { permissionSchema } from './permission.js'
+import { projectSchema, descriptionMaxLength } from './project.js'
+import { userSchema } from './user.js'
+import { organizationSchema } from './organization.js'
+import { clusterSchema } from './cluster.js'
+
+export {
+  repoSchema,
+  environmentSchema,
+  permissionSchema,
+  projectSchema,
+  userSchema,
+  organizationSchema,
+  descriptionMaxLength,
+  clusterSchema,
+}

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,18 +1,7 @@
-import { repoSchema } from './repository.js'
-import { environmentSchema } from './environment.js'
-import { permissionSchema } from './permission.js'
-import { projectSchema, descriptionMaxLength } from './project.js'
-import { userSchema } from './user.js'
-import { organizationSchema } from './organization.js'
-import { clusterSchema } from './cluster.js'
-
-export {
-  repoSchema,
-  environmentSchema,
-  permissionSchema,
-  projectSchema,
-  userSchema,
-  organizationSchema,
-  descriptionMaxLength,
-  clusterSchema,
-}
+export { repoSchema } from './repository.js'
+export { environmentSchema } from './environment.js'
+export { permissionSchema } from './permission.js'
+export { projectSchema, descriptionMaxLength } from './project.js'
+export { userSchema } from './user.js'
+export { clusterSchema } from './cluster.js'
+export { organizationSchema } from './organization.js'

--- a/packages/test-utils/src/random-utils.js
+++ b/packages/test-utils/src/random-utils.js
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { achievedStatus, projectRoles, logActions } from 'shared'
+import { repeatFn } from './func-utils.js'
 
 export const getRandomProjectName = () => {
   return faker.lorem.word()
@@ -31,6 +32,26 @@ export const getRandomProject = (organization = faker.string.uuid()) => {
   }
 }
 
+export const getRandomCluster = (projectsId = repeatFn(2)(faker.string.uuid)) => {
+  return {
+    id: faker.string.uuid(),
+    label: faker.lorem.word(),
+    projectsId,
+    user: {
+      certData: 'userCAD',
+      keyData: 'userCKD',
+    },
+    cluster: {
+      caData: 'clusterCAD',
+      server: 'https://coucou.com:5000',
+      tlsServerName: 'coucou.com',
+    },
+    privacy: faker.helpers.arrayElement(['public', 'dedicated']),
+    clusterResources: faker.datatype.boolean(),
+    secretName: faker.internet.password({ length: 50 }),
+  }
+}
+
 export const getRandomUser = () => {
   return {
     id: faker.string.uuid(),
@@ -59,7 +80,7 @@ export const getRandomRepo = (projectId = faker.string.uuid()) => {
   }
   if (repo.isPrivate) {
     repo.externalUserName = faker.internet.userName()
-    repo.externalToken = faker.internet.password(25)
+    repo.externalToken = faker.internet.password({ length: 25 })
   }
 
   return repo

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,6 +332,9 @@ importers:
       '@kubernetes/client-node':
         specifier: ^0.18.1
         version: 0.18.1
+      '@types/node':
+        specifier: ^18.16.16
+        version: 18.16.16
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.11
         version: 5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.42.0)(typescript@5.0.2)
@@ -2138,7 +2141,7 @@ packages:
       '@types/markdown-it': 12.2.3
       '@yankeeinlondon/happy-wrapper': 2.10.1(jsdom@22.1.0)
       fp-ts: 2.16.0
-      inferred-types: 0.37.6(jsdom@22.1.0)
+      inferred-types: 0.37.6(happy-dom@8.9.0)(jsdom@22.1.0)
       markdown-it: 13.0.1
       vite-plugin-md: 0.22.5(@vitejs/plugin-vue@4.2.3)(jsdom@22.1.0)(vite@4.3.9)
     transitivePeerDependencies:
@@ -2162,7 +2165,7 @@ packages:
     resolution: {integrity: sha512-TLtRc/mxI74ahP3s+fJpIi+lBFAhuJuVjiQhmyi/xEwJ2pDepuWMRXT6UfJOA1cGkZ5/XGa9NFw/SQR6M5jfoQ==}
     engines: {node: '>=14.0'}
     dependencies:
-      inferred-types: 0.37.6(jsdom@22.1.0)
+      inferred-types: 0.37.6(happy-dom@8.9.0)(jsdom@22.1.0)
       js-yaml: 4.1.0
       kind-of: 6.0.3
       section-matter: 1.0.0
@@ -2598,28 +2601,6 @@ packages:
       bumpp: 8.2.1
       callsites: 4.0.0
       inferred-types: 0.37.6(happy-dom@8.9.0)(jsdom@22.1.0)
-      vitest: 0.25.8(happy-dom@8.9.0)(jsdom@22.1.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@vitest/browser'
-      - '@vitest/ui'
-      - happy-dom
-      - jsdom
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /brilliant-errors@0.7.3(jsdom@22.1.0):
-    resolution: {integrity: sha512-WT9BkAze4SUOJfr7LUwJWNDAvynEAvUMvMPuFKu8QQKnRq+WMx3DAtHfOBJjHmHRxf748JY3CNVytSk6HH2yGg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      bumpp: 8.2.1
-      callsites: 4.0.0
-      inferred-types: 0.37.6(jsdom@22.1.0)
       vitest: 0.25.8(happy-dom@8.9.0)(jsdom@22.1.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -4820,24 +4801,6 @@ packages:
     resolution: {integrity: sha512-CfL5g1wR5rVwX2K5S6wSL+h9eODScum/LBwlhGRrcBIvfYppvUQM0aeRJ1BZS+QE38kGzd3v+U526+nQR7ZUkg==}
     dependencies:
       brilliant-errors: 0.7.3(happy-dom@8.9.0)(jsdom@22.1.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@vitest/browser'
-      - '@vitest/ui'
-      - happy-dom
-      - jsdom
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /inferred-types@0.37.6(jsdom@22.1.0):
-    resolution: {integrity: sha512-CfL5g1wR5rVwX2K5S6wSL+h9eODScum/LBwlhGRrcBIvfYppvUQM0aeRJ1BZS+QE38kGzd3v+U526+nQR7ZUkg==}
-    dependencies:
-      brilliant-errors: 0.7.3(jsdom@22.1.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       axios:
         specifier: ^1.4.0
         version: 1.4.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       jszip:
         specifier: ^3.10.1
         version: 3.10.1


### PR DESCRIPTION
- remanier `ClusterForm.vue`  : 
  - [x] zone upload de fichier de type `kubeconfig` format `yaml`
  - [x] label: string => champ utilisateur
  - [x]  supprimer le champ Nom du secret `secretName`
  - [x] clusterResources: boolean => champ utilisateur default: false
  - [x] privacy: ClusterPrivacy => champ utilisateur default: dedicated
  - [x] liste de projects => faire un map pour récupérer les id
  - [x] user: UserAuthBasic | UserAuthCerts | UserAuthToken => à parser du fichier uploadé
  - [x] cluster: Pick<Cluster, 'name' | 'caData' | 'server' | 'tlsServerName'> => à parser du fichier uploadé
  - [x] laisser possibilité à l'utilisateur de choisir le context : s'il y a pas de current-context il faut afficher un select avec tous les contexts.name et en fonction du choix de l'utilisateur récupérer le context correspondant
 
- [x] tests ct
- [x] test store 
- [x] test e2e

#### parser kubeconfig

- `user` => si pas de current context, prendre le premier `contexts.context.user` => trouver `users.name` correspondant
- `cluster` => si pas de current context, prendre le premier `contexts.context.cluster` =>  trouver `clusters.cluster.name` correspondant / `tlsServerName` construit à partir de `clusters.cluster.server` sans https:// ni :4000 (sni)