### PR TITLE
fix: :bug: get only client app version from env on production build

### DIFF
--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -28,6 +28,10 @@ const serverHost = process.env.SERVER_HOST ?? 'localhost'
 const serverPort = process.env.SERVER_PORT ?? 4000
 const clientPort = process.env.CLIENT_PORT ?? 8080
 
+const define = process.env.NODE_ENV === 'production'
+  ? { 'process.env': { APP_VERSION: process.env.APP_VERSION } }
+  : { 'process.env': process.env }
+
 // https://vitejs.dev/config/
 export default defineConfig({
   server: {
@@ -41,9 +45,7 @@ export default defineConfig({
       },
     },
   },
-  define: {
-    'process.env': process.env,
-  },
+  define,
   plugins: [
     vue(),
     AutoImport({


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement l'ensemble des variables d'environnement du client sont chargées lors de la phase de build de production de l'application.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Uniquement la variable `APP_VERSION` est chargée lors de la phase de build de production, c'est la seule à devoir être chargée pour injecter le numéro de version de l'application durant cette phase, les autres variables étant peuplées lors de la phase de run de l'application.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
