### PR TITLE
fix: :green_heart: fix ci-cd build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.images.name }}
+          name: digests-${{ matrix.images.name }}-${{ inputs.MULTI_ARCH && inputs.USE_QEMU && 'multiarch' || (contains(runner.arch, 'ARM') && 'arm64' || 'amd64') }}
           path: /tmp/digests/${{ matrix.images.name }}/*
           if-no-files-found: error
           retention-days: 1
@@ -160,11 +160,12 @@ jobs:
       matrix:
         images: ${{ fromJSON(needs.matrix.outputs.build-matrix) }}
     steps:
-      - name: Download digests
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: digests-${{ matrix.images.name }}
+          pattern: digests-${{ matrix.images.name }}-*
           path: /tmp/digests/${{ matrix.images.name }}
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "package-name": "console",
+      "include-component-in-tag": false,
       "extra-files": [
         "helm/Chart.yaml",
         "helm/values.yaml"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
- Le tag est créé avec le nom du composant qui est release, dans notre cas le tag est `console-vX.Y.Z` au lieu de `vX.Y.Z`
- Les images ne se builds pas à cause de conflits sur les noms des artefacts uploadés (conflits dans la matrice Github entre le build `amd64` et `arm64`)

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
- Le tag ne devrait plus inclure le composant release (nous en avons qu'un seul donc préférons ne pas le spécifier)
- Les images ne devrait plus avoir de conflits sur l'upload de leurs artefacts.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
