### PR TITLE
fix: 🐛 insert user when first accessing admin pages

### DIFF
--- a/apps/server/src/resources/cluster/admin/business.ts
+++ b/apps/server/src/resources/cluster/admin/business.ts
@@ -1,6 +1,5 @@
-import type { User } from '@prisma/client'
 import { ClusterBusinessSchema, ClusterPrivacy, CreateClusterBusinessSchema, Project, UserProfile, type Cluster } from '@cpn-console/shared'
-import { addLogs, createCluster as createClusterQuery, deleteCluster as deleteClusterQuery, getClusterById, getClusterByLabel, getClusterEnvironments, getClustersWithProjectIdAndConfig, getProjectsByClusterId, getStagesByClusterId, getUserById, linkClusterToProjects, linkZoneToClusters, removeClusterFromProject, removeClusterFromStage, updateCluster as updateClusterQuery } from '@/resources/queries-index.js'
+import { addLogs, createCluster as createClusterQuery, deleteCluster as deleteClusterQuery, getClusterById, getClusterByLabel, getClusterEnvironments, getClustersWithProjectIdAndConfig, getOrCreateUser, getProjectsByClusterId, getStagesByClusterId, linkClusterToProjects, linkZoneToClusters, removeClusterFromProject, removeClusterFromStage, updateCluster as updateClusterQuery } from '@/resources/queries-index.js'
 import { linkClusterToStages } from '@/resources/stage/business.js'
 import { validateSchema } from '@/utils/business.js'
 import { BadRequestError, DsoError, NotFoundError, UnauthorizedError } from '@/utils/errors.js'
@@ -14,7 +13,8 @@ export const checkClusterProjectIds = (data: Omit<Cluster, 'id'> & { id?: Cluste
 }
 
 export const getAllClusters = async (kcUser: UserProfile) => {
-  const user = await getUserById(kcUser.id)
+  const { groups: _, ...userInfo } = kcUser
+  const user = await getOrCreateUser(userInfo)
   if (!user) throw new UnauthorizedError('Vous n\'êtes pas connecté')
 
   const clusters = await getClustersWithProjectIdAndConfig()

--- a/apps/server/src/resources/cluster/business.ts
+++ b/apps/server/src/resources/cluster/business.ts
@@ -1,12 +1,13 @@
 import { UserProfile } from '@cpn-console/shared'
 import { UnauthorizedError } from '@/utils/errors.js'
 import {
-  getUserById,
+  getOrCreateUser,
   listClustersForUser,
 } from '../queries-index.js'
 
 export const getAllUserClusters = async (kcUser: UserProfile) => {
-  const user = await getUserById(kcUser.id)
+  const { groups: _, ...userInfo } = kcUser
+  const user = await getOrCreateUser(userInfo)
   if (!user) throw new UnauthorizedError('Vous n\'êtes pas connecté')
 
   const clusters = await listClustersForUser(user.id)

--- a/apps/server/src/resources/quota/business.ts
+++ b/apps/server/src/resources/quota/business.ts
@@ -1,13 +1,14 @@
 import { UnauthorizedError } from '@/utils/errors.js'
 import {
-  getUserById,
   getQuotas as getQuotasQuery,
   getAllQuotas,
+  getOrCreateUser,
 } from '../queries-index.js'
 import { UserProfile, adminGroupPath } from '@cpn-console/shared'
 
 export const getQuotas = async (kcUser: UserProfile) => {
-  const user = await getUserById(kcUser.id)
+  const { groups: _, ...userInfo } = kcUser
+  const user = await getOrCreateUser(userInfo)
   if (!user) throw new UnauthorizedError('Vous n\'êtes pas connecté')
 
   const quotas = kcUser.groups?.includes(adminGroupPath)

--- a/packages/eslintconfig/index.js
+++ b/packages/eslintconfig/index.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   rules: {
     "comma-dangle": [2, "always-multiline"],
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: "^_" }],
     "@typescript-eslint/no-explicit-any": "off",
     '@typescript-eslint/ban-ts-comment': 'off',
   },


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
Message d'erreur "Vous n'êtes pas connecté" sur les pages d'admin lorsque la table User ne contient pas encore l'utilisateur connecté avec keycloak (premières connexions)

## Quel est le nouveau comportement ?
Plus de message d'erreur grâce au passage par un `getOrCreateUser`

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
