### PR TITLE
fix: :bug: fix gitlab deletion API request

### DIFF
--- a/plugins/gitlab/src/class.ts
+++ b/plugins/gitlab/src/class.ts
@@ -181,8 +181,9 @@ export class GitlabApi extends PluginApi {
     }
   }
 
-  public async deleteRepository(repoId: number) {
-    return this.api.Projects.remove(repoId, { permanentlyRemove: true })
+  public async deleteRepository(repoId: number, fullPath: string) {
+    await this.api.Projects.remove(repoId) // Marks for deletion
+    return this.api.Projects.remove(repoId, { permanentlyRemove: true, fullPath }) // Effective deletion
   }
 }
 

--- a/plugins/gitlab/src/functions.ts
+++ b/plugins/gitlab/src/functions.ts
@@ -143,7 +143,7 @@ export const upsertDsoProject: StepCall<Project> = async (payload) => {
 export const deleteDsoProject: StepCall<Project> = async (payload) => {
   try {
     const group = await payload.apis.gitlab.getProjectGroup()
-    if (group) await deleteGroup(group?.id)
+    if (group) await deleteGroup(group.id, group.full_path)
 
     return {
       status: {
@@ -208,7 +208,7 @@ export const deleteZone: StepCall<ZoneObject> = async (payload) => {
   try {
     const gitlabApi = payload.apis.gitlab
     const zoneRepo = await gitlabApi.getOrCreateInfraProject(payload.args.slug)
-    await gitlabApi.deleteRepository(zoneRepo.id)
+    await gitlabApi.deleteRepository(zoneRepo.id, zoneRepo.path_with_namespace)
     return returnResult
   } catch (error) {
     returnResult.error = parseError(cleanGitlabError(error))

--- a/plugins/gitlab/src/group.ts
+++ b/plugins/gitlab/src/group.ts
@@ -1,6 +1,7 @@
 import { getApi } from './utils.js'
 
-export async function deleteGroup(groupId: number) {
+export async function deleteGroup(groupId: number, fullPath: string) {
   const api = getApi()
-  return api.Groups.remove(groupId)
+  await api.Groups.remove(groupId) // Marks for deletion
+  return api.Groups.remove(groupId, { permanentlyRemove: true, fullPath }) // Effective deletion
 }

--- a/plugins/gitlab/src/repositories.ts
+++ b/plugins/gitlab/src/repositories.ts
@@ -23,7 +23,7 @@ export async function ensureRepositories(gitlabApi: GitlabProjectApi, project: P
         && !gitlabRepository.topics?.includes(pluginManagedTopic)
         && !project.repositories.find(repo => repo.internalRepoName === gitlabRepository.name,
         )))
-      .map(gitlabRepository => gitlabApi.deleteRepository(gitlabRepository.id)),
+      .map(gitlabRepository => gitlabApi.deleteRepository(gitlabRepository.id, gitlabRepository.path_with_namespace)),
     // create missing repositories
     ...project.repositories.map(repo => ensureRepositoryExists(gitlabRepositories, repo, gitlabApi, projectMirrorCreds, vaultApi)),
   ]


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
Avec Gitlab 18.x :
- le groupe n'est plus immédiatement supprimé lors de la suppression du projet, mais au bout de 7 jours
- les suppressions de projects (dépôts) échouent avec l'erreur "Project must be marked for deletion first."

## Quel est le nouveau comportement ?
Implémentation du double d'appel d'API pour une suppression immédiate, tel que préconisé par la documentation :
https://docs.gitlab.com/api/projects/#delete-a-project

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
