### PR TITLE
fix: :bug: don't ignore user token when testing cluster deployment mode

### DIFF
--- a/plugins/argocd/src/functions.ts
+++ b/plugins/argocd/src/functions.ts
@@ -54,7 +54,7 @@ export const upsertProject: StepCall<Project> = async (payload) => {
         appProjectName, infraAppsRepoUrl, sourceRepos, infraProject.id, gitlabApi,
       )
 
-      if (!cluster.user.keyData) {
+      if (!cluster.user.keyData && !cluster.user.token) {
         console.log(`Direct argocd API calls are disabled for cluster ${cluster.label}`)
         continue
       }

--- a/plugins/kubernetes/src/api.ts
+++ b/plugins/kubernetes/src/api.ts
@@ -3,7 +3,7 @@ import { type ClusterObject } from '@cpn-console/hooks'
 import { AnyObjectsApi } from './customApiClass.js'
 
 export const createCoreV1Api = (cluster: ClusterObject) => {
-  if (!cluster.user.keyData) {
+  if (!cluster.user.keyData && !cluster.user.token) {
     // Special case: disable direct calls to the cluster
     console.log(`Direct kubernetes API calls are disabled for cluster ${cluster.label}`)
     return
@@ -28,7 +28,7 @@ export const createCoreV1Apis = (clusters: ClusterObject[]) => {
 }
 
 export const createCustomObjectApi = (cluster: ClusterObject) => {
-  if (!cluster.user.keyData) {
+  if (!cluster.user.keyData && !cluster.user.token) {
     // Special case: disable direct calls to the cluster
     return
   }


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
Un kubeconfig en mode user token est considéré comme un cluster inaccessible.

## Quel est le nouveau comportement ?
Le kubeconfig avec token est bien utilisé pour communiquer avec le cluster.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
