### PR TITLE
ci: :construction_worker: fix trivy pull rate limits

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -57,10 +57,6 @@ jobs:
       - name: Checks-out repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker buildx
-        if: ${{ matrix.images.build != false }}
-        uses: docker/setup-buildx-action@v3
-
       - name: Run Trivy vulnerability scanner on images
         uses: aquasecurity/trivy-action@master
         with:
@@ -70,6 +66,7 @@ jobs:
           vuln-type: "os,library"
           ignore-unfixed: true
           output: trivy-results.sarif
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Upload Trivy scan results to GitHub Security tab
@@ -96,6 +93,7 @@ jobs:
           skip-dirs: "**/node_modules,ci"
           ignore-unfixed: true
           output: trivy-results.sarif
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Le pull de l'image Trivy est parfois bloqué par le rate limit :
```sh
GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 103.354µs, allowed: 44000/minute
```

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
L'authentification par token Github doit remédier aux problèmes de rate limit (cf. [la doc](https://aquasecurity.github.io/trivy/v0.55/docs/references/troubleshooting/#github-rate-limiting).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
