### PR TITLE
fix: add label to page update cluster

### DIFF
--- a/apps/client/src/components/ClusterForm.vue
+++ b/apps/client/src/components/ClusterForm.vue
@@ -217,7 +217,7 @@ const isConnectionDetailsShown = ref(true)
     <h1
       class="fr-h1"
     >
-      {{ isNewCluster ? 'Ajouter un cluster' : 'Mettre à jour le cluster' }}
+      {{ isNewCluster ? 'Ajouter un cluster' : 'Mettre à jour le cluster ' + localCluster.label }}
     </h1>
     <div
       class="cursor-pointer"


### PR DESCRIPTION
Ajoute le nom du cluster dans la page de modification des clusters:

Exemple:

Avant:
`Mettre à jour le cluster`

Après:
`Mettre à jour le cluster pas-top-cluster`