### PR TITLE
ci: :construction_worker: enable manual trigger on unit tests in ci

### DIFF
--- a/.github/workflows/tests-component.yml
+++ b/.github/workflows/tests-component.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           path: |
             ./.turbo/cache
-          key: turbo-component-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/**/src/**','packages/**/src/**') }}
+          key: turbo-component-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/**/src/**','apps/client/cypress/**','packages/**/src/**') }}
           restore-keys: |
             turbo-component-${{ runner.os }}-${{ runner.arch }}-
 

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           path: |
             ./.turbo/cache
-          key: turbo-e2e-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/**/src/**','packages/**/src/**') }}
+          key: turbo-e2e-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/**/src/**','apps/client/cypress/**','packages/**/src/**') }}
           restore-keys: |
             turbo-e2e-${{ runner.os }}-${{ runner.arch }}-
 

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -16,6 +16,7 @@ on:
         required: false
       SONAR_PROJECT_KEY:
         required: false
+  workflow_dispatch:
 
 jobs:
   unit-tests:
@@ -154,6 +155,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Set sonarqube args
+        id: sonar-args
+        run: |
+          echo "SONAR_ARGS_PR=-Dsonar.pullrequest.provider=github -Dsonar.pullrequest.key=${{ github.event.number }} -Dsonar.pullrequest.branch=${{ github.head_ref }} -Dsonar.pullrequest.base=${{ github.base_ref }} -Dsonar.pullrequest.github.repository=${{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "SONAR_ARGS_BRANCH=-Dsonar.branch.name=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@master
         env:
@@ -168,12 +175,7 @@ jobs:
             -Dsonar.javascript.lcov.reportPaths=coverage/apps/server/coverage/lcov.info,coverage/apps/client/coverage/lcov.info,coverage/packages/shared/coverage/lcov.info
             -Dsonar.coverage.exclusions=**/*.spec.js,**/*.spec.ts,**/*.vue,**/assets/**,**/cypress/**,**/packages/test-utils/**,apps/server/src/plugins/**
             -Dsonar.scm.provider=git
-            -Dsonar.pullrequest.provider=github
-            -Dsonar.pullrequest.key=${{ github.event.number }}
-            -Dsonar.pullrequest.branch=${{ github.head_ref }}
-            -Dsonar.pullrequest.base=${{ github.base_ref }}
-            -Dsonar.pullrequest.github.repository=${{ github.repository }}
-          # -Dsonar.branch.name=${{ github.event.pull_request.head.ref }}
+            ${{ github.event_name == 'pull_request' && steps.sonar-args.outputs.SONAR_ARGS_PR || steps.sonar-args.outputs.SONAR_ARGS_BRANCH }}
         continue-on-error: true
             
       - name: SonarQube Quality Gate check

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,7 +56,7 @@
     "projectInit"
   ],
   "sonarlint.connectedMode.project": {
-    "connectionId": "https://test-sonarqube.osc-secnum-fr1.scalingo.io",
-    "projectKey": "dso-console"
+    "connectionId": "https://sonarqube.fabrique-numerique.fr",
+    "projectKey": "cloud-pi-native_console_AYsa46O31ebDtzs-pYyZ"
   },
 }

--- a/turbo.json
+++ b/turbo.json
@@ -57,7 +57,11 @@
         "server#test:e2e-ci"
       ],
       "inputs": [
-        "src/**"
+        "src/**",
+        "cypress/components/specs/**",
+        "cypress/components/support/**",
+        "cypress/e2e/specs/**",
+        "cypress/e2e/support/**"
       ],
       "outputs": []
     },


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Il est uniquement possible de lancer les tests unitaire par le pipeline de CI complet.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Il est possible de lancer les tests unitaire manuellement avec l'analyse Sonar de la branche qui a déclenché le workflow.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
