### PR TITLE
ci: :construction_worker: handle app preview

### DIFF
--- a/.github/labeler/build.yml
+++ b/.github/labeler/build.yml
@@ -1,0 +1,3 @@
+built:
+- changed-files:
+  - any-glob-to-any-file: '**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,14 @@ jobs:
       MULTI_ARCH: ${{ needs.expose-vars.outputs.MULTI_ARCH == 'true' }}
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
 
+  build-label:
+    uses: ./.github/workflows/label.yml
+    needs:
+      - expose-vars
+      - build
+    with:
+      CONF_PATH: ./.github/labeler/build.yml
+
   e2e-tests:
     uses: ./.github/workflows/tests-e2e.yml
     if: ${{ needs.path-filter.outputs.apps == 'true' }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,21 @@
+name: Add labels on PR
+
+on:
+  workflow_call:
+    inputs:
+      CONF_PATH:
+        required: true
+        type: string
+
+jobs:
+  label:
+    name: Add labels on PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checks-out repository
+        uses: actions/checkout@v4
+
+      - name: Add pull request label
+        uses: actions/labeler@v5
+        with:
+          configuration-path: ${{ inputs.CONF_PATH }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,32 @@
+name: Preview comment
+
+on:
+  pull_request:
+    types:
+      - labeled
+    branches:
+      - "**"
+
+jobs:
+  preview-comment:
+    name: Add comment with preview infos
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checks-out repository
+        uses: actions/checkout@v4
+
+      - name: Generate app url
+        id: generate-url
+        run: |
+          echo "CONSOLE_URL=$(echo "${{ vars.CONSOLE_TEMPLATE_URL }}" | sed 's|<pr_number>|${{ github.event.number }}|g')" >> $GITHUB_OUTPUT
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            🤖 Hey !
+            
+            A preview of the application is available at : ${{ steps.generate-url.outputs.CONSOLE_URL }}
+
+            *Please be patient, deployment may take a few minutes.*

--- a/ci/preview/applicationset.yaml
+++ b/ci/preview/applicationset.yaml
@@ -1,0 +1,45 @@
+# Applicationset template used for preview app in CI/CD
+# cf. https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/#github
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cpn-console-preview
+  namespace: <argocd_namespace>
+spec:
+  generators:
+  - pullRequest:
+      github:
+        owner: cloud-pi-native
+        repo: console
+        labels:
+        - preview
+        - built
+        appSecretName: <repo_secret> # Secret containing Github App infos (cf. https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#github-app-repositories)
+  template:
+    metadata:
+      name: cpn-console-preview-pr-{{number}}
+    spec:
+      destination:
+        namespace: cpn-preview-pr-{{number}}
+        server: https://kubernetes.default.svc
+      project: <argocd_project>
+      source:
+        chart: cpn-console
+        repoURL: https://cloud-pi-native.github.io/helm-charts
+        targetRevision: 1.*.*
+        helm:
+          values: |
+            client:
+              image:
+                tag: pr-{{number}}
+            server:
+              image:
+                tag: pr-{{number}}
+            ...
+      syncPolicy:
+        syncOptions:
+        - CreateNamespace=true
+        - ApplyOutOfSyncOnly=true
+        automated:
+          selfHeal: true


### PR DESCRIPTION
<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Il n'est pas possible d'utiliser les preview apps.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Ajoute la gestion des preview apps. Si on ajoute le label `preview` sur la PR :
- Déploie une app Argo-cd avec les images construites dans la PR.
- Ajoute un commentaire sur la PR avec l'url de la console.

Les utilisateurs créés dans Keycloak sont :
- Un utilisateur admin *- `admin`*.
- Un utilisateur standard *- `test`*.

L'application est détruite si on retire le tag / close la PR / merge la PR.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Cette fonctionnalité utilise le [pull request generator de Argo-cd](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/#github).

J'ai dû faire des release du chart de la console pour permettre l'import d'un realm de dev.