### PR TITLE
refactor: :recycle: handle disabling helm postgres deployment

### DIFF
--- a/helm/templates/cm-postgres.yaml
+++ b/helm/templates/cm-postgres.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled -}}
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -11,3 +12,4 @@ data:
   PGDATA: /var/lib/postgresql/data/pgdata
   {{- end }}
   {{- include "containerEnv" .Values.postgres.container | indent 2 }}
+{{- end -}}

--- a/helm/templates/cm-scripts.yaml
+++ b/helm/templates/cm-scripts.yaml
@@ -11,6 +11,6 @@ data:
 {{- range $i, $val := .Values.server.plugins }}
     wget {{ $val }} -O {{ $i }}.zip;
     mkdir -p /plugins/{{ $i }}
-    unzip {{ $i }}.zip -d /plugins/{{ $i }};
+    unzip -o {{ $i }}.zip -d /plugins/{{ $i }}
 {{- end }}
 {{- end }}

--- a/helm/templates/cm-server.yaml
+++ b/helm/templates/cm-server.yaml
@@ -19,9 +19,16 @@ data:
   KEYCLOAK_REDIRECT_URI: {{ .redirectUri }}
   {{- end }}
   SERVER_PORT: {{ .Values.server.container.port | quote }}
+  {{- if .Values.postgres.enabled -}}
   {{- with .Values.postgres }}
   DB_HOST: {{ $.Release.Name }}-{{ .service.hostname }}-service
   DB_URL: postgresql://{{ .container.user }}:{{ .container.pass }}@{{ $.Release.Name }}-{{ .service.hostname }}-service:{{ .service.port }}/{{ .container.db }}?schema=public 
+  {{- end }}
+  {{- else }}
+  {{- with .Values.postgres.external }}
+  DB_HOST: {{ .host }}
+  DB_URL: postgresql://{{ .username }}:{{ .password }}@{{ .host }}:{{ .port }}/{{ .database }}?schema=public 
+  {{- end }}
   {{- end }}
   {{- if .Values.server.extraCa.name }}
   NODE_EXTRA_CA_CERTS: /config/ca_certs

--- a/helm/templates/deployment-postgres.yaml
+++ b/helm/templates/deployment-postgres.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -49,3 +50,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.postgres.pvc.size }}
+{{- end -}}

--- a/helm/templates/services-postgres.yaml
+++ b/helm/templates/services-postgres.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.postgres.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-{{ .Values.postgres.service.hostname }}-service
+spec:
+  type: {{ .Values.postgres.service.type }}
+  selector:
+    app: {{ $.Release.Name }}-{{ .Values.postgres.service.hostname }}
+  ports:
+  - port: {{ .Values.postgres.service.port }}
+    targetPort: {{ .Values.postgres.container.port }}
+    nodePort: {{ .Values.postgres.service.nodePort }}
+{{- end }}

--- a/helm/templates/services.yaml
+++ b/helm/templates/services.yaml
@@ -1,4 +1,4 @@
-{{ $containers := list "server" "client" "postgres" }}
+{{ $containers := list "server" "client" }}
 {{- range $container := $containers -}}
 {{- with index $.Values $container }}
 ---

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -101,6 +101,13 @@ client:
     type: ClusterIP
 
 postgres:
+  enabled: true
+  external:
+    host: ""
+    port: ""
+    username: ""
+    password: ""
+    database: ""
   container:
     image: docker.io/postgres:15.3
     port: 5432


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Il est actuellement impossible de désactiver le déploiement de postgres dans le chart Helm.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Il existe désormais une clé `postgres.enabled` (par défaut `true`) pour désactiver le déploiement du postgres.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
- Permet le futur remplacement du postgres déployé par un cluster CNPG.
- Fix le problème de plugins déjà présents sur l'init-container.
