### PR TITLE
feat: :sparkles: disallow hyphen on project, environment and stage

### DIFF
--- a/apps/client/cypress/components/specs/environment-form.ct.ts
+++ b/apps/client/cypress/components/specs/environment-form.ct.ts
@@ -62,7 +62,7 @@ describe('EnvironmentForm.vue', () => {
     cy.getByDataTestid('cancelEnvironmentBtn').should('be.enabled')
 
     cy.getByDataTestid('environmentNameInput')
-      .clear().type('prod-0')
+      .clear().type('prod0')
     cy.get('select#stage-select > option')
       .should('have.length', randomDbSetup.stages.length + 1)
     cy.get('select#stage-select')

--- a/apps/client/cypress/e2e/specs/admin/clusters.e2e.ts
+++ b/apps/client/cypress/e2e/specs/admin/clusters.e2e.ts
@@ -10,7 +10,7 @@ describe('Administration clusters', () => {
 
   const newCluster = {
     label: 'newCluster',
-    projects: ['dinum - beta-app'],
+    projects: ['dinum - betaapp'],
     stages: allStages.map(stage => stage.name),
     infos: 'Floating IP: 1.1.1.1',
     cluster: {

--- a/apps/client/cypress/e2e/specs/admin/projects.e2e.ts
+++ b/apps/client/cypress/e2e/specs/admin/projects.e2e.ts
@@ -103,7 +103,7 @@ describe('Administration projects', () => {
     cy.intercept('GET', 'api/v1/quotas').as('getQuotas')
     cy.intercept('DELETE', 'api/v1/projects/*').as('archiveProject')
 
-    const projectName = 'admin-archive'
+    const projectName = 'adminarchive'
 
     cy.createProject({ name: projectName }, admin?.email)
 
@@ -144,7 +144,7 @@ describe('Administration projects', () => {
   })
 
   it('Should update an environment quota, loggedIn as admin', () => {
-    const project = projects.find(project => project.name === 'beta-app')
+    const project = projects.find(project => project.name === 'betaapp')
     const privateQuota = {
       id: '',
       name: 'XXXXLprivate',
@@ -236,7 +236,7 @@ describe('Administration projects', () => {
   })
 
   it('Should remove and add a user from a project, loggedIn as admin', () => {
-    const project = projects.find(project => project.name === 'beta-app')
+    const project = projects.find(project => project.name === 'betaapp')
     const user = project.roles.find(role => role.role !== 'owner')?.user
 
     cy.intercept('GET', 'api/v1/admin/projects').as('getAllProjects')

--- a/apps/client/cypress/e2e/specs/environments.e2e.ts
+++ b/apps/client/cypress/e2e/specs/environments.e2e.ts
@@ -19,13 +19,13 @@ describe('Manage project environments', () => {
   project1FirstEnvironment.stage = getModelById('stage', project1EnvQuotaStage?.stageId)
   const environments = [
     {
-      name: 'integ-test',
+      name: 'integtest',
       stage: integrationStage,
       quota: quotaSmall,
       cluster: clusterPublic,
     },
     {
-      name: 'stage-test',
+      name: 'stagetest',
       stage: stagingStage,
       quota: quotaMedium,
       cluster: clusterPublic,

--- a/apps/client/src/components/EnvironmentForm.vue
+++ b/apps/client/src/components/EnvironmentForm.vue
@@ -207,9 +207,9 @@ watch(quotaId, () => {
         label="Nom de l'environnement"
         label-visible
         required="required"
-        :hint="`Ne doit pas contenir d'espace, doit être unique pour le projet et le cluster sélectionnés, être en minuscules et faire plus de 2 et moins de ${longestEnvironmentName} caractères.`"
+        :hint="`Ne doit pas contenir d'espace ni de trait d'union, doit être unique pour le projet et le cluster sélectionnés, être en minuscules et faire plus de 2 et moins de ${longestEnvironmentName} caractères.`"
         :error-message="!!localEnvironment.name && !isValid(environmentSchema, localEnvironment, 'name') ? `Le nom de l\'environnment ne doit pas contenir d\'espace, doit être unique pour le projet et le cluster sélectionnés, être en minuscules et faire plus de 2 et moins de ${longestEnvironmentName} caractères.`: undefined"
-        placeholder="integ-0"
+        placeholder="integ0"
         :disabled="!props.isEditable"
       />
       <DsfrSelect

--- a/apps/client/src/components/StageForm.vue
+++ b/apps/client/src/components/StageForm.vue
@@ -121,6 +121,7 @@ onBeforeMount(() => {
       v-model="localStage.name"
       label="Nom du type d'environnement"
       label-visible
+      hint="Ne doit pas contenir d'espace, de trait d'union, ni de caractères spéciaux."
       :required="true"
       data-testid="nameInput"
       :disabled="!isNewStage"

--- a/apps/client/src/views/CreateProject.vue
+++ b/apps/client/src/views/CreateProject.vue
@@ -120,7 +120,7 @@ onMounted(async () => {
             data-testid="nameInput"
             type="text"
             required="required"
-            :error-message="!!updatedValues.name && !isValid(projectSchema, project, 'name', { projectNameMaxLength }) ? `Le nom du projet doit être en minuscule, ne pas contenir d\'espace, faire plus de 2 et moins de ${projectNameMaxLength} caractères.`: undefined"
+            :error-message="!!updatedValues.name && !isValid(projectSchema, project, 'name', { projectNameMaxLength }) ? `Le nom du projet doit être en minuscule, ne pas contenir d\'espace ni de trait d'union, faire plus de 2 et moins de ${projectNameMaxLength} caractères.`: undefined"
             label="Nom du projet"
             label-visible
             :hint="`Nom du projet dans l'offre Cloud π Native. Ne doit pas contenir d'espace, doit être unique pour l'organisation, doit être en minuscules, doit faire plus de 2 et moins de ${projectNameMaxLength} caractères.`"

--- a/packages/shared/src/schemas/environment.ts
+++ b/packages/shared/src/schemas/environment.ts
@@ -7,7 +7,7 @@ export const environmentSchema = Joi.object({
 
   name: Joi.string()
     .required()
-    .pattern(/^[a-z0-9-]+$/)
+    .pattern(/^[a-z0-9]+$/)
     .min(2)
     .max(longestEnvironmentName),
 

--- a/packages/shared/src/schemas/project.ts
+++ b/packages/shared/src/schemas/project.ts
@@ -8,7 +8,7 @@ export const projectSchema = Joi.object({
     .uuid(),
 
   name: Joi.string()
-    .pattern(/^[a-z0-9-]+$/)
+    .pattern(/^[a-z0-9]+$/)
     .min(2)
     .max(Joi.ref('$projectNameMaxLength'))
     .required(),

--- a/packages/shared/src/schemas/stage.ts
+++ b/packages/shared/src/schemas/stage.ts
@@ -5,6 +5,7 @@ export const stageSchema = Joi.object({
     .uuid(),
 
   name: Joi.string()
+    .pattern(/^[a-zA-Z0-9]+$/)
     .required(),
 
   quotaIds: Joi.array()

--- a/packages/test-utils/src/imports/data.ts
+++ b/packages/test-utils/src/imports/data.ts
@@ -214,7 +214,7 @@ export const data = {
   project: [
     {
       id: '22e7044f-8414-435d-9c4a-2df42a65034b',
-      name: 'beta-app',
+      name: 'betaapp',
       organizationId: '2368a61e-f243-42f6-b471-a85b056ee131',
       description: null,
       status: 'created',
@@ -232,7 +232,7 @@ export const data = {
     },
     {
       id: '9dabf3f9-6c86-4358-8598-65007d78df65',
-      name: 'project-to-archive',
+      name: 'projecttoarchive',
       organizationId: '2368a61e-f243-42f6-b471-a85b056ee131',
       description: null,
       status: 'created',
@@ -286,7 +286,7 @@ export const data = {
     },
     {
       id: '83833faf-f654-40dd-bcd5-cf2e944fc702',
-      name: 'psij-failed',
+      name: 'psijfailed',
       organizationId: 'b644c07f-193c-47ed-ae10-b88a8f63d20b',
       description: "Application de transmission d'informations entre agents de la PS et de l'IJ.",
       status: 'failed',


### PR DESCRIPTION
## Issues

Ne pas autoriser les traits d'union dans les noms d'environnement, de projet et de stage (exploit a besoin de faire des requêtes avec des regex séparant les ressources par trait d'union).