### PR TITLE
ci: :construction_worker: restore all files on unit tests cache hit

### DIFF
--- a/.github/workflows/tests-component.yml
+++ b/.github/workflows/tests-component.yml
@@ -94,11 +94,30 @@ jobs:
           restore-keys: |
             node-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Get turbo cache directories
+        id: turbo-cache
+        run: |
+          TURBO_CACHE_PATHS=""
+          for pkg in $(find ./apps ./packages ./plugins -type d -mindepth 1 -maxdepth 1 -not -path "**/node_modules"); do
+            if [ -z "$TURBO_CACHE_PATHS" ]; then
+          TURBO_CACHE_PATHS="$pkg/dist
+          $pkg/types"
+            else
+          TURBO_CACHE_PATHS="$TURBO_CACHE_PATHS
+          $pkg/dist
+          $pkg/types"
+            fi
+          done
+          echo "TURBO_CACHE_PATHS<<EOF" >> $GITHUB_OUTPUT
+          echo "$TURBO_CACHE_PATHS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Cache turbo files
         uses: actions/cache@v4
         with:
           path: |
             ./.turbo/cache
+            ${{ steps.turbo-cache.outputs.TURBO_CACHE_PATHS }}
           key: turbo-component-${{ runner.os }}-${{ runner.arch }}-${{ matrix.browsers }}-${{ hashFiles('apps/**/src/**','apps/client/cypress/**','packages/**/src/**','plugins/**/src/**') }}
           restore-keys: |
             turbo-component-${{ runner.os }}-${{ runner.arch }}-${{ matrix.browsers }}-

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -102,11 +102,30 @@ jobs:
           restore-keys: |
             node-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Get turbo cache directories
+        id: turbo-cache
+        run: |
+          TURBO_CACHE_PATHS=""
+          for pkg in $(find ./apps ./packages ./plugins -type d -mindepth 1 -maxdepth 1 -not -path "**/node_modules"); do
+            if [ -z "$TURBO_CACHE_PATHS" ]; then
+          TURBO_CACHE_PATHS="$pkg/dist
+          $pkg/types"
+            else
+          TURBO_CACHE_PATHS="$TURBO_CACHE_PATHS
+          $pkg/dist
+          $pkg/types"
+            fi
+          done
+          echo "TURBO_CACHE_PATHS<<EOF" >> $GITHUB_OUTPUT
+          echo "$TURBO_CACHE_PATHS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Cache turbo files
         uses: actions/cache@v4
         with:
           path: |
             ./.turbo/cache
+            ${{ steps.turbo-cache.outputs.TURBO_CACHE_PATHS }}
           key: turbo-e2e-${{ runner.os }}-${{ runner.arch }}-${{ matrix.browsers }}-${{ hashFiles('apps/**/src/**','apps/client/cypress/**','packages/**/src/**','plugins/**/src/**') }}
           restore-keys: |
             turbo-e2e-${{ runner.os }}-${{ runner.arch }}-${{ matrix.browsers }}-

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -33,6 +33,8 @@ jobs:
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
+    outputs:
+      turbo-cache: ${{ steps.turbo-cache.outputs.TURBO_CACHE_PATHS }}
     steps:
       - name: Checks-out repository
         uses: actions/checkout@v4
@@ -63,13 +65,32 @@ jobs:
           restore-keys: |
             node-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Get turbo cache directories
+        id: turbo-cache
+        run: |
+          TURBO_CACHE_PATHS=""
+          for pkg in $(find ./apps ./packages ./plugins -type d -mindepth 1 -maxdepth 1 -not -path "**/node_modules"); do
+            if [ -z "$TURBO_CACHE_PATHS" ]; then
+          TURBO_CACHE_PATHS="$pkg/dist
+          $pkg/types
+          $pkg/coverage"
+            else
+          TURBO_CACHE_PATHS="$TURBO_CACHE_PATHS
+          $pkg/dist
+          $pkg/types
+          $pkg/coverage"
+            fi
+          done
+          echo "TURBO_CACHE_PATHS<<EOF" >> $GITHUB_OUTPUT
+          echo "$TURBO_CACHE_PATHS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Cache turbo files
         uses: actions/cache@v4
         with:
           path: |
             ./.turbo/cache
-            ./apps/**/coverage
-            ./packages/**/coverage
+            ${{ steps.turbo-cache.outputs.TURBO_CACHE_PATHS }}
           key: turbo-unit-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/**/src/**','packages/**/src/**','plugins/**/src/**') }}
           restore-keys: |
             turbo-unit-${{ runner.os }}-${{ runner.arch }}-
@@ -112,6 +133,7 @@ jobs:
     name: Run code quality analysis
     runs-on: ubuntu-latest
     needs:
+      - unit-tests
       - check-secrets
     if: ${{ needs.check-secrets.outputs.run-scan == 'true' }}
     steps:
@@ -157,9 +179,8 @@ jobs:
         with:
           path: |
             ./.turbo/cache
-            ./apps/**/coverage
-            ./packages/**/coverage
-          key: turbo-unit-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/**/src/**','packages/**/src/**') }}
+            ${{ needs.unit-tests.outputs.turbo-cache }}
+          key: turbo-unit-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/**/src/**','packages/**/src/**','plugins/**/src/**') }}
           restore-keys: |
             turbo-unit-${{ runner.os }}-${{ runner.arch }}-
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Le cache de la CI pendant les tests unitaires n'est pas correctement restauré ce qui fait tomber la CI en échec. Actuellement uniquement les fichiers turbo / de coverage sont restaurés.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Désormais le cache des tests unitaires embarque aussi les dossiers `src/`, `dist/` ou encore `types/`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
