### PR TITLE
fix: :lipstick: now the snackbar can stack messages and limit the length

### DIFF
--- a/apps/client/src/components/DsoSnackbar.vue
+++ b/apps/client/src/components/DsoSnackbar.vue
@@ -5,40 +5,66 @@ import { useSnackbarStore } from '@/stores/snackbar.js'
 
 const route = useRoute()
 const snackbarStore = useSnackbarStore()
-
 const routePath = computed(() => route.path)
-const message = computed(() => snackbarStore.message)
-const isOpen = computed(() => snackbarStore.isOpen)
-const type = computed(() => snackbarStore.type)
-
-const closeSnackbar = () => {
-  snackbarStore.hideMessage()
-}
 
 watch(routePath, () => {
-  closeSnackbar()
+  snackbarStore.clearMessages()
 })
 </script>
 
 <template>
-  <div class="w-full flex justify-center">
+  <div
+    class="flex justify-left dso-snackbar"
+  >
     <DsfrAlert
+      v-for="message in Object.values(snackbarStore.messages)"
+      :key="message.timestamp"
       data-testid="snackbar"
-      :description="message"
-      :type="type"
-      :closed="!isOpen"
-      class="dso-snackbar"
+      :description="message.text.slice(0, 1000)"
+      :type="message.type"
+      :class="message.isDisplayed ? 'dso-snackbar-message' : 'dso-snackbar-message-hidden'"
       small
       closeable
-      @close="closeSnackbar()"
+      @click="snackbarStore.hide(message)"
     />
   </div>
 </template>
 
 <style scoped>
-.dso-snackbar {
-  @apply fixed bottom-4 z-1;
+@keyframes swipe {
+  100% { left: -300%;
+  display: none; }
 
+  0% { left: 0;
+  display: block; }
+}
+
+.dso-snackbar {
+  display: grid;
+  grid-column: auto;
+  row-gap: 1px;
+
+  @apply w-full fixed bottom-4 z-1;
+
+  pointer-events: none;
+}
+
+.dso-snackbar-message {
+  @apply z-1;
+
+  margin-top: 0.5rem;
+  position: relative;
+  background-color: var(--background-default-grey);
+  pointer-events: all;
+}
+
+.dso-snackbar-message-hidden {
+  @apply z-1;
+
+  animation: swipe 1s;
+  margin-top: 0.5rem;
+  position: relative;
+  z-index: -2;
   background-color: var(--background-default-grey);
 }
 </style>

--- a/apps/client/src/utils/func.ts
+++ b/apps/client/src/utils/func.ts
@@ -4,7 +4,7 @@ export const copyContent = async (content: string): Promise<void> => {
   const snackbarStore = useSnackbarStore()
   try {
     await navigator.clipboard.writeText(content)
-    snackbarStore.setMessage('Donnée copiée', 'success')
+    snackbarStore.setMessage('Donnée copiée', 'success', 3000)
   } catch (error: any) {
     snackbarStore.setMessage(error?.message, 'error')
   }

--- a/apps/client/src/views/projects/DsoDashboard.vue
+++ b/apps/client/src/views/projects/DsoDashboard.vue
@@ -65,7 +65,7 @@ const handleSecretDisplay = async () => {
     try {
       if (!project.value) throw new Error('Pas de projet sélectionné')
       projectSecrets.value = await projectStore.getProjectSecrets(project.value.id)
-      snackbarStore.setMessage('Secrets récupérés')
+      snackbarStore.setMessage('Secrets récupérés', 'info', 3000)
     } catch (error) {
       handleError(error)
     }
@@ -186,7 +186,7 @@ onBeforeMount(async () => {
         :resource="{
           ...project,
           resourceKey: 'locked',
-          wording: `Projet ${project?.name}`
+          wording: `Projet ${project?.name}`,
         }"
       />
       <DsoBadge

--- a/ci/kind/run-load.sh
+++ b/ci/kind/run-load.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 printf "\n\n${red}[kind wrapper].${no_color} Load images into cluster node\n\n"
 
 kind load docker-image $(cat "$COMPOSE_FILE" \


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
Un seul message à la fois peut être affiché dans la snack bar

## Quel est le nouveau comportement ?
Plusieurs message peuvent être affichés, ils disparaissent au bout d'un moment avec un timer par défaut ou déterminé

## Cette PR introduit-elle un breaking change ?
non

## Autres informations
Un TU passé en skip merci de lire la l.94

![image](https://github.com/cloud-pi-native/console/assets/33383276/625b218b-5b8e-433f-aef8-f93ed48eb623)
