### PR TITLE
fix: :bug: share loadingct display knowledge

### DIFF
--- a/apps/client/cypress/components/specs/stage-form.ct.ts
+++ b/apps/client/cypress/components/specs/stage-form.ct.ts
@@ -1,3 +1,4 @@
+import { Pinia, createPinia, setActivePinia } from 'pinia'
 import '@gouvfr/dsfr/dist/dsfr.min.css'
 import '@gouvfr/dsfr/dist/utility/icons/icons.min.css'
 import '@gouvfr/dsfr/dist/utility/utility.main.min.css'
@@ -5,9 +6,18 @@ import '@gouvminint/vue-dsfr/styles'
 import '@/main.css'
 import StageForm from '@/components/StageForm.vue'
 import { getRandomCluster, getRandomEnv, getRandomQuota, getRandomQuotaStage, getRandomStage, repeatFn } from '@dso-console/test-utils'
+import { useSnackbarStore } from '@/stores/snackbar.js'
 
 describe('StageForm.vue', () => {
+  let pinia: Pinia
+
+  beforeEach(() => {
+    pinia = createPinia()
+
+    setActivePinia(pinia)
+  })
   it('Should mount a new quota StageForm', () => {
+    useSnackbarStore()
     const allQuotas = repeatFn(4)(getRandomQuota)
     const allClusters = repeatFn(3)(getRandomCluster)
 
@@ -36,6 +46,7 @@ describe('StageForm.vue', () => {
   })
 
   it('Should mount an update stage StageForm', () => {
+    useSnackbarStore()
     const allQuotas = repeatFn(4)(getRandomQuota)
     const allClusters = repeatFn(3)(getRandomCluster)
     const stageToUpdate = getRandomStage()
@@ -77,6 +88,7 @@ describe('StageForm.vue', () => {
   })
 
   it('Should mount an update quotaForm without associatedEnvironments', () => {
+    useSnackbarStore()
     const allQuotas = repeatFn(4)(getRandomQuota)
     const allClusters = repeatFn(3)(getRandomCluster)
     const stageToUpdate = getRandomStage()

--- a/apps/client/src/App.vue
+++ b/apps/client/src/App.vue
@@ -37,8 +37,12 @@ onMounted(() => {
 })
 
 onErrorCaptured((error) => {
-  if (error instanceof Error) return snackbarStore.setMessage(error?.message, 'error')
-  snackbarStore.setMessage('Une erreur inconnue est survenue.')
+  if (error instanceof Error) {
+    snackbarStore.setMessage(error?.message, 'error')
+  } else {
+    snackbarStore.setMessage('Une erreur inconnue est survenue.')
+  }
+  snackbarStore.isWaitingForResponse = false
   return false
 })
 

--- a/apps/client/src/components/EnvironmentForm.vue
+++ b/apps/client/src/components/EnvironmentForm.vue
@@ -49,10 +49,6 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
-  isUpdatingEnvironment: {
-    type: Boolean,
-    default: false,
-  },
   allClusters: {
     type: Array,
     default: () => [],
@@ -382,7 +378,7 @@ watch(quotaId, () => {
       />
     </div>
     <LoadingCt
-      v-if="props.isUpdatingEnvironment"
+      v-if="snackbarStore.isWaitingForResponse"
       description="Opérations en cours sur l'environnement"
     />
   </div>

--- a/apps/client/src/components/QuotaForm.vue
+++ b/apps/client/src/components/QuotaForm.vue
@@ -3,6 +3,7 @@ import { computed, onBeforeMount, ref } from 'vue'
 import { quotaSchema, schemaValidator } from '@dso-console/shared'
 import { copyContent } from '@/utils/func.js'
 import type { UpdateQuotaType } from '@/views/admin/ListQuotas.vue'
+import { useSnackbarStore } from '@/stores/snackbar.js'
 
 const props = defineProps({
   isNewQuota: {
@@ -20,10 +21,6 @@ const props = defineProps({
   associatedEnvironments: {
     type: Array,
     default: () => [],
-  },
-  isUpdatingQuota: {
-    type: Boolean,
-    default: false,
   },
 })
 
@@ -259,7 +256,7 @@ onBeforeMount(() => {
       </div>
     </div>
     <LoadingCt
-      v-if="props.isUpdatingQuota"
+      v-if="useSnackbarStore().isWaitingForResponse"
       description="Opérations en cours sur le quota"
     />
   </div>

--- a/apps/client/src/components/RepoForm.vue
+++ b/apps/client/src/components/RepoForm.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue'
 import { repoSchema, schemaValidator, isValid, instanciateSchema } from '@dso-console/shared'
+import { useSnackbarStore } from '@/stores/snackbar.js'
 
 const props = defineProps({
   repo: {
@@ -19,10 +20,6 @@ const props = defineProps({
     default: false,
   },
   isProjectLocked: {
-    type: Boolean,
-    default: false,
-  },
-  isUpsertingRepo: {
     type: Boolean,
     default: false,
   },
@@ -240,7 +237,7 @@ const cancel = () => {
       </div>
     </div>
     <LoadingCt
-      v-if="props.isUpsertingRepo"
+      v-if="useSnackbarStore().isWaitingForResponse"
       description="Opérations en cours sur le dépôt"
     />
   </div>

--- a/apps/client/src/components/StageForm.vue
+++ b/apps/client/src/components/StageForm.vue
@@ -3,6 +3,7 @@ import { computed, onBeforeMount, ref } from 'vue'
 import { stageSchema, schemaValidator } from '@dso-console/shared'
 import { copyContent } from '@/utils/func.js'
 import type { UpdateStageType } from '@/views/admin/ListStages.vue'
+import { useSnackbarStore } from '@/stores/snackbar.js'
 
 const props = defineProps({
   isNewStage: {
@@ -24,10 +25,6 @@ const props = defineProps({
   associatedEnvironments: {
     type: Array,
     default: () => [],
-  },
-  isUpdatingStage: {
-    type: Boolean,
-    default: false,
   },
 })
 
@@ -258,7 +255,7 @@ onBeforeMount(() => {
       </div>
     </div>
     <LoadingCt
-      v-if="props.isUpdatingStage"
+      v-if="useSnackbarStore().isWaitingForResponse"
       description="Opérations en cours sur le type d'environnement"
     />
   </div>

--- a/apps/client/src/components/TeamCt.vue
+++ b/apps/client/src/components/TeamCt.vue
@@ -14,6 +14,7 @@ import {
 import pDebounce from 'p-debounce'
 import { useProjectUserStore } from '@/stores/project-user'
 import { copyContent } from '@/utils/func.js'
+import { useSnackbarStore } from '@/stores/snackbar.js'
 
 const projectUserStore = useProjectUserStore()
 
@@ -29,7 +30,6 @@ const props = withDefaults(
     userProfile: UserProfile
     project: Pick<ProjectModel, 'id' | 'locked' | 'name'>
     roles: Array<RoleModel>
-    isUpdatingProjectMembers?: boolean
     knownUsers: Record<string, Required<UserModel>>
   }>(),
   {},
@@ -200,7 +200,7 @@ watch(() => props.roles, setRows)
       />
     </div>
     <LoadingCt
-      v-if="isUpdatingProjectMembers"
+      v-if="useSnackbarStore().isWaitingForResponse"
       description="Mise à jour de l'équipe projet"
     />
   </div>

--- a/apps/client/src/stores/snackbar.ts
+++ b/apps/client/src/stores/snackbar.ts
@@ -7,7 +7,8 @@ export const useSnackbarStore = defineStore('snackbar', () => {
   const message: Ref<string | undefined> = ref(undefined)
   const isOpen: Ref<boolean> = ref(false)
   const type: Ref<ErrorTypes> = ref('info')
-  const timeoutId: Ref< ReturnType<typeof setTimeout> | undefined> = ref(undefined)
+  const timeoutId: Ref<ReturnType<typeof setTimeout> | undefined> = ref(undefined)
+  const isWaitingForResponse = ref<boolean>(false)
 
   const setMessage = (errorMessage: string, errorType: ErrorTypes = 'info', timeout: number = defaultTimeout) => {
     if (timeoutId.value) {
@@ -33,6 +34,7 @@ export const useSnackbarStore = defineStore('snackbar', () => {
     isOpen,
     type,
     timeoutId,
+    isWaitingForResponse,
     setMessage,
     hideMessage,
   }

--- a/apps/client/src/views/CreateProject.vue
+++ b/apps/client/src/views/CreateProject.vue
@@ -13,12 +13,13 @@ import {
   type ProjectInfos,
 } from '@dso-console/shared'
 import router from '@/router/index.js'
+import { useSnackbarStore } from '@/stores/snackbar.js'
 
 const projectStore = useProjectStore()
 const userStore = useUserStore()
 const organizationStore = useOrganizationStore()
+const snackbarStore = useSnackbarStore()
 
-const owner = computed(() => userStore.userProfile)
 const organizationName = computed(() => {
   const org = orgOptions?.value.find(org => org.id === project.value?.organizationId)
   return org?.value
@@ -36,14 +37,12 @@ const project: Ref<ProjectInfos> = ref({
   name: '',
 })
 
-const isCreatingProject = ref(false)
-
 const orgOptions: Ref<Array<any>> = ref([])
 
 const updatedValues: Ref<Record<any, any>> = ref({})
 
 const createProject = async () => {
-  isCreatingProject.value = true
+  snackbarStore.isWaitingForResponse = true
   updatedValues.value = instanciateSchema({ schema: projectSchema }, true)
   const keysToValidate = ['organizationId', 'name']
   const errorSchema = schemaValidator(projectSchema, project.value, { keysToValidate, context: { projectNameMaxLength: projectNameMaxLength.value } })
@@ -51,7 +50,7 @@ const createProject = async () => {
     await projectStore.createProject(project.value)
     router.push('/projects')
   }
-  isCreatingProject.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const updateProject = (key: string, value: any) => {
@@ -90,7 +89,7 @@ onMounted(async () => {
     >
       <DsfrAlert
         type="info"
-        :description="`L'adresse e-mail du souscripteur associé au projet sera : ${owner.email}`"
+        :description="`L'adresse e-mail du souscripteur associé au projet sera : ${userStore.userProfile?.email}`"
         small
         class="fr-mb-2w"
       />
@@ -151,7 +150,7 @@ onMounted(async () => {
       @click="createProject()"
     />
     <LoadingCt
-      v-if="isCreatingProject"
+      v-if="snackbarStore.isWaitingForResponse"
       description="Projet en cours de création"
     />
   </div>

--- a/apps/client/src/views/admin/ListProjects.vue
+++ b/apps/client/src/views/admin/ListProjects.vue
@@ -52,7 +52,6 @@ const environmentsRows: Ref<EnvironnementRows > = ref([])
 const repositoriesRows: Ref<RepositoryRows> = ref([])
 const tableKey = ref(getRandomId('table'))
 const selectedProject: Ref<typeof allProjects['value'][0] | undefined> = ref()
-const isWaitingForResponse = ref(false)
 const teamCtKey = ref(getRandomId('team'))
 const environmentsCtKey = ref(getRandomId('environment'))
 const repositoriesCtKey = ref(getRandomId('repository'))
@@ -238,11 +237,11 @@ const getRepositoriesRows = () => {
 }
 
 const getAllProjects = async () => {
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   allProjects.value = await adminProjectStore.getAllProjects()
   setRows()
   if (selectedProject.value) selectProject(selectedProject.value.id)
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const selectProject = async (projectId: string) => {
@@ -253,44 +252,44 @@ const selectProject = async (projectId: string) => {
 
 const updateEnvironmentQuota = async ({ environmentId, quotaId }: {environmentId: string, quotaId: string}) => {
   if (!selectedProject.value) return
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   const environment = selectedProject.value?.environments.find(environment => environment.id === environmentId)
   environment.quotaStageId = environment.quotaStage.stage.quotaStage.find(quotaStage => quotaStage.quotaId === quotaId)?.id
   await projectEnvironmentStore.updateEnvironment(environment, selectedProject.value.id)
   await getAllProjects()
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const handleProjectLocking = async (projectId: string, lock: boolean) => {
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   await adminProjectStore.handleProjectLocking(projectId, lock)
   await getAllProjects()
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const replayHooks = async ({ resource, resourceId }: {resource: string, resourceId: string}) => {
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   // snackbarStore.setMessage(`Reprovisionnement de la ressource ${resource} ayant pour id ${resourceId}`)
   console.log({ resource, resourceId })
   snackbarStore.setMessage('Cette fonctionnalité n\'est pas encore disponible.')
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const archiveProject = async (projectId: string) => {
   if (!selectedProject.value) return
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   await adminProjectStore.archiveProject(projectId)
   await getAllProjects()
   selectedProject.value = undefined
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const addUserToProject = async (email: string) => {
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   const newRoles = await projectUserStore.addUserToProject(selectedProject.value?.id, { email })
   teamCtKey.value = getRandomId('team')
   selectedProject.value.roles = newRoles
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const updateUserRole = ({ userId, role }: { userId: string, role: string }) => {
@@ -300,13 +299,13 @@ const updateUserRole = ({ userId, role }: { userId: string, role: string }) => {
 
 const removeUserFromProject = async (userId: string) => {
   if (!selectedProject.value) return
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   if (selectedProject.value.id) {
     const newRoles = await projectUserStore.removeUserFromProject(selectedProject.value.id, userId)
     selectedProject.value.roles = newRoles
   }
   teamCtKey.value = getRandomId('team')
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const generateProjectsDataFile = async () => {
@@ -342,7 +341,7 @@ onBeforeMount(async () => {
         secondary
         icon-only
         icon="ri-file-download-line"
-        :disabled="!!isWaitingForResponse"
+        :disabled="snackbarStore.isWaitingForResponse"
         @click="generateProjectsDataFile()"
       />
       <DsfrFileDownload
@@ -359,7 +358,7 @@ onBeforeMount(async () => {
         secondary
         icon-only
         icon="ri-refresh-fill"
-        :disabled="!!isWaitingForResponse"
+        :disabled="snackbarStore.isWaitingForResponse"
         @click="async() => {
           await getAllProjects()
         }"
@@ -511,7 +510,7 @@ onBeforeMount(async () => {
       </div>
     </div>
     <LoadingCt
-      v-if="isWaitingForResponse"
+      v-if="snackbarStore.isWaitingForResponse"
       description="Opérations en cours"
     />
   </div>

--- a/apps/client/src/views/projects/DsoDashboard.vue
+++ b/apps/client/src/views/projects/DsoDashboard.vue
@@ -20,24 +20,23 @@ const description = ref<string | undefined>(project.value ? project.value.descri
 const isEditingDescription = ref(false)
 const isArchivingProject = ref(false)
 const projectToArchive = ref('')
-const isWaitingForResponse = ref(false)
 const isSecretShown = ref(false)
 const projectSecrets = ref<Record<string, any>>({})
 const allStages = ref<Array<any>>([])
 
 const updateProject = async (projectId: ProjectInfos['id']) => {
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   // @ts-ignore
   await projectStore.updateProject(projectId, { description: description.value })
   isEditingDescription.value = false
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const archiveProject = async (projectId: ProjectInfos['id']) => {
-  isWaitingForResponse.value = true
+  snackbarStore.isWaitingForResponse = true
   await projectStore.archiveProject(projectId)
   router.push('/projects')
-  isWaitingForResponse.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const getDynamicTitle = (locked: ProjectInfos['locked'], description: ProjectInfos['description']) => {
@@ -49,11 +48,11 @@ const getDynamicTitle = (locked: ProjectInfos['locked'], description: ProjectInf
 const handleSecretDisplay = async () => {
   isSecretShown.value = !isSecretShown.value
   if (isSecretShown.value && !Object.keys(projectSecrets.value).length) {
-    isWaitingForResponse.value = true
+    snackbarStore.isWaitingForResponse = true
     if (!project.value) throw new Error('Pas de projet sélectionné')
     projectSecrets.value = await projectStore.getProjectSecrets(project.value.id)
     snackbarStore.setMessage('Secrets récupérés')
-    isWaitingForResponse.value = false
+    snackbarStore.isWaitingForResponse = false
   }
 }
 
@@ -285,7 +284,7 @@ onBeforeMount(async () => {
       </div>
     </div>
     <LoadingCt
-      v-if="isWaitingForResponse"
+      v-if="snackbarStore.isWaitingForResponse"
       description="Opérations en cours"
     />
   </div>

--- a/apps/client/src/views/projects/DsoTeam.vue
+++ b/apps/client/src/views/projects/DsoTeam.vue
@@ -14,14 +14,13 @@ const usersStore = useUsersStore()
 const snackbarStore = useSnackbarStore()
 
 const project = computed(() => projectStore.selectedProject)
-const isUpdatingProjectMembers = ref(false)
 const teamCtKey = ref(getRandomId('team'))
 
 const addUserToProject = async (email: string) => {
-  isUpdatingProjectMembers.value = true
+  snackbarStore.isWaitingForResponse = true
   await projectUserStore.addUserToProject(project.value?.id, { email })
   teamCtKey.value = getRandomId('team')
-  isUpdatingProjectMembers.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 const updateUserRole = ({ userId, role }: { userId: string, role: string }) => {
@@ -30,10 +29,10 @@ const updateUserRole = ({ userId, role }: { userId: string, role: string }) => {
 }
 
 const removeUserFromProject = async (userId: string) => {
-  isUpdatingProjectMembers.value = true
+  snackbarStore.isWaitingForResponse = true
   await projectUserStore.removeUserFromProject(project.value?.id, userId)
   teamCtKey.value = getRandomId('team')
-  isUpdatingProjectMembers.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 </script>
@@ -47,7 +46,6 @@ const removeUserFromProject = async (userId: string) => {
     :project="{id: project?.id, name: project?.name }"
     :known-users="usersStore.users"
     :roles="project.roles"
-    :is-updating-project-members="isUpdatingProjectMembers"
     @add-member="(email) => addUserToProject(email)"
     @update-role="({ userId, role}) => updateUserRole({ userId, role})"
     @remove-member="(userId) => removeUserFromProject(userId)"

--- a/apps/client/src/views/projects/ManageEnvironments.vue
+++ b/apps/client/src/views/projects/ManageEnvironments.vue
@@ -5,11 +5,13 @@ import { useProjectEnvironmentStore } from '@/stores/project-environment.js'
 import { projectIsLockedInfo, sortArrByObjKeyAsc } from '@dso-console/shared'
 import { useUserStore } from '@/stores/user.js'
 import { useAdminClusterStore } from '@/stores/admin/cluster'
+import { useSnackbarStore } from '@/stores/snackbar.js'
 
 const projectStore = useProjectStore()
 const projectEnvironmentStore = useProjectEnvironmentStore()
 const userStore = useUserStore()
 const adminClusterStore = useAdminClusterStore()
+const snackbarStore = useSnackbarStore()
 
 const project = computed(() => projectStore.selectedProject)
 const isOwner = computed(() => project.value?.roles.some(role => role.userId === userStore.userProfile.id && role.role === 'owner'))
@@ -20,7 +22,6 @@ const allClusters = computed(() => adminClusterStore.clusters)
 const environments = ref([])
 const selectedEnvironment = ref({})
 const isNewEnvironmentForm = ref(false)
-const isUpdatingEnvironment = ref(false)
 
 // @ts-ignore
 const setEnvironmentsTiles = (project) => {
@@ -57,32 +58,32 @@ const cancel = () => {
 
 // @ts-ignore
 const addEnvironment = async (environment) => {
-  isUpdatingEnvironment.value = true
+  snackbarStore.isWaitingForResponse = true
   // @ts-ignore
   if (!project.value.locked) {
     await projectEnvironmentStore.addEnvironmentToProject(environment)
   }
   cancel()
-  isUpdatingEnvironment.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 // @ts-ignore
 const putEnvironment = async (environment) => {
-  isUpdatingEnvironment.value = true
+  snackbarStore.isWaitingForResponse = true
   // @ts-ignore
   if (!project.value.locked) {
     await projectEnvironmentStore.updateEnvironment(environment, project.value.id)
   }
   cancel()
-  isUpdatingEnvironment.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 // @ts-ignore
 const deleteEnvironment = async (environment) => {
-  isUpdatingEnvironment.value = true
+  snackbarStore.isWaitingForResponse = true
   await projectEnvironmentStore.deleteEnvironment(environment.id)
   setSelectedEnvironment({})
-  isUpdatingEnvironment.value = false
+  snackbarStore.isWaitingForResponse = false
 }
 
 onMounted(async () => {
@@ -132,7 +133,6 @@ watch(project, () => {
     <EnvironmentForm
       :environment="{projectId: project?.id}"
       :environment-names="environmentNames"
-      :is-updating-environment="isUpdatingEnvironment"
       :is-project-locked="project?.locked"
       :project-clusters="project?.clusters"
       @add-environment="(environment) => addEnvironment(environment)"
@@ -191,7 +191,6 @@ watch(project, () => {
         v-if="Object.keys(selectedEnvironment).length !== 0 && selectedEnvironment.id === environment.id"
         :environment="selectedEnvironment"
         :environment-names="environmentNames"
-        :is-updating-environment="isUpdatingEnvironment"
         :project-clusters="project?.clusters"
         :is-editable="false"
         :is-project-locked="project?.locked"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
La gestion d'erreur dans un handler global (App.vue) ne permet plus de passer le booléen conditionnant la visibilité du LoadingCt.vue => en cas d'erreur, on reste sur le loading.

## Quel est le nouveau comportement ?
Le booléen conditionnant la visibilité du LoadingCt.vue est partagé entre les vues et composants via le store => en cas d'erreur, on ne reste pas sur le loading.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
