### PR TITLE
fix: :bug: handle vault ha for status monitor

### DIFF
--- a/plugins/vault/package.json
+++ b/plugins/vault/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cpn-console/vault-plugin",
   "description": "",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": false,
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/vault/src/monitor.ts
+++ b/plugins/vault/src/monitor.ts
@@ -17,7 +17,7 @@ type VaultRes = {
 const monitor = async (instance: Monitor): Promise<MonitorInfos> => {
   instance.lastStatus.lastUpdateTimestamp = (new Date()).getTime()
   try {
-    const res = await axios.get(`${requiredEnv('VAULT_URL')}v1/sys/health`, {
+    const res = await axios.get(`${requiredEnv('VAULT_URL')}v1/sys/health?standbyok=true`, {
       headers: {
         'X-Vault-Token': requiredEnv('VAULT_TOKEN'),
       },


### PR DESCRIPTION

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Le check du statut de Vault ne renvoi pas nécessairement `statusCode: 200` dans le cas d'un cluster Vault.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Le check du statut de Vault renvoi `statusCode: 200` même s'il la requête tombe sur un noeud en standby.

cf. https://developer.hashicorp.com/vault/api-docs/system/health#parameters

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
