### PR TITLE
Bump Cypress v14.5.2

### DIFF
--- a/apps/client/cypress/e2e/specs/repos.e2e.ts
+++ b/apps/client/cypress/e2e/specs/repos.e2e.ts
@@ -225,7 +225,7 @@ describe('Add repos into project', () => {
 
     cy.wait('@syncRepo').its('response.statusCode').should('match', /^20\d$/)
 
-    cy.getByDataTestid('snackbar').should('contain', `Job de synchronisation lancé pour le dépôt repo03`)
+    cy.getByDataTestid('snackbar').should('contain', `Travail de synchronisation lancé pour le dépôt repo03`)
 
     cy.getByDataTestid('branchNameInput')
       .clear()
@@ -242,7 +242,7 @@ describe('Add repos into project', () => {
 
     cy.wait('@syncRepo').its('response.statusCode').should('match', /^20\d$/)
 
-    cy.getByDataTestid('snackbar').should('contain', `Job de synchronisation lancé pour le dépôt repo03`)
+    cy.getByDataTestid('snackbar').should('contain', `Travail de synchronisation lancé pour le dépôt repo03`)
   })
 
   it('Should delete a repo', () => {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -52,7 +52,7 @@
   },
   "optionalDependencies": {
     "@cypress/vue": "6.0.2",
-    "cypress": "14.1.0",
+    "cypress": "14.5.2",
     "cypress-vite": "1.6.0"
   },
   "devDependencies": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -52,7 +52,7 @@
   },
   "optionalDependencies": {
     "@cypress/vue": "6.0.2",
-    "cypress": "14.0.0",
+    "cypress": "14.1.0",
     "cypress-vite": "1.6.0"
   },
   "devDependencies": {

--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -113,7 +113,7 @@ async function syncRepository() {
   if (!selectedRepo.value) return
   if (!isAllSyncing.value && !branchName.value) branchName.value = 'main'
   await props.project.Repositories.sync(selectedRepo.value.id, { syncAllBranches: isAllSyncing.value, branchName: branchName.value })
-  snackbarStore.setMessage(`Job de synchronisation lancé pour le dépôt ${selectedRepo.value.internalRepoName}`)
+  snackbarStore.setMessage(`Travail de synchronisation lancé pour le dépôt ${selectedRepo.value.internalRepoName}`)
 }
 
 // Add locale-specific relative date/time formatting rules.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,10 +204,10 @@ importers:
     optionalDependencies:
       '@cypress/vue':
         specifier: 6.0.2
-        version: 6.0.2(cypress@14.0.0)(vue@3.5.13(typescript@5.7.2))
+        version: 6.0.2(cypress@14.1.0)(vue@3.5.13(typescript@5.7.2))
       cypress:
-        specifier: 14.0.0
-        version: 14.0.0
+        specifier: 14.1.0
+        version: 14.1.0
       cypress-vite:
         specifier: 1.6.0
         version: 1.6.0(vite@6.2.0(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
@@ -3585,8 +3585,8 @@ packages:
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  cypress@14.0.0:
-    resolution: {integrity: sha512-kEGqQr23so5IpKeg/dp6GVi7RlHx1NmW66o2a2Q4wk9gRaAblLZQSiZJuDI8UMC4LlG5OJ7Q6joAiqTrfRNbTw==}
+  cypress@14.1.0:
+    resolution: {integrity: sha512-pPPj8Uu9NwjaaiXAEcjYZZmgsq6v9Zs1Nw6a+zRF+ANgYSNhH4S32SjFRsvMcuOHR/8dp4GBJhBPqIPSs+TxaA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -8653,9 +8653,9 @@ snapshots:
       uuid: 8.3.2
     optional: true
 
-  '@cypress/vue@6.0.2(cypress@14.0.0)(vue@3.5.13(typescript@5.7.2))':
+  '@cypress/vue@6.0.2(cypress@14.1.0)(vue@3.5.13(typescript@5.7.2))':
     dependencies:
-      cypress: 14.0.0
+      cypress: 14.1.0
       vue: 3.5.13(typescript@5.7.2)
     optional: true
 
@@ -10629,7 +10629,7 @@ snapshots:
       - supports-color
     optional: true
 
-  cypress@14.0.0:
+  cypress@14.1.0:
     dependencies:
       '@cypress/request': 3.0.7
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,10 +204,10 @@ importers:
     optionalDependencies:
       '@cypress/vue':
         specifier: 6.0.2
-        version: 6.0.2(cypress@14.1.0)(vue@3.5.13(typescript@5.7.2))
+        version: 6.0.2(cypress@14.5.2)(vue@3.5.13(typescript@5.7.2))
       cypress:
-        specifier: 14.1.0
-        version: 14.1.0
+        specifier: 14.5.2
+        version: 14.5.2
       cypress-vite:
         specifier: 1.6.0
         version: 1.6.0(vite@6.2.0(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
@@ -1626,10 +1626,6 @@ packages:
   '@clack/prompts@0.9.1':
     resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
 
-  '@colors/colors@1.5.0':
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
-    engines: {node: '>=0.1.90'}
-
   '@commitlint/cli@19.7.1':
     resolution: {integrity: sha512-iObGjR1tE/PfDtDTEfd+tnRkB3/HJzpQqRTyofS2MPPkDn1mp3DBC8SoPDayokfAy+xKhF8+bwRCJO25Nea0YQ==}
     engines: {node: '>=v18'}
@@ -1740,8 +1736,8 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.0.0
 
-  '@cypress/request@3.0.7':
-    resolution: {integrity: sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==}
+  '@cypress/request@3.0.8':
+    resolution: {integrity: sha512-h0NFgh1mJmm1nr4jCwkGHwKneVYKghUyWe6TMNrk0B9zsjAJxpg8C4/+BAcmLgCPa1vj1V8rNUaILl+zYRUWBQ==}
     engines: {node: '>= 6'}
 
   '@cypress/vue@6.0.2':
@@ -3416,8 +3412,8 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
-  cli-table3@0.6.5:
-    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+  cli-table3@0.6.1:
+    resolution: {integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==}
     engines: {node: 10.* || >= 12.*}
 
   cli-truncate@2.1.0:
@@ -3453,6 +3449,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  colors@1.4.0:
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3585,8 +3585,8 @@ packages:
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  cypress@14.1.0:
-    resolution: {integrity: sha512-pPPj8Uu9NwjaaiXAEcjYZZmgsq6v9Zs1Nw6a+zRF+ANgYSNhH4S32SjFRsvMcuOHR/8dp4GBJhBPqIPSs+TxaA==}
+  cypress@14.5.2:
+    resolution: {integrity: sha512-O4E4CEBqDHLDrJD/dfStHPcM+8qFgVVZ89Li7xDU0yL/JxO/V0PEcfF2I8aGa7uA2MGNLkNUAnghPM83UcHOJw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -4477,6 +4477,10 @@ packages:
 
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
+  hasha@5.2.2:
+    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
+    engines: {node: '>=8'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -5902,10 +5906,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.13.1:
-    resolution: {integrity: sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==}
-    engines: {node: '>=0.6'}
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -8489,9 +8489,6 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@colors/colors@1.5.0':
-    optional: true
-
   '@commitlint/cli@19.7.1(@types/node@22.13.5)(typescript@5.7.2)':
     dependencies:
       '@commitlint/format': 19.5.0
@@ -8631,7 +8628,7 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.0
 
-  '@cypress/request@3.0.7':
+  '@cypress/request@3.0.8':
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.13.2
@@ -8646,16 +8643,16 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.13.1
+      qs: 6.14.0
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
       uuid: 8.3.2
     optional: true
 
-  '@cypress/vue@6.0.2(cypress@14.1.0)(vue@3.5.13(typescript@5.7.2))':
+  '@cypress/vue@6.0.2(cypress@14.5.2)(vue@3.5.13(typescript@5.7.2))':
     dependencies:
-      cypress: 14.1.0
+      cypress: 14.5.2
       vue: 3.5.13(typescript@5.7.2)
     optional: true
 
@@ -10454,11 +10451,11 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
-  cli-table3@0.6.5:
+  cli-table3@0.6.1:
     dependencies:
       string-width: 4.2.3
     optionalDependencies:
-      '@colors/colors': 1.5.0
+      colors: 1.4.0
     optional: true
 
   cli-truncate@2.1.0:
@@ -10499,6 +10496,9 @@ snapshots:
   colord@2.9.3: {}
 
   colorette@2.0.20: {}
+
+  colors@1.4.0:
+    optional: true
 
   combined-stream@1.0.8:
     dependencies:
@@ -10629,9 +10629,9 @@ snapshots:
       - supports-color
     optional: true
 
-  cypress@14.1.0:
+  cypress@14.5.2:
     dependencies:
-      '@cypress/request': 3.0.7
+      '@cypress/request': 3.0.8
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.9
@@ -10644,7 +10644,7 @@ snapshots:
       check-more-types: 2.24.0
       ci-info: 4.1.0
       cli-cursor: 3.1.0
-      cli-table3: 0.6.5
+      cli-table3: 0.6.1
       commander: 6.2.1
       common-tags: 1.8.2
       dayjs: 1.11.13
@@ -10657,6 +10657,7 @@ snapshots:
       figures: 3.2.0
       fs-extra: 9.1.0
       getos: 3.2.1
+      hasha: 5.2.2
       is-installed-globally: 0.4.0
       lazy-ass: 1.6.0
       listr2: 3.14.0(enquirer@2.4.1)
@@ -11826,6 +11827,12 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+    optional: true
+
+  hasha@5.2.2:
+    dependencies:
+      is-stream: 2.0.1
+      type-fest: 0.8.1
     optional: true
 
   hasown@2.0.2:
@@ -13431,11 +13438,6 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
-
-  qs@6.13.1:
-    dependencies:
-      side-channel: 1.1.0
-    optional: true
 
   qs@6.14.0:
     dependencies:


### PR DESCRIPTION
## Issues liées

Issues numéro: #1669 

## Quel est le comportement actuel ?

La version actuellement utilisée (v14.0) ne supporte pas le Webdriver BiDi qui est désormais le seul moyen pour Cypress d'automatiser Firefox. L'ancien protocole (CDP) était déprécié et a été abandonné dans la dernière (`latest`) version de Firefox (v141).

## Quel est le nouveau comportement ?

La version 14.5.2 (la dernière v14.x en date) de Cypress est utilisée. Les tests sont OK.

## Cette PR introduit-elle un breaking change ?

Non.