### PR TITLE
perf(gitlabe): trace the number of calls to gitlabe api

### DIFF
--- a/plugins/gitlab/src/class.ts
+++ b/plugins/gitlab/src/class.ts
@@ -196,6 +196,8 @@ export class GitlabZoneApi extends GitlabApi {
     const rootId = await getGroupRootId()
     // Get or create projects_root_dir/infra group
     const searchResult = await this.api.Groups.search(infraGroupName)
+    // console.log("[SEARCH_GROUPE_BY_ZONE]")
+    // console.trace(searchResult)
     const existingParentGroup = searchResult.find(group => group.parent_id === rootId && group.name === infraGroupName)
     return existingParentGroup || await this.api.Groups.create(infraGroupName, infraGroupPath, {
       parentId: rootId,
@@ -210,6 +212,8 @@ export class GitlabZoneApi extends GitlabApi {
     const infraGroup = await this.getOrCreateInfraGroup()
     // Get or create projects_root_dir/infra/zone
     const infraProjects = await this.api.Groups.allProjects(infraGroup.id)
+    // console.log("[GET_ALL_PROJECTS_BY_INFRA_GROUP]")
+    // console.trace(infraProjects)
     return infraProjects.find(repo => repo.name === zone) ?? await this.createEmptyRepository({
       repoName: zone,
       groupId: infraGroup.id,


### PR DESCRIPTION
## Issues liées 
***PR nom mergeable.***
Just pour montrer les calls

Issues numéro:
- [x] trace the number of calls to gitlabe api

8 calls to `getApi()` 
rapport:
```shell
dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at getGroupRootId (/app/plugins/gitlab/src/utils.ts:14:21)
dso-console_server  |     at Module.getOrCreateGroupRoot (/app/plugins/gitlab/src/utils.ts:61:22)
dso-console_server  |     at Object.start (/app/plugins/gitlab/src/index.ts:20:3)
dso-console_server  |     at Object.register (/app/packages/hooks/src/index.ts:58:14)
dso-console_server  |     at Module.initPm (/app/apps/server/src/plugins.ts:17:6)
dso-console_server  |     at Module.getPreparedApp (/app/apps/server/src/prepare-app.ts:79:3)
dso-console_server  |     at /app/apps/server/src/server.ts:6:13
dso-console_server  |     at ViteNodeRunner.runModule (file:///app/node_modules/.pnpm/vite-node@2.1.9_@types+node@22.13.5_terser@5.39.0/node_modules/vite-node/dist/client.mjs:399:5)
dso-console_server  |     at ViteNodeRunner.directRequest (file:///app/node_modules/.pnpm/vite-node@2.1.9_@types+node@22.13.5_terser@5.39.0/node_modules/vite-node/dist/client.mjs:381:5)
dso-console_server  | Plugin gitlab registered at deleteProject:main deleteProject:post upsertProject:check upsertProject:main upsertProject:post getProjectSecrets:main syncRepository:main syncRepository:post upsertZone:pre upsertZone:post deleteZone:main
```
## Action synchronisation
```shell
dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at Module.getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at new GitlabApi (/app/plugins/gitlab/src/class.ts:41:16)
dso-console_server  |     at new GitlabProjectApi (/app/plugins/gitlab/src/class.ts:230:5)
dso-console_server  |     at api (/app/plugins/gitlab/src/index.ts:17:59)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:106:33
dso-console_server  |     at Array.forEach (<anonymous>)
dso-console_server  |     at Object.execute (/app/packages/hooks/src/hooks/hook.ts:105:26)
dso-console_server  |     at upsertProject (/app/apps/server/src/utils/hook-wrapper.ts:37:45)
dso-console_server  |     at Object.upsert (/app/apps/server/src/utils/hook-wrapper.ts:55:21)

dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at Module.getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at new GitlabProjectApi (/app/plugins/gitlab/src/class.ts:232:16)
dso-console_server  |     at api (/app/plugins/gitlab/src/index.ts:17:59)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:106:33
dso-console_server  |     at Array.forEach (<anonymous>)
dso-console_server  |     at Object.execute (/app/packages/hooks/src/hooks/hook.ts:105:26)
dso-console_server  |     at upsertProject (/app/apps/server/src/utils/hook-wrapper.ts:37:45)
dso-console_server  |     at Object.upsert (/app/apps/server/src/utils/hook-wrapper.ts:55:21)

dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at Module.getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at new GitlabApi (/app/plugins/gitlab/src/class.ts:41:16)
dso-console_server  |     at new GitlabZoneApi (/app/plugins/gitlab/src/class.ts:191:5)
dso-console_server  |     at new GitlabProjectApi (/app/plugins/gitlab/src/class.ts:233:20)
dso-console_server  |     at api (/app/plugins/gitlab/src/index.ts:17:59)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:106:33
dso-console_server  |     at Array.forEach (<anonymous>)
dso-console_server  |     at Object.execute (/app/packages/hooks/src/hooks/hook.ts:105:26)
dso-console_server  |     at upsertProject (/app/apps/server/src/utils/hook-wrapper.ts:37:45)
dso-console_server  |     at Object.upsert (/app/apps/server/src/utils/hook-wrapper.ts:55:21)

dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at Module.getGroupRootId (/app/plugins/gitlab/src/utils.ts:14:21)
dso-console_server  |     at GitlabProjectApi.getProjectGroup (/app/plugins/gitlab/src/class.ts:254:28) ##call api await this.api.Groups.allSubgroups(parentId)
dso-console_server  |     at GitlabProjectApi.getOrCreateProjectGroup (/app/plugins/gitlab/src/class.ts:261:30)
dso-console_server  |     at Object.upsertDsoProject [as gitlab] (/app/plugins/gitlab/src/functions.ts:101:21) ## <--- INTERESTING GITLABE VIA HOOK ---->
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:38
dso-console_server  |     at Array.map (<anonymous>)
dso-console_server  |     at executeStep (/app/packages/hooks/src/hooks/hook.ts:65:21)
dso-console_server  |     at Object.execute (/app/packages/hooks/src/hooks/hook.ts:119:23)
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)

dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at Module.getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at Module.upsertUser (/app/plugins/gitlab/src/user.ts:29:15)
dso-console_server  |     at /app/plugins/gitlab/src/members.ts:9:50
dso-console_server  |     at Array.map (<anonymous>)
dso-console_server  |     at Module.ensureMembers (/app/plugins/gitlab/src/members.ts:9:38)
dso-console_server  |     at Object.upsertDsoProject [as gitlab] (/app/plugins/gitlab/src/functions.ts:103:43) ## <--- INTERESTING GITLABE VIA HOOK ---->
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:22
dso-console_server  |     at async Promise.all (index 1)
dso-console_server  |     at executeStep (/app/packages/hooks/src/hooks/hook.ts:78:19)

dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at Module.getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at getUser (/app/plugins/gitlab/src/user.ts:8:15) ## 2 call await api.Users.all({ search: user.email }) || await api.Users.all({ username: user.username })
dso-console_server  |     at Module.upsertUser (/app/plugins/gitlab/src/user.ts:31:30)
dso-console_server  |     at /app/plugins/gitlab/src/members.ts:9:50
dso-console_server  |     at Array.map (<anonymous>)
dso-console_server  |     at Module.ensureMembers (/app/plugins/gitlab/src/members.ts:9:38)
dso-console_server  |     at Object.upsertDsoProject [as gitlab] (/app/plugins/gitlab/src/functions.ts:103:43) ## <--- INTERESTING GITLABE VIA HOOK ---->
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:22
dso-console_server  |     at async Promise.all (index 1)

dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at Module.getGroupRootId (/app/plugins/gitlab/src/utils.ts:14:21) ## await gitlabApi.Groups.search(projectRootDir)
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraGroup (/app/plugins/gitlab/src/class.ts:196:26)
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:210:35)
dso-console_server  |     at GitlabProjectApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:306:31)
dso-console_server  |     at /app/plugins/argocd/src/functions.ts:61:46
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)
dso-console_server  |     at async Promise.all (index 0)
dso-console_server  |     at Object.upsertProject [as argocd] (/app/plugins/argocd/src/functions.ts:54:5) ## <--- INTERESTING ARGOCD VIA HOOK ---->
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:22

dso-console_server  | <--------- [TRACE]: CAll gitlab Api with url: https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/ timeout: 300000--------->
dso-console_server  | Trace: [TRACE_ACTION]
dso-console_server  |     at getApi (/app/plugins/gitlab/src/utils.ts:73:11)
dso-console_server  |     at Module.getGroupRootId (/app/plugins/gitlab/src/utils.ts:14:21)
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraGroup (/app/plugins/gitlab/src/class.ts:196:26)
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:210:35)
dso-console_server  |     at GitlabProjectApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:306:31)
dso-console_server  |     at removeInfraEnvValues (/app/plugins/argocd/src/functions.ts:294:42)
dso-console_server  |     at Object.upsertProject [as argocd] (/app/plugins/argocd/src/functions.ts:147:11) ## <--- INTERESTING ARGOCD VIA HOOK ---->
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:22
dso-console_server  |     at async Promise.all (index 0)
```

### trace 2 calls on `getOrCreateInfraProject` on `GitlabZoneApi` && `GitlabProjectApi`
```shell
## First call
dso-console_server  | [SEARCH_GROUPE_BY_ZONE
dso-console_server  | Trace: [
dso-console_server  |   {
dso-console_server  |     id: 12,
dso-console_server  |     web_url: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/groups/forge-mi/projects/infra',
dso-console_server  |     name: 'Infra',
dso-console_server  |     path: 'infra',
dso-console_server  |     description: 'Group that hosts infrastructure-as-code repositories for all zones (ArgoCD pull targets).',
dso-console_server  |     visibility: 'private',
dso-console_server  |     share_with_group_lock: false,
dso-console_server  |     require_two_factor_authentication: false,
dso-console_server  |     two_factor_grace_period: 48,
dso-console_server  |     project_creation_level: 'maintainer',
dso-console_server  |     auto_devops_enabled: null,
dso-console_server  |     subgroup_creation_level: 'owner',
dso-console_server  |     emails_disabled: false,
dso-console_server  |     emails_enabled: true,
dso-console_server  |     mentions_disabled: null,
dso-console_server  |     lfs_enabled: true,
dso-console_server  |     math_rendering_limits_enabled: true,
dso-console_server  |     lock_math_rendering_limits_enabled: false,
dso-console_server  |     default_branch: null,
dso-console_server  |     default_branch_protection: 0,
dso-console_server  |     default_branch_protection_defaults: {
dso-console_server  |       allowed_to_push: [Array],
dso-console_server  |       allow_force_push: true,
dso-console_server  |       allowed_to_merge: [Array],
dso-console_server  |       developer_can_initial_push: false,
dso-console_server  |       code_owner_approval_required: false
dso-console_server  |     },
dso-console_server  |     avatar_url: null,
dso-console_server  |     request_access_enabled: true,
dso-console_server  |     full_name: 'forge-mi / projects / Infra',
dso-console_server  |     full_path: 'forge-mi/projects/infra',
dso-console_server  |     created_at: '2025-02-18T23:57:42.683Z',
dso-console_server  |     parent_id: 3,
dso-console_server  |     organization_id: 1,
dso-console_server  |     shared_runners_setting: 'enabled',
dso-console_server  |     max_artifacts_size: null,
dso-console_server  |     ldap_cn: null,
dso-console_server  |     ldap_access: null,
dso-console_server  |     wiki_access_level: 'enabled'
dso-console_server  |   }
dso-console_server  | ]
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraGroup (/app/plugins/gitlab/src/class.ts:200:13)
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:212:24)
dso-console_server  |     at GitlabProjectApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:310:12)
dso-console_server  |     at /app/plugins/argocd/src/functions.ts:61:30
dso-console_server  |     at async Promise.all (index 0)
dso-console_server  |     at Object.upsertProject [as argocd] (/app/plugins/argocd/src/functions.ts:54:5)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:22
dso-console_server  |     at async Promise.all (index 0)
dso-console_server  |     at executeStep (/app/packages/hooks/src/hooks/hook.ts:78:19)
dso-console_server  | [GET_ALL_PROJECTS_BY_INFRA_GROUP
dso-console_server  | Trace: [
dso-console_server  |   {
dso-console_server  |     id: 4,
dso-console_server  |     description: 'Repository hosting deployment files for this zone.',
dso-console_server  |     name: 'default',
dso-console_server  |     name_with_namespace: 'forge-mi / projects / Infra / default',
dso-console_server  |     path: 'default',
dso-console_server  |     path_with_namespace: 'forge-mi/projects/infra/default',
dso-console_server  |     created_at: '2025-02-18T23:57:43.745Z',
dso-console_server  |     default_branch: 'main',
dso-console_server  |     tag_list: [],
dso-console_server  |     topics: [],
dso-console_server  |     ssh_url_to_repo: 'git@gitlab.sdid-hp.cpin.numerique-interieur.com:forge-mi/projects/infra/default.git',
dso-console_server  |     http_url_to_repo: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/forge-mi/projects/infra/default.git',
dso-console_server  |     web_url: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/forge-mi/projects/infra/default',
dso-console_server  |     readme_url: null,
dso-console_server  |     forks_count: 0,
dso-console_server  |     avatar_url: null,
dso-console_server  |     star_count: 0,
dso-console_server  |     last_activity_at: '2025-04-01T12:13:47.083Z',
dso-console_server  |     namespace: {
dso-console_server  |       id: 12,
dso-console_server  |       name: 'Infra',
dso-console_server  |       path: 'infra',
dso-console_server  |       kind: 'group',
dso-console_server  |       full_path: 'forge-mi/projects/infra',
dso-console_server  |       parent_id: 3,
dso-console_server  |       avatar_url: null,
dso-console_server  |       web_url: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/groups/forge-mi/projects/infra'
dso-console_server  |     },
dso-console_server  |     repository_storage: 'default',
dso-console_server  |     _links: {
dso-console_server  |       self: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4',
dso-console_server  |       issues: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/issues',
dso-console_server  |       merge_requests: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/merge_requests',
dso-console_server  |       repo_branches: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/repository/branches',
dso-console_server  |       labels: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/labels',
dso-console_server  |       events: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/events',
dso-console_server  |       members: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/members',
dso-console_server  |       cluster_agents: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/cluster_agents'
dso-console_server  |     },
dso-console_server  |     packages_enabled: true,
dso-console_server  |     empty_repo: false,
dso-console_server  |     archived: false,
dso-console_server  |     visibility: 'private',
dso-console_server  |     resolve_outdated_diff_discussions: false,
dso-console_server  |     container_expiration_policy: {
dso-console_server  |       cadence: '1d',
dso-console_server  |       enabled: false,
dso-console_server  |       keep_n: 10,
dso-console_server  |       older_than: '90d',
dso-console_server  |       name_regex: '.*',
dso-console_server  |       name_regex_keep: null,
dso-console_server  |       next_run_at: '2025-02-19T23:57:43.804Z'
dso-console_server  |     },
dso-console_server  |     repository_object_format: 'sha1',
dso-console_server  |     issues_enabled: true,
dso-console_server  |     merge_requests_enabled: true,
dso-console_server  |     wiki_enabled: true,
dso-console_server  |     jobs_enabled: true,
dso-console_server  |     snippets_enabled: true,
dso-console_server  |     container_registry_enabled: false,
dso-console_server  |     service_desk_enabled: false,
dso-console_server  |     service_desk_address: null,
dso-console_server  |     can_create_merge_request_in: true,
dso-console_server  |     issues_access_level: 'enabled',
dso-console_server  |     repository_access_level: 'enabled',
dso-console_server  |     merge_requests_access_level: 'enabled',
dso-console_server  |     forking_access_level: 'enabled',
dso-console_server  |     wiki_access_level: 'enabled',
dso-console_server  |     builds_access_level: 'enabled',
dso-console_server  |     snippets_access_level: 'enabled',
dso-console_server  |     pages_access_level: 'private',
dso-console_server  |     analytics_access_level: 'enabled',
dso-console_server  |     container_registry_access_level: 'disabled',
dso-console_server  |     security_and_compliance_access_level: 'private',
dso-console_server  |     releases_access_level: 'enabled',
dso-console_server  |     environments_access_level: 'enabled',
dso-console_server  |     feature_flags_access_level: 'enabled',
dso-console_server  |     infrastructure_access_level: 'enabled',
dso-console_server  |     monitor_access_level: 'enabled',
dso-console_server  |     model_experiments_access_level: 'enabled',
dso-console_server  |     model_registry_access_level: 'enabled',
dso-console_server  |     emails_disabled: false,
dso-console_server  |     emails_enabled: true,
dso-console_server  |     shared_runners_enabled: true,
dso-console_server  |     lfs_enabled: true,
dso-console_server  |     creator_id: 1,
dso-console_server  |     import_url: null,
dso-console_server  |     import_type: null,
dso-console_server  |     import_status: 'none',
dso-console_server  |     open_issues_count: 0,
dso-console_server  |     description_html: '<p data-sourcepos="1:1-1:50" dir="auto">Repository hosting deployment files for this zone.</p>',
dso-console_server  |     updated_at: '2025-04-01T12:13:47.083Z',
dso-console_server  |     ci_default_git_depth: 20,
dso-console_server  |     ci_delete_pipelines_in_seconds: null,
dso-console_server  |     ci_forward_deployment_enabled: true,
dso-console_server  |     ci_forward_deployment_rollback_allowed: true,
dso-console_server  |     ci_job_token_scope_enabled: false,
dso-console_server  |     ci_separated_caches: true,
dso-console_server  |     ci_allow_fork_pipelines_to_run_in_parent_project: true,
dso-console_server  |     ci_id_token_sub_claim_components: [ 'project_path', 'ref_type', 'ref' ],
dso-console_server  |     build_git_strategy: 'fetch',
dso-console_server  |     keep_latest_artifact: true,
dso-console_server  |     restrict_user_defined_variables: true,
dso-console_server  |     ci_pipeline_variables_minimum_override_role: 'developer',
dso-console_server  |     runners_token: 'GR1348941vVJrUaZQpSXmmpm_naFo',
dso-console_server  |     runner_token_expiration_interval: null,
dso-console_server  |     group_runners_enabled: true,
dso-console_server  |     auto_cancel_pending_pipelines: 'enabled',
dso-console_server  |     build_timeout: 3600,
dso-console_server  |     auto_devops_enabled: true,
dso-console_server  |     auto_devops_deploy_strategy: 'continuous',
dso-console_server  |     ci_push_repository_for_job_token_allowed: false,
dso-console_server  |     ci_config_path: null,
dso-console_server  |     public_jobs: true,
dso-console_server  |     shared_with_groups: [],
dso-console_server  |     only_allow_merge_if_pipeline_succeeds: false,
dso-console_server  |     allow_merge_on_skipped_pipeline: null,
dso-console_server  |     request_access_enabled: true,
dso-console_server  |     only_allow_merge_if_all_discussions_are_resolved: false,
dso-console_server  |     remove_source_branch_after_merge: true,
dso-console_server  |     printing_merge_request_link_enabled: true,
dso-console_server  |     merge_method: 'merge',
dso-console_server  |     squash_option: 'default_off',
dso-console_server  |     enforce_auth_checks_on_uploads: true,
dso-console_server  |     suggestion_commit_message: null,
dso-console_server  |     merge_commit_template: null,
dso-console_server  |     squash_commit_template: null,
dso-console_server  |     issue_branch_template: null,
dso-console_server  |     warn_about_potentially_unwanted_characters: true,
dso-console_server  |     autoclose_referenced_issues: true,
dso-console_server  |     max_artifacts_size: null,
dso-console_server  |     requirements_enabled: false,
dso-console_server  |     requirements_access_level: 'enabled',
dso-console_server  |     security_and_compliance_enabled: true,
dso-console_server  |     compliance_frameworks: []
dso-console_server  |   }
dso-console_server  | ]
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:216:13)
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)
dso-console_server  |     at GitlabProjectApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:310:12)
dso-console_server  |     at /app/plugins/argocd/src/functions.ts:61:30
dso-console_server  |     at async Promise.all (index 0)
dso-console_server  |     at Object.upsertProject [as argocd] (/app/plugins/argocd/src/functions.ts:54:5)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:22
dso-console_server  |     at async Promise.all (index 0)
dso-console_server  |     at executeStep (/app/packages/hooks/src/hooks/hook.ts:78:19)
dso-console_server  |     at Object.execute (/app/packages/hooks/src/hooks/hook.ts:119:17)

## Second call
dso-console_server  | [SEARCH_GROUPE_BY_ZONE
dso-console_server  | Trace: [
dso-console_server  |   {
dso-console_server  |     id: 12,
dso-console_server  |     web_url: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/groups/forge-mi/projects/infra',
dso-console_server  |     name: 'Infra',
dso-console_server  |     path: 'infra',
dso-console_server  |     description: 'Group that hosts infrastructure-as-code repositories for all zones (ArgoCD pull targets).',
dso-console_server  |     visibility: 'private',
dso-console_server  |     share_with_group_lock: false,
dso-console_server  |     require_two_factor_authentication: false,
dso-console_server  |     two_factor_grace_period: 48,
dso-console_server  |     project_creation_level: 'maintainer',
dso-console_server  |     auto_devops_enabled: null,
dso-console_server  |     subgroup_creation_level: 'owner',
dso-console_server  |     emails_disabled: false,
dso-console_server  |     emails_enabled: true,
dso-console_server  |     mentions_disabled: null,
dso-console_server  |     lfs_enabled: true,
dso-console_server  |     math_rendering_limits_enabled: true,
dso-console_server  |     lock_math_rendering_limits_enabled: false,
dso-console_server  |     default_branch: null,
dso-console_server  |     default_branch_protection: 0,
dso-console_server  |     default_branch_protection_defaults: {
dso-console_server  |       allowed_to_push: [Array],
dso-console_server  |       allow_force_push: true,
dso-console_server  |       allowed_to_merge: [Array],
dso-console_server  |       developer_can_initial_push: false,
dso-console_server  |       code_owner_approval_required: false
dso-console_server  |     },
dso-console_server  |     avatar_url: null,
dso-console_server  |     request_access_enabled: true,
dso-console_server  |     full_name: 'forge-mi / projects / Infra',
dso-console_server  |     full_path: 'forge-mi/projects/infra',
dso-console_server  |     created_at: '2025-02-18T23:57:42.683Z',
dso-console_server  |     parent_id: 3,
dso-console_server  |     organization_id: 1,
dso-console_server  |     shared_runners_setting: 'enabled',
dso-console_server  |     max_artifacts_size: null,
dso-console_server  |     ldap_cn: null,
dso-console_server  |     ldap_access: null,
dso-console_server  |     wiki_access_level: 'enabled'
dso-console_server  |   }
dso-console_server  | ]
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraGroup (/app/plugins/gitlab/src/class.ts:200:13)
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:212:24)
dso-console_server  |     at GitlabProjectApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:310:12)
dso-console_server  |     at removeInfraEnvValues (/app/plugins/argocd/src/functions.ts:294:26)
dso-console_server  |     at Object.upsertProject [as argocd] (/app/plugins/argocd/src/functions.ts:147:5)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:22
dso-console_server  |     at async Promise.all (index 0)
dso-console_server  |     at executeStep (/app/packages/hooks/src/hooks/hook.ts:78:19)
dso-console_server  |     at Object.execute (/app/packages/hooks/src/hooks/hook.ts:119:17)
dso-console_server  | [GET_ALL_PROJECTS_BY_INFRA_GROUP
dso-console_server  | Trace: [
dso-console_server  |   {
dso-console_server  |     id: 4,
dso-console_server  |     description: 'Repository hosting deployment files for this zone.',
dso-console_server  |     name: 'default',
dso-console_server  |     name_with_namespace: 'forge-mi / projects / Infra / default',
dso-console_server  |     path: 'default',
dso-console_server  |     path_with_namespace: 'forge-mi/projects/infra/default',
dso-console_server  |     created_at: '2025-02-18T23:57:43.745Z',
dso-console_server  |     default_branch: 'main',
dso-console_server  |     tag_list: [],
dso-console_server  |     topics: [],
dso-console_server  |     ssh_url_to_repo: 'git@gitlab.sdid-hp.cpin.numerique-interieur.com:forge-mi/projects/infra/default.git',
dso-console_server  |     http_url_to_repo: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/forge-mi/projects/infra/default.git',
dso-console_server  |     web_url: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/forge-mi/projects/infra/default',
dso-console_server  |     readme_url: null,
dso-console_server  |     forks_count: 0,
dso-console_server  |     avatar_url: null,
dso-console_server  |     star_count: 0,
dso-console_server  |     last_activity_at: '2025-04-01T12:13:47.083Z',
dso-console_server  |     namespace: {
dso-console_server  |       id: 12,
dso-console_server  |       name: 'Infra',
dso-console_server  |       path: 'infra',
dso-console_server  |       kind: 'group',
dso-console_server  |       full_path: 'forge-mi/projects/infra',
dso-console_server  |       parent_id: 3,
dso-console_server  |       avatar_url: null,
dso-console_server  |       web_url: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/groups/forge-mi/projects/infra'
dso-console_server  |     },
dso-console_server  |     repository_storage: 'default',
dso-console_server  |     _links: {
dso-console_server  |       self: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4',
dso-console_server  |       issues: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/issues',
dso-console_server  |       merge_requests: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/merge_requests',
dso-console_server  |       repo_branches: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/repository/branches',
dso-console_server  |       labels: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/labels',
dso-console_server  |       events: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/events',
dso-console_server  |       members: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/members',
dso-console_server  |       cluster_agents: 'https://gitlab.sdid-hp.cpin.numerique-interieur.com/api/v4/projects/4/cluster_agents'
dso-console_server  |     },
dso-console_server  |     packages_enabled: true,
dso-console_server  |     empty_repo: false,
dso-console_server  |     archived: false,
dso-console_server  |     visibility: 'private',
dso-console_server  |     resolve_outdated_diff_discussions: false,
dso-console_server  |     container_expiration_policy: {
dso-console_server  |       cadence: '1d',
dso-console_server  |       enabled: false,
dso-console_server  |       keep_n: 10,
dso-console_server  |       older_than: '90d',
dso-console_server  |       name_regex: '.*',
dso-console_server  |       name_regex_keep: null,
dso-console_server  |       next_run_at: '2025-02-19T23:57:43.804Z'
dso-console_server  |     },
dso-console_server  |     repository_object_format: 'sha1',
dso-console_server  |     issues_enabled: true,
dso-console_server  |     merge_requests_enabled: true,
dso-console_server  |     wiki_enabled: true,
dso-console_server  |     jobs_enabled: true,
dso-console_server  |     snippets_enabled: true,
dso-console_server  |     container_registry_enabled: false,
dso-console_server  |     service_desk_enabled: false,
dso-console_server  |     service_desk_address: null,
dso-console_server  |     can_create_merge_request_in: true,
dso-console_server  |     issues_access_level: 'enabled',
dso-console_server  |     repository_access_level: 'enabled',
dso-console_server  |     merge_requests_access_level: 'enabled',
dso-console_server  |     forking_access_level: 'enabled',
dso-console_server  |     wiki_access_level: 'enabled',
dso-console_server  |     builds_access_level: 'enabled',
dso-console_server  |     snippets_access_level: 'enabled',
dso-console_server  |     pages_access_level: 'private',
dso-console_server  |     analytics_access_level: 'enabled',
dso-console_server  |     container_registry_access_level: 'disabled',
dso-console_server  |     security_and_compliance_access_level: 'private',
dso-console_server  |     releases_access_level: 'enabled',
dso-console_server  |     environments_access_level: 'enabled',
dso-console_server  |     feature_flags_access_level: 'enabled',
dso-console_server  |     infrastructure_access_level: 'enabled',
dso-console_server  |     monitor_access_level: 'enabled',
dso-console_server  |     model_experiments_access_level: 'enabled',
dso-console_server  |     model_registry_access_level: 'enabled',
dso-console_server  |     emails_disabled: false,
dso-console_server  |     emails_enabled: true,
dso-console_server  |     shared_runners_enabled: true,
dso-console_server  |     lfs_enabled: true,
dso-console_server  |     creator_id: 1,
dso-console_server  |     import_url: null,
dso-console_server  |     import_type: null,
dso-console_server  |     import_status: 'none',
dso-console_server  |     open_issues_count: 0,
dso-console_server  |     description_html: '<p data-sourcepos="1:1-1:50" dir="auto">Repository hosting deployment files for this zone.</p>',
dso-console_server  |     updated_at: '2025-04-01T12:13:47.083Z',
dso-console_server  |     ci_default_git_depth: 20,
dso-console_server  |     ci_delete_pipelines_in_seconds: null,
dso-console_server  |     ci_forward_deployment_enabled: true,
dso-console_server  |     ci_forward_deployment_rollback_allowed: true,
dso-console_server  |     ci_job_token_scope_enabled: false,
dso-console_server  |     ci_separated_caches: true,
dso-console_server  |     ci_allow_fork_pipelines_to_run_in_parent_project: true,
dso-console_server  |     ci_id_token_sub_claim_components: [ 'project_path', 'ref_type', 'ref' ],
dso-console_server  |     build_git_strategy: 'fetch',
dso-console_server  |     keep_latest_artifact: true,
dso-console_server  |     restrict_user_defined_variables: true,
dso-console_server  |     ci_pipeline_variables_minimum_override_role: 'developer',
dso-console_server  |     runners_token: 'GR1348941vVJrUaZQpSXmmpm_naFo',
dso-console_server  |     runner_token_expiration_interval: null,
dso-console_server  |     group_runners_enabled: true,
dso-console_server  |     auto_cancel_pending_pipelines: 'enabled',
dso-console_server  |     build_timeout: 3600,
dso-console_server  |     auto_devops_enabled: true,
dso-console_server  |     auto_devops_deploy_strategy: 'continuous',
dso-console_server  |     ci_push_repository_for_job_token_allowed: false,
dso-console_server  |     ci_config_path: null,
dso-console_server  |     public_jobs: true,
dso-console_server  |     shared_with_groups: [],
dso-console_server  |     only_allow_merge_if_pipeline_succeeds: false,
dso-console_server  |     allow_merge_on_skipped_pipeline: null,
dso-console_server  |     request_access_enabled: true,
dso-console_server  |     only_allow_merge_if_all_discussions_are_resolved: false,
dso-console_server  |     remove_source_branch_after_merge: true,
dso-console_server  |     printing_merge_request_link_enabled: true,
dso-console_server  |     merge_method: 'merge',
dso-console_server  |     squash_option: 'default_off',
dso-console_server  |     enforce_auth_checks_on_uploads: true,
dso-console_server  |     suggestion_commit_message: null,
dso-console_server  |     merge_commit_template: null,
dso-console_server  |     squash_commit_template: null,
dso-console_server  |     issue_branch_template: null,
dso-console_server  |     warn_about_potentially_unwanted_characters: true,
dso-console_server  |     autoclose_referenced_issues: true,
dso-console_server  |     max_artifacts_size: null,
dso-console_server  |     requirements_enabled: false,
dso-console_server  |     requirements_access_level: 'enabled',
dso-console_server  |     security_and_compliance_enabled: true,
dso-console_server  |     compliance_frameworks: []
dso-console_server  |   }
dso-console_server  | ]
dso-console_server  |     at GitlabZoneApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:216:13)
dso-console_server  |     at processTicksAndRejections (node:internal/process/task_queues:105:5)
dso-console_server  |     at GitlabProjectApi.getOrCreateInfraProject (/app/plugins/gitlab/src/class.ts:310:12)
dso-console_server  |     at removeInfraEnvValues (/app/plugins/argocd/src/functions.ts:294:26)
dso-console_server  |     at Object.upsertProject [as argocd] (/app/plugins/argocd/src/functions.ts:147:5)
dso-console_server  |     at /app/packages/hooks/src/hooks/hook.ts:74:22
dso-console_server  |     at async Promise.all (index 0)
dso-console_server  |     at executeStep (/app/packages/hooks/src/hooks/hook.ts:78:19)
dso-console_server  |     at Object.execute (/app/packages/hooks/src/hooks/hook.ts:119:17)
dso-console_server  |     at upsertProject (/app/apps/server/src/utils/hook-wrapper.ts:37:19)
```

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
