### PR TITLE
feat: :necktie: hide private quotas for all on environment form

### DIFF
--- a/apps/client/cypress/e2e/specs/admin/clusters.e2e.ts
+++ b/apps/client/cypress/e2e/specs/admin/clusters.e2e.ts
@@ -123,6 +123,7 @@ describe('Administration clusters', () => {
 
   it('Should create a cluster', () => {
     cy.intercept('POST', '/api/v1/admin/clusters').as('createCluster')
+    cy.intercept('GET', '/api/v1/admin/clusters/*/environments').as('getClusterEnvironments')
 
     cy.getByDataTestid('addClusterLink')
       .click()
@@ -176,6 +177,7 @@ describe('Administration clusters', () => {
     cy.getByDataTestid(`clusterTile-${newCluster.label}`)
       .should('be.visible')
       .click()
+    cy.wait('@getClusterEnvironments')
     cy.get('h1')
       .should('contain', 'Mettre à jour le cluster')
     cy.get('div.json-box')

--- a/apps/client/cypress/e2e/specs/admin/projects.e2e.ts
+++ b/apps/client/cypress/e2e/specs/admin/projects.e2e.ts
@@ -1,10 +1,11 @@
 import { statusDict, formatDate, sortArrByObjKeyAsc, type Organization, type Project } from '@cpn-console/shared'
 import { getModel, getModelById } from '../../support/func.js'
 
-function checkTableRowsLength (length: number) {
+const checkTableRowsLength = (length: number) => {
   if (!length) cy.get('tr:last-child>td:first-child').should('have.text', 'Aucun projet trouvé')
   else cy.get('tr').should('have.length', length)
 }
+
 describe('Administration projects', () => {
   const admin = getModelById('user', 'cb8e5b4b-7b7b-40f5-935f-594f48ae6566')
   const organizations = getModel('organization') as Organization[]

--- a/apps/client/src/components/EnvironmentForm.vue
+++ b/apps/client/src/components/EnvironmentForm.vue
@@ -14,7 +14,6 @@ import { useSnackbarStore } from '@/stores/snackbar.js'
 import { useQuotaStore } from '@/stores/quota.js'
 import { useStageStore } from '@/stores/stage.js'
 import { useZoneStore } from '@/stores/zone.js'
-import { useUserStore } from '@/stores/user.js'
 
 type OptionType = {
   text: string
@@ -46,7 +45,6 @@ const snackbarStore = useSnackbarStore()
 const stageStore = useStageStore()
 const quotaStore = useQuotaStore()
 const zoneStore = useZoneStore()
-const userStore = useUserStore()
 
 const localEnvironment = ref(props.environment)
 const environmentToDelete = ref('')
@@ -101,10 +99,10 @@ const setEnvironmentOptions = () => {
   quotaOptions.value =
     quotaStore.quotas
       .filter(quota =>
-        (quota.stageIds.includes(localEnvironment.value.stageId ?? '') && // quotas disponibles sur ce stage,
-          (!quota.isPrivate || userStore.isAdmin)
-        ) || // et ne pas afficher les quotasprivés
-        quota.id === localEnvironment.value.quotaId) // ou celui actuellement associé (au cas où l'association ne soit plus disponible)
+        (quota.stageIds.includes(
+          localEnvironment.value.stageId ?? '') && // quotas disponibles pour ce type d'environnement
+          !quota.isPrivate) || // et ne pas afficher les quotas privés
+        quota.id === localEnvironment.value.quotaId) // ou quota actuellement associé (au cas où l'association ne soit plus disponible)
       .map(quota => ({
         text: `${quota.name} (${quota.cpu}CPU, ${quota.memory})`,
         value: quota.id,

--- a/packages/test-utils/src/imports/data.ts
+++ b/packages/test-utils/src/imports/data.ts
@@ -17,7 +17,7 @@ const environment = [
     updatedAt: '2023-07-03T14:46:56.829Z',
     clusterId: 'aaaaaaaa-5b03-45d5-847b-149dec875680',
     quotaId: '5a57b62f-2465-4fb6-a853-5a751d099199',
-    stageId: '4a9ad694-4c54-4a3c-9579-548bf4b7b1b9',
+    stageId: '38fa869d-6267-441d-af7f-e0548fd06b7e',
   },
   {
     id: '8d4503eb-64c7-407e-89db-6ab80865071f',
@@ -37,7 +37,7 @@ const environment = [
     updatedAt: '2023-07-03T14:46:56.859Z',
     clusterId: 'aaaaaaaa-5b03-45d5-847b-149dec875680',
     quotaId: '5a57b62f-2465-4fb6-a853-5a751d099199',
-    stageId: '4a9ad694-4c54-4a3c-9579-548bf4b7b1b9',
+    stageId: '38fa869d-6267-441d-af7f-e0548fd06b7e',
   },
   {
     id: '1b9f1053-fcf5-4053-a7b2-ff8a2c0c1921',
@@ -57,7 +57,7 @@ const environment = [
     updatedAt: '2023-07-03T14:46:56.803Z',
     clusterId: '126ac57f-263c-4463-87bb-d4e9017056b2',
     quotaId: '5a57b62f-2465-4fb6-a853-5a751d099199',
-    stageId: '4a9ad694-4c54-4a3c-9579-548bf4b7b1b9',
+    stageId: 'd434310e-7850-4d59-b47f-0772edf50582',
   },
   {
     id: '1c654f00-4798-4a80-929f-960ddb36774b',
@@ -67,7 +67,7 @@ const environment = [
     updatedAt: '2023-07-03T14:46:56.803Z',
     clusterId: '32636a52-4dd1-430b-b08a-b2e5ed9d1789',
     quotaId: '5a57b62f-2465-4fb6-a853-5a751d099199',
-    stageId: '4a9ad694-4c54-4a3c-9579-548bf4b7b1b9',
+    stageId: 'd434310e-7850-4d59-b47f-0772edf50582',
   },
   {
     id: '2805a1f5-0ca4-46a4-b3d7-5b649aee4a91',
@@ -77,7 +77,7 @@ const environment = [
     updatedAt: '2023-07-03T14:46:56.815Z',
     clusterId: '32636a52-4dd1-430b-b08a-b2e5ed9d1789',
     quotaId: '5a57b62f-2465-4fb6-a853-5a751d099199',
-    stageId: '4a9ad694-4c54-4a3c-9579-548bf4b7b1b9',
+    stageId: 'd434310e-7850-4d59-b47f-0772edf50582',
   },
 ]
 const projectClusterHistory = environment.reduce((acc, { projectId, clusterId }) => {


### PR DESCRIPTION
## Quel est le comportement actuel ?
Pour un admin membre d'un projet qui souhaiterait modifier ou ajouter un environnement, on affiche la liste de tous les quotas, y compris les quotas privés.

## Quel est le nouveau comportement ?
On n'affiche plus les quotas privés sur le formulaire de modification ou de création d'un environnement, peu importe le rôle de la personne.

## Autres informations
L'admin a toujours accès au quota privé dans la liste admin des projets. 
