### PR TITLE
Ci/enable chart deploy test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
   deploy-tests:
     uses: ./.github/workflows/tests-deploy.yml
-    if: ${{ needs.path-filter.outputs.apps != 'true' }}
+    if: ${{ needs.path-filter.outputs.apps != 'true' || (!github.event.pull_request.draft && github.base_ref == 'main') }}
     needs:
       - path-filter
       - expose-vars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     with:
       NODE_VERSION: ${{ needs.expose-vars.outputs.NODE_VERSION }}
       PNPM_VERSION: ${{ needs.expose-vars.outputs.PNPM_VERSION }}
-      BROWSERS: "${{ github.base_ref == 'main' && 'electron,firefox' || 'firefox' }}"
+      BROWSERS: "${{ github.base_ref == 'main' && 'chrome,firefox' || 'firefox' }}"
 
   build:
     uses: ./.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
       NODE_VERSION: ${{ needs.expose-vars.outputs.NODE_VERSION }}
       PNPM_VERSION: ${{ needs.expose-vars.outputs.PNPM_VERSION }}
       TAG: pr-${{ github.event.pull_request.number || github.event.number }}
-      BROWSERS: "${{ github.base_ref == 'main' && 'electron,firefox' || 'firefox' }}"
+      BROWSERS: "${{ github.base_ref == 'main' && 'chrome,firefox' || 'firefox' }}"
 
   deploy-tests:
     uses: ./.github/workflows/tests-deploy.yml

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prepare": "husky",
     "test": "turbo run test --concurrency 1 --color --no-daemon",
     "test:cov": "turbo run test:cov --color --no-daemon",
-    "test:ct": "turbo run test:ct --color --no-daemon",
+    "test:ct": "pnpm --filter @cpn-console/shared run build && pnpm --filter @cpn-console/test-utils run build && pnpm --filter @cpn-console/client run test:ct",
     "test:ct-ci": "turbo run test:ct-ci --color --no-daemon",
     "test:e2e": "pnpm kube:e2e",
     "test:e2e-ci": "pnpm kube:prod; pnpm kube:e2e-ci"

--- a/turbo.json
+++ b/turbo.json
@@ -66,6 +66,7 @@
         "^@cpn-console/shared#build",
         "^@cpn-console/test-utils#build"
       ],
+      "cache": false,
       "outputs": []
     },
     "test:ct-ci": {
@@ -80,6 +81,7 @@
         "^@cpn-console/shared#build",
         "^@cpn-console/test-utils#build"
       ],
+      "cache": false,
       "outputs": []
     },
     "test:e2e-ci": {


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
- Les tests de déploiement du chart de la Console sont effectué lors de chaque flow de release (lors du merge dans `main`) en parallèle des tests e2e docker.
- Les tests Cypress UI n'utilisent plus Turbo.
- La CI utilise `chrome` à la place de `electron` pour les tests Cypress (https://github.com/cypress-io/cypress/issues/28892)

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
