### PR TITLE
fix: fix admin roles not being retrieved when a new user logs in for …

### DIFF
--- a/apps/server/src/resources/user/business.spec.ts
+++ b/apps/server/src/resources/user/business.spec.ts
@@ -149,6 +149,8 @@ describe('test users business', () => {
     it('should create user and return adminPerms', async () => {
       prisma.adminRole.findMany.mockResolvedValue(adminRoles)
       prisma.user.findUnique.mockResolvedValue(undefined)
+      prisma.user.create.mockResolvedValue(user)
+      prisma.user.update.mockResolvedValue(user)
       const response = await logViaSession(userToLog)
       expect(response.adminPerms).toBe(0n)
       expect(prisma.user.create).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Résout le ticket: #1596 

## Quel est le comportement actuel ?

Lorsqu'un utilisateur Administrateur se connecte pour la première fois, la section "Administration" n'apparaît pas.

## Quel est le nouveau comportement ?

Lorsqu'un utilisateur Administrateur se connecte pour la première fois, la section "Administration" apparaît.

## Cette PR introduit-elle un breaking change ?

Non.