### PR TITLE
ci: :construction_worker: add postgres annotations in helm chart

### DIFF
--- a/helm/templates/deployment-postgres.yaml
+++ b/helm/templates/deployment-postgres.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         {{- include "checksumCm" (list $ "/cm-postgres.yaml") | nindent 8 }}
+        {{- if .Values.postgres.container.annotations }}
+        {{- .Values.postgres.container.annotations | toYaml | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ .Release.Name }}-postgres
     spec:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -105,6 +105,7 @@ postgres:
     image: docker.io/postgres:15.3
     port: 5432
     imagePullPolicy: Always
+    annotations: {}
     env: #hashmap of custom env
     db: dso-console-db
     user: admin


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Il est actuellement impossible d'injecter des annotations sur le statefulset postgres déployé par le chart CPiN.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Il est désormais possible d'injecter des annotations sur le statefulset postgres déployé par le chart CPiN (via les `values.yaml`).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
