### PR TITLE
fix: fix hiding tile header for all tiles instead of just the project…

### DIFF
--- a/apps/client/src/views/projects/DsoProjects.vue
+++ b/apps/client/src/views/projects/DsoProjects.vue
@@ -55,6 +55,7 @@ onBeforeMount(async () => {
       v-for="project in projectList"
       :key="project.id"
       class="min-w-75 h-45"
+      id="project-list"
     >
       <DsfrTile
         class="h-full"
@@ -95,7 +96,7 @@ a.fr-tile__link::after {
   margin-bottom: 0 !important;
 }
 
-.fr-tile__header {
+#project-list .fr-tile__header {
   display: none;
 }
 </style>


### PR DESCRIPTION
## Quel est le comportement actuel ?

Lorsqu'on affiche les Services Externes les icônes de services n'apparaissent pas.

## Quel est le nouveau comportement ?

Lorsqu'on affiche les Services Externes les icônes de services apparaissent.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Il y a probablement d'autres styles CSS qui "débordent" de cette manière car ils ne sont pas correctement scopés.