### PR TITLE
fix: :bug: correctly handle external plugins init

### DIFF
--- a/apps/server/src/plugins.ts
+++ b/apps/server/src/plugins.ts
@@ -29,8 +29,11 @@ export const initPm = async () => {
     const moduleAbsPath = `${pluginsDir}/${dirName}`
     try {
       statSync(`${moduleAbsPath}/package.json`)
-      const module = await import(moduleAbsPath) as {plugin: Plugin}
-      pm.register(module.plugin)
+      const pkg = await import(`${moduleAbsPath}/package.json`, { assert: { type: 'json' } })
+      const entrypoint = pkg.default.module || pkg.default.main
+      if (!entrypoint) throw new Error(`No entrypoint found in package.json : ${pkg.default.name}`)
+      const { plugin } = await import(`${moduleAbsPath}/${entrypoint}`) as { plugin: Plugin }
+      pm.register(plugin)
     } catch (error) {
       console.error(`Could not import module ${moduleAbsPath}`)
       console.error(error.stack)


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Les plugins externes ne sont pas correctement importés car l'import est fait sur le dossier du plugin, ce qui n'est pas possible via les imports ESM.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Le plugin manager parse le `package.json` du plugin pour y trouver le point d'entrée `module` ou `main` et importer ce fichier plutôt que le dossier complet.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
