### PR TITLE
fix: :card_file_box: set all project status to failed for v6 release

### DIFF
--- a/apps/server/src/prisma/migrations/20231026150220_dso/migration.sql
+++ b/apps/server/src/prisma/migrations/20231026150220_dso/migration.sql
@@ -1,0 +1,3 @@
+-- Please read 6.0.0 Release notes !
+-- set all projects to failed to avoid unlock them
+UPDATE public."Project" SET "status"='failed'


### PR DESCRIPTION
## Quel est le comportement actuel ?
Pour la migrations v6 les projets pourraient s'unlock malencontreusement

## Quel est le nouveau comportement ?
Empeche que ce soit le cas sur les anciens projets à migrer

## Cette PR introduit-elle un breaking change ?

- [ ] Oui
- [x] Non
