### PR TITLE
feat: :loud_sound: add payload and full hook response in validation failed log

### DIFF
--- a/apps/server/src/utils/business.ts
+++ b/apps/server/src/utils/business.ts
@@ -1,11 +1,15 @@
+import { PluginResult } from '@/plugins/hooks/hook.js'
+import { hooks } from '@/plugins/index.js'
 import {
   getEnvironmentsByProjectId,
   getProjectRepositories,
   getProjectById,
   lockProject,
   unlockProject,
+  addLogs,
 } from '@/resources/queries-index.js'
-import type { Project } from '@prisma/client'
+import type { Project, User } from '@prisma/client'
+import { BadRequestError } from './errors.js'
 
 export const unlockProjectIfNotFailed = async (projectId: Project['id']) => {
   const environmentStatuses = (await getEnvironmentsByProjectId(projectId))?.map(environment => environment?.status)
@@ -20,5 +24,21 @@ export const unlockProjectIfNotFailed = async (projectId: Project['id']) => {
     return lockProject(projectId)
   } else {
     return unlockProject(projectId)
+  }
+}
+
+export const checkCreateProject = async (owner: User, resource: 'Project' | 'Repository') => {
+  const pluginsResults = await hooks.createProject.validate({ owner })
+  if (pluginsResults?.failed) {
+    const reasons = Object.values(pluginsResults)
+      .filter((plugin: PluginResult) => plugin?.status?.result === 'KO')
+      .map((plugin: PluginResult) => plugin.status.message)
+      .join('; ')
+
+    // @ts-ignore
+    await addLogs(`Create ${resource} Validation`, pluginsResults, owner.id)
+
+    const message = 'Echec de la validation des prérequis par les services externes'
+    throw new BadRequestError(message, { description: reasons })
   }
 }


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
On ne reçoit pas la payload dans un log d'échec de `validate`.
On ne sait pas non plus quel plugin envoie quelle erreur.

## Quel est le nouveau comportement ?
On reçoit désormais la réponse entière des plugins, exactement comme lors d'un `execute` :

```js
{
  "id": "5b1b0155-2e53-4062-9a76-1c125cb3e77d",
  "data": {
    "args": {
      "owner": {
        "id": "db14f17d-a54d-4376-8b8d-603cbaf774b7",
        "email": "claire.nollet@interieur.gouv.fr",
        "lastName": "Nollet",
        "firstName": "Claire"
      }
    },
    "failed": true,
    "gitlab": {
      "error": "{}",
      "status": {
        "result": "KO",
        "message": "Erreur !!!"
      }
    },
    "sonarqube": {
      "status": {
        "result": "OK",
        "message": ""
      }
    }
  },
  "userId": "db14f17d-a54d-4376-8b8d-603cbaf774b7"
}
```

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
