### PR TITLE
refactor: :recycle: use toSorted instead of sort

### DIFF
--- a/apps/client/cypress/e2e/specs/admin/projects.e2e.js
+++ b/apps/client/cypress/e2e/specs/admin/projects.e2e.js
@@ -1,5 +1,5 @@
 import { getModel } from '../../support/func.js'
-import { statusDict, formatDate } from 'shared'
+import { statusDict, formatDate, sortArrByObjKeyAsc } from 'shared'
 
 describe('Administration projects', () => {
   const organizations = getModel('organization')
@@ -12,8 +12,7 @@ describe('Administration projects', () => {
     cy.visit('/admin/projects')
     cy.url().should('contain', '/admin/projects')
     cy.wait('@getAllProjects', { timeout: 10000 }).its('response').then(response => {
-      projects = response?.body
-        ?.sort((a, b) => a.name >= b.name ? 1 : -1)
+      projects = sortArrByObjKeyAsc(response.body, 'name')
         ?.map(project => ({
           organization: organizations.find(organization => organization.id === project.organizationId).label,
           name: project.name,

--- a/apps/client/src/components/PermissionForm.vue
+++ b/apps/client/src/components/PermissionForm.vue
@@ -36,7 +36,7 @@ const usersToLicence = computed(() =>
 const suggestions = computed(() => usersToLicence.value.map(user => user.email))
 
 const setPermissions = () => {
-  permissions.value = environment.value.permissions.sort((a, b) => a.user?.email >= b.user?.email ? 1 : -1)
+  permissions.value = environment.value.permissions.toSorted((a, b) => a.user?.email >= b.user?.email ? 1 : -1)
 }
 
 const addPermission = async (userEmail) => {

--- a/apps/client/src/views/admin/ListClusters.vue
+++ b/apps/client/src/views/admin/ListClusters.vue
@@ -4,6 +4,7 @@ import { useSnackbarStore } from '@/stores/snackbar.js'
 import { useAdminClusterStore } from '@/stores/admin/cluster.js'
 import { useAdminProjectStore } from '@/stores/admin/project.js'
 import ClusterForm from '@/components/ClusterForm.vue'
+import { sortArrByObjKeyAsc } from 'shared'
 
 const adminClusterStore = useAdminClusterStore()
 const adminProjectStore = useAdminProjectStore()
@@ -17,8 +18,7 @@ const isUpdatingCluster = ref(false)
 const isNewClusterForm = ref(false)
 
 const setClusterTiles = (clusters) => {
-  clusterList.value = clusters
-    ?.sort((a, b) => (a.label >= b.label ? 1 : -1))
+  clusterList.value = sortArrByObjKeyAsc(clusters, 'label')
     ?.map(cluster => ({
       id: cluster.id,
       title: cluster.label,

--- a/apps/client/src/views/admin/ListOrganizations.vue
+++ b/apps/client/src/views/admin/ListOrganizations.vue
@@ -8,6 +8,7 @@ import {
   isValid,
   instanciateSchema,
   organizationSchema,
+  sortArrByObjKeyAsc,
 } from 'shared'
 import { getRandomId } from '@gouvminint/vue-dsfr'
 
@@ -36,8 +37,7 @@ const isUpdatingOrganization = ref(null)
 const isOrgAlreadyTaken = computed(() => allOrganizations.value.find(org => org.name === newOrg.value.name))
 
 const setRows = () => {
-  rows.value = allOrganizations.value
-    ?.sort((a, b) => a.name >= b.name ? 1 : -1)
+  rows.value = sortArrByObjKeyAsc(allOrganizations.value, 'name')
     ?.map(({ label, name, source, active, createdAt, updatedAt }) => ([
       {
         component: 'input',

--- a/apps/client/src/views/admin/ListProjects.vue
+++ b/apps/client/src/views/admin/ListProjects.vue
@@ -2,7 +2,7 @@
 import { onMounted, ref, computed } from 'vue'
 import { useAdminProjectStore } from '@/stores/admin/project.js'
 import { useSnackbarStore } from '@/stores/snackbar.js'
-import { formatDate, statusDict } from 'shared'
+import { formatDate, statusDict, sortArrByObjKeyAsc } from 'shared'
 import { useAdminOrganizationStore } from '@/stores/admin/organization.js'
 
 const adminProjectStore = useAdminProjectStore()
@@ -27,8 +27,7 @@ const headers = [
 const rows = ref([])
 
 const setRows = () => {
-  rows.value = allProjects.value
-    ?.sort((a, b) => a.name >= b.name ? 1 : -1)
+  rows.value = sortArrByObjKeyAsc(allProjects.value, 'name')
     ?.map(({ organizationId, name, description, roles, status, locked, createdAt, updatedAt }) => ([
       organizations.value?.find(org => org.id === organizationId).label,
       name,

--- a/apps/client/src/views/projects/DsoProjects.vue
+++ b/apps/client/src/views/projects/DsoProjects.vue
@@ -4,6 +4,7 @@ import { useProjectStore } from '@/stores/project.js'
 import { useSnackbarStore } from '@/stores/snackbar.js'
 import router from '@/router/index.js'
 import DsoSelectedProject from './DsoSelectedProject.vue'
+import { sortArrByObjKeyAsc } from 'shared'
 
 const projectStore = useProjectStore()
 const snackbarStore = useSnackbarStore()
@@ -12,8 +13,7 @@ const projects = computed(() => projectStore?.projects)
 const projectList = ref([])
 
 const setProjectList = (projects) => {
-  projectList.value = projects
-    ?.sort((a, b) => (a.name >= b.name ? 1 : -1))
+  projectList.value = sortArrByObjKeyAsc(projects, 'name')
     ?.map(project => ({
       id: project.id,
       title: project.name,

--- a/apps/client/src/views/projects/DsoRepos.vue
+++ b/apps/client/src/views/projects/DsoRepos.vue
@@ -6,7 +6,7 @@ import { useUserStore } from '@/stores/user.js'
 import { useSnackbarStore } from '@/stores/snackbar.js'
 import RepoForm from '@/components/RepoForm.vue'
 import DsoSelectedProject from './DsoSelectedProject.vue'
-import { projectIsLockedInfo } from 'shared'
+import { projectIsLockedInfo, sortArrByObjKeyAsc } from 'shared'
 
 const projectStore = useProjectStore()
 const projectRepositoryStore = useProjectRepositoryStore()
@@ -26,8 +26,7 @@ const isNewRepoForm = ref(false)
 const isUpsertingRepo = ref(false)
 
 const setReposTiles = (project) => {
-  repos.value = project?.repositories
-    ?.sort((a, b) => (a.internalRepoName >= b.internalRepoName ? 1 : -1))
+  repos.value = sortArrByObjKeyAsc(project?.repositories, 'internalRepoName')
     ?.map(repo => ({
       id: repo.internalRepoName,
       title: repo.internalRepoName,

--- a/apps/client/src/views/projects/ManageEnvironments.vue
+++ b/apps/client/src/views/projects/ManageEnvironments.vue
@@ -4,7 +4,7 @@ import DsoSelectedProject from './DsoSelectedProject.vue'
 import { useProjectStore } from '@/stores/project.js'
 import { useProjectEnvironmentStore } from '@/stores/project-environment.js'
 import EnvironmentForm from '@/components/EnvironmentForm.vue'
-import { allEnv, projectIsLockedInfo } from 'shared'
+import { allEnv, projectIsLockedInfo, sortArrByObjKeyAsc } from 'shared'
 import { useUserStore } from '@/stores/user.js'
 import { useSnackbarStore } from '@/stores/snackbar.js'
 
@@ -23,8 +23,7 @@ const isNewEnvironmentForm = ref(false)
 const isUpdatingEnvironment = ref(false)
 
 const setEnvironmentsTiles = (project) => {
-  environments.value = project?.environments
-    ?.sort((a, b) => (a.name >= b.name ? 1 : -1))
+  environments.value = sortArrByObjKeyAsc(project?.environments, 'name')
     ?.map(environment => ({
       id: environment.id,
       title: environment.name,

--- a/packages/shared/src/utils/functions.ts
+++ b/packages/shared/src/utils/functions.ts
@@ -16,3 +16,9 @@ export const calcProjectNameMaxLength = (organizationName) => {
 }
 
 export const getUniqueListBy = (arr, key) => [...new Map(arr.map(item => [item[key], item])).values()]
+
+interface Keyable {
+    [key: string]: any
+}
+
+export const sortArrByObjKeyAsc = (arr: Array<Keyable>, key: string) => arr.toSorted((a: object, b: object) => a[key] >= b[key] ? 1 : -1)


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted#browser_compatibility

`toSorted` supporté par `node` à partir de la version `20`.
Mais on ne l'utilise que dans le front, donc ce sera les navigateurs qui le calculeront.