### PR TITLE
feat: :sparkles: add replay hooks button for project

### DIFF
--- a/apps/client/cypress/e2e/specs/admin/logs.e2e.ts
+++ b/apps/client/cypress/e2e/specs/admin/logs.e2e.ts
@@ -46,7 +46,9 @@ describe('Administration logs', () => {
     cy.getByDataTestid('seeFirstPageBtn').should('be.enabled')
     cy.getByDataTestid('seeNextPageBtn').should('be.disabled')
     cy.getByDataTestid('seeLastPageBtn').should('be.disabled')
-    cy.get('[data-testid$="-json"]').should('have.length', 2)
+    cy.get('[data-testid$="-json"]')
+      .should('have.length.of.at.least', 1)
+      .and('have.length.at.most', 10)
     logs.slice(20, logCount - 20).forEach(log => {
       cy.getByDataTestid(`${log.id}-json`)
         .should('be.visible')

--- a/apps/client/src/api/projects.spec.ts
+++ b/apps/client/src/api/projects.spec.ts
@@ -4,11 +4,13 @@ import {
   getUserProjects,
   createProject,
   archiveProject,
+  replayHooks,
 
 } from './projects.js'
 
 const apiClientGet = vi.spyOn(apiClient, 'get')
 const apiClientPost = vi.spyOn(apiClient, 'post')
+const apiClientPut = vi.spyOn(apiClient, 'put')
 const apiClientDelete = vi.spyOn(apiClient, 'delete')
 
 describe('API', () => {
@@ -39,6 +41,17 @@ describe('API', () => {
       expect(apiClientPost).toHaveBeenCalled()
       expect(apiClientPost).toHaveBeenCalledTimes(1)
       expect(apiClientPost.mock.calls[0][0]).toBe('/projects')
+    })
+
+    it('Should replay hooks for a project', async () => {
+      const projectId = 'thisIsAnId'
+      apiClientPut.mockReturnValueOnce(Promise.resolve({ data: { id: 'idTest' } }))
+
+      await replayHooks(projectId)
+
+      expect(apiClientPut).toHaveBeenCalled()
+      expect(apiClientPut).toHaveBeenCalledTimes(1)
+      expect(apiClientPut.mock.calls[0][0]).toBe(`/projects/${projectId}/hooks`)
     })
 
     it('Should archive a project', async () => {

--- a/apps/client/src/api/projects.ts
+++ b/apps/client/src/api/projects.ts
@@ -17,6 +17,11 @@ export const updateProject = async (projectId: ProjectParams['projectId'], data:
   return response.data
 }
 
+export const replayHooks = async (projectId: ProjectParams['projectId']) => {
+  const response = await apiClient.put(`/projects/${projectId}/hooks`)
+  return response.data
+}
+
 export const archiveProject = async (projectId: ProjectParams['projectId']): Promise<void> => { // TODO: Promise<ProjectOutputDto | null> ou pas ?
   await apiClient.delete(`/projects/${projectId}`)
 }

--- a/apps/client/src/stores/project.ts
+++ b/apps/client/src/stores/project.ts
@@ -1,7 +1,7 @@
-import { defineStore } from 'pinia'
-import { type Ref, ref } from 'vue'
 import api from '@/api/index.js'
-import type { CreateProjectDto, ProjectInfos, ProjectParams, UpdateProjectDto, ProjectModel, RoleModel } from '@cpn-console/shared'
+import type { CreateProjectDto, ProjectInfos, ProjectModel, ProjectParams, RoleModel, UpdateProjectDto } from '@cpn-console/shared'
+import { defineStore } from 'pinia'
+import { ref, type Ref } from 'vue'
 
 export const useProjectStore = defineStore('project', () => {
   const selectedProject: Ref<ProjectInfos | undefined> = ref(undefined)
@@ -29,6 +29,10 @@ export const useProjectStore = defineStore('project', () => {
     await getUserProjects()
   }
 
+  const replayHooksForProject = async (projectId: string) => {
+    return api.replayHooks(projectId)
+  }
+
   const archiveProject = async (projectId: ProjectParams['projectId']) => {
     await api.archiveProject(projectId)
     selectedProject.value = undefined
@@ -52,6 +56,7 @@ export const useProjectStore = defineStore('project', () => {
     updateProject,
     getUserProjects,
     createProject,
+    replayHooksForProject,
     archiveProject,
     getProjectSecrets,
     updateProjectRoles,

--- a/apps/client/src/views/admin/ListProjects.vue
+++ b/apps/client/src/views/admin/ListProjects.vue
@@ -10,6 +10,7 @@ import { useUserStore } from '@/stores/user.js'
 import { useUsersStore } from '@/stores/users.js'
 import { useProjectUserStore } from '@/stores/project-user'
 import { useAdminQuotaStore } from '@/stores/admin/quota'
+import { useProjectStore } from '@/stores/project.js'
 
 const adminProjectStore = useAdminProjectStore()
 const adminOrganizationStore = useAdminOrganizationStore()
@@ -235,11 +236,11 @@ const handleProjectLocking = async (projectId: string, lock: boolean) => {
   snackbarStore.isWaitingForResponse = false
 }
 
-const replayHooks = async ({ resource, resourceId }: {resource: string, resourceId: string}) => {
+const replayHooks = async (projectId: string) => {
   snackbarStore.isWaitingForResponse = true
-  // snackbarStore.setMessage(`Reprovisionnement de la ressource ${resource} ayant pour id ${resourceId}`)
-  console.log({ resource, resourceId })
-  snackbarStore.setMessage('Cette fonctionnalité n\'est pas encore disponible.')
+  await useProjectStore().replayHooksForProject(projectId)
+  await getAllProjects()
+  snackbarStore.setMessage(`Le projet ayant pour id ${projectId} a été reprovisionné avec succès`, 'success')
   snackbarStore.isWaitingForResponse = false
 }
 
@@ -376,12 +377,11 @@ onBeforeMount(async () => {
       />
       <div class="w-full flex gap-4 fr-mb-2w">
         <DsfrButton
+          data-testid="replayHooksBtn"
           label="Reprovisionner le projet"
-          title="Cette fonctionnalité n'est pas encore disponible"
           icon="ri-refresh-fill"
           secondary
-          disabled
-          @click="replayHooks({resource: 'project', resourceId: selectedProject.id})"
+          @click="replayHooks(selectedProject.id)"
         />
         <DsfrButton
           data-testid="handleProjectLockingBtn"

--- a/apps/client/src/views/projects/DsoDashboard.vue
+++ b/apps/client/src/views/projects/DsoDashboard.vue
@@ -32,6 +32,13 @@ const updateProject = async (projectId: ProjectInfos['id']) => {
   snackbarStore.isWaitingForResponse = false
 }
 
+const replayHooks = async (projectId: ProjectInfos['id']) => {
+  snackbarStore.isWaitingForResponse = true
+  await useProjectStore().replayHooksForProject(projectId)
+  snackbarStore.setMessage('Le projet a été reprovisionné avec succès', 'success')
+  snackbarStore.isWaitingForResponse = false
+}
+
 const archiveProject = async (projectId: ProjectInfos['id']) => {
   snackbarStore.isWaitingForResponse = true
   await projectStore.archiveProject(projectId)
@@ -173,6 +180,17 @@ onBeforeMount(async () => {
           resourceKey: 'status',
           wording: `Projet ${project?.name}`
         }"
+      />
+    </div>
+    <div
+      class="fr-mt-2w"
+    >
+      <DsfrButton
+        data-testid="replayHooksBtn"
+        label="Reprovisionner le projet"
+        icon="ri-refresh-fill"
+        secondary
+        @click="replayHooks(project?.id ?? '')"
       />
     </div>
     <div

--- a/apps/server/src/resources/cluster/business.ts
+++ b/apps/server/src/resources/cluster/business.ts
@@ -1,5 +1,5 @@
-import { UnauthorizedError } from '@/utils/errors.js'
 import { UserProfile, adminGroupPath, exclude } from '@cpn-console/shared'
+import { UnauthorizedError } from '@/utils/errors.js'
 import {
   getClustersWithProjectIdAndConfig,
   getUserById,

--- a/apps/server/src/resources/cluster/business.ts
+++ b/apps/server/src/resources/cluster/business.ts
@@ -1,5 +1,5 @@
-import { UserProfile, adminGroupPath, exclude } from '@cpn-console/shared'
 import { UnauthorizedError } from '@/utils/errors.js'
+import { UserProfile, adminGroupPath, exclude } from '@cpn-console/shared'
 import {
   getClustersWithProjectIdAndConfig,
   getUserById,

--- a/apps/server/src/resources/project/router.ts
+++ b/apps/server/src/resources/project/router.ts
@@ -5,6 +5,7 @@ import {
   updateProject,
   archiveProject,
   getProjectSecrets,
+  replayHooks,
 } from './business.js'
 import { projectContract } from '@cpn-console/shared'
 import { serverInstance } from '@/app.js'
@@ -95,6 +96,26 @@ export const projectRouter = () => serverInstance.router(projectContract, {
     return {
       status: 200,
       body: project,
+    }
+  },
+
+  // Reprovisionner un projet
+  replayHooksForProject: async ({ request: req, params }) => {
+    const requestor = req.session.user
+    const projectId = params.projectId
+
+    await replayHooks(projectId, requestor, req.id)
+
+    addReqLogs({
+      req,
+      message: 'Projet reprovisionné avec succès',
+      infos: {
+        projectId,
+      },
+    })
+    return {
+      status: 204,
+      body: null,
     }
   },
 

--- a/packages/shared/src/contracts/project.ts
+++ b/packages/shared/src/contracts/project.ts
@@ -4,6 +4,7 @@ import {
   GetProjectsSchema,
   GetProjectSecretsSchema,
   UpdateProjectSchema,
+  ReplayHooksForProjectSchema,
   ArchiveProjectSchema,
   PatchProjectSchema,
 } from '../schemas/index.js'
@@ -44,6 +45,16 @@ export const projectContract = contractInstance.router({
     pathParams: UpdateProjectSchema.params,
     body: UpdateProjectSchema.body,
     responses: UpdateProjectSchema.responses,
+  },
+
+  replayHooksForProject: {
+    method: 'PUT',
+    path: `${apiPrefix}/projects/:projectId/hooks`,
+    summary: 'Replay hooks for project',
+    description: 'Replay hooks for a project.',
+    body: null,
+    pathParams: ReplayHooksForProjectSchema.params,
+    responses: ReplayHooksForProjectSchema.responses,
   },
 
   archiveProject: {

--- a/packages/shared/src/schemas/project.ts
+++ b/packages/shared/src/schemas/project.ts
@@ -71,6 +71,17 @@ export const UpdateProjectSchema = {
   },
 }
 
+export const ReplayHooksForProjectSchema = {
+  params: z.object({
+    projectId: z.string()
+      .uuid(),
+  }),
+  responses: {
+    204: null,
+    500: ErrorSchema,
+  },
+}
+
 export const PatchProjectSchema = {
   params: z.object({
     projectId: z.string()


### PR DESCRIPTION
Ajout d'un bouton "Reprovisionner le projet" sur les pages `projects/dashboard` et `admin/projects`

![Screenshot from 2024-03-26 17-06-22](https://github.com/cloud-pi-native/console/assets/71137721/660fd533-0b18-4c11-b9fd-9cbdfa5a32af)

![Screenshot from 2024-03-26 17-10-22](https://github.com/cloud-pi-native/console/assets/71137721/ce1ab6a3-6571-4f99-b0b9-aed5b6a6cb90)

## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
