### PR TITLE
Draft (Proof of Concept) - Add an hybrid SPA/SSR interaction

### DIFF
--- a/apps/client/src/opencds/app.js
+++ b/apps/client/src/opencds/app.js
@@ -1,0 +1,1 @@
+../../../../plugins/opencds/app.js

--- a/apps/client/src/router/index.ts
+++ b/apps/client/src/router/index.ts
@@ -16,7 +16,7 @@ import { swaggerUiPath } from '@cpn-console/shared'
 import { uuid } from '@/utils/regex.js'
 
 const AdminCluster = () => import('@/views/admin/AdminCluster.vue')
-const AdminServiceChain = () => import('@/views/admin/AdminServiceChain.vue')
+// const AdminServiceChain = () => import('@/views/admin/AdminServiceChain.vue')
 const ServicesHealth = () => import('@/views/ServicesHealth.vue')
 const CreateProject = () => import('@/views/CreateProject.vue')
 const ProfileWrapper = () => import('@/views/profile/ProfileWrapper.vue')
@@ -30,7 +30,7 @@ const ListProjects = () => import('@/views/admin/ListProjects.vue')
 const ListLogs = () => import('@/views/admin/ListLogs.vue')
 const AdminRoles = () => import('@/views/admin/AdminRoles.vue')
 const ListClusters = () => import('@/views/admin/ListClusters.vue')
-const ListServiceChains = () => import('@/views/admin/ListServiceChains.vue')
+const ListServiceChainsBis = () => import('@/views/admin/ListServiceChainsBis.vue')
 const ListStages = () => import('@/views/admin/ListStages.vue')
 const ListZones = () => import('@/views/admin/ListZones.vue')
 const ListPlugins = () => import('@/views/admin/ListPlugins.vue')
@@ -185,18 +185,23 @@ export const routes: Readonly<RouteRecordRaw[]> = [
           {
             path: '',
             name: 'ListServiceChains',
-            component: ListServiceChains,
+            component: ListServiceChainsBis,
           },
-          {
-            path: ':id',
-            name: 'AdminServiceChain',
-            component: AdminServiceChain,
-            props(to) {
-              return {
-                id: to.params.id,
-              }
-            },
-          },
+          // {
+          // path: '',
+          // name: 'ListServiceChains',
+          // component: ListServiceChains,
+          // },
+          // {
+          // path: ':id',
+          // name: 'AdminServiceChain',
+          // component: AdminServiceChain,
+          // props(to) {
+          // return {
+          // id: to.params.id,
+          // }
+          // },
+          // },
         ],
       },
       {

--- a/apps/client/src/views/admin/ListServiceChainsBis.vue
+++ b/apps/client/src/views/admin/ListServiceChainsBis.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+import { createApp } from '@/opencds/app.js'
+import { getKeycloak } from '@/utils/keycloak/keycloak'
+
+const response = ref('Loading SSR component…')
+onUpdated(() => {
+  createApp().mount('#opencds')
+})
+
+onMounted(async () => {
+  response.value = await (
+    await fetch('/api/v1/opencds', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${getKeycloak().token}`,
+      },
+    })
+  ).text()
+})
+</script>
+
+<template>
+  <div v-html="response" />
+</template>

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      vue: 'vue/dist/vue.esm-bundler.js',
     },
     dedupe: ['vue'],
   },

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -66,7 +66,8 @@
     "node-vault-client": "^1.0.1",
     "prisma": "^6.0.1",
     "undici": "^7.1.0",
-    "vitest-mock-extended": "^2.0.2"
+    "vitest-mock-extended": "^2.0.2",
+    "vue": "^3.5.13"
   },
   "devDependencies": {
     "@cpn-console/eslint-config": "workspace:^",

--- a/apps/server/src/opencds/app.js
+++ b/apps/server/src/opencds/app.js
@@ -1,0 +1,1 @@
+../../../../plugins/opencds/app.js

--- a/apps/server/src/resources/index.ts
+++ b/apps/server/src/resources/index.ts
@@ -1,5 +1,8 @@
 import type { FastifyInstance } from 'fastify'
+import { renderToString } from 'vue/server-renderer'
+
 import { serverInstance } from '@/app.js'
+import { createApp } from '@/opencds/app.js'
 
 import { adminRoleRouter } from './admin-role/router.js'
 import { adminTokenRouter } from './admin-token/router.js'
@@ -45,5 +48,16 @@ export function apiRouter() {
     await app.register(serverInstance.plugin(systemSettingsRouter()), validateTrue)
     await app.register(serverInstance.plugin(userRouter()), validateTrue)
     await app.register(serverInstance.plugin(zoneRouter()), validateTrue)
+
+    // Dynamically render a Vue.js component and send it back
+    // as a raw string
+    app.get('/api/v1/opencds', async (_, reply) => {
+      const component = createApp()
+      const html = await renderToString(component)
+      reply
+        .code(200)
+        .header('Content-Type', 'text/html; charset=utf-8')
+        .send(`<div id="opencds">${html}</div>`)
+    })
   }
 }

--- a/plugins/opencds/app.js
+++ b/plugins/opencds/app.js
@@ -1,0 +1,10 @@
+// This file is symlinked from plugins/opencds/app.js
+
+import { createSSRApp } from 'vue'
+
+export function createApp() {
+  return createSSRApp({
+    data: () => ({ count: 1 }),
+    template: `<div @click="count++">{{ count }}</div>`,
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
       vitest-mock-extended:
         specifier: ^2.0.2
         version: 2.0.2(typescript@5.7.2)(vitest@2.1.9(@types/node@22.13.5)(jsdom@25.0.1)(terser@5.39.0))
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.13(typescript@5.7.2)
     devDependencies:
       '@cpn-console/eslint-config':
         specifier: workspace:^
@@ -7868,7 +7871,7 @@ snapshots:
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7920,7 +7923,7 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -8476,7 +8479,7 @@ snapshots:
       '@babel/parser': 7.26.9
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8855,7 +8858,7 @@ snapshots:
   '@eslint/config-array@0.19.2':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8871,7 +8874,7 @@ snapshots:
   '@eslint/eslintrc@3.3.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -9036,7 +9039,7 @@ snapshots:
       '@antfu/install-pkg': 1.0.0
       '@antfu/utils': 8.1.1
       '@iconify/types': 2.0.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 15.15.0
       kolorist: 1.8.0
       local-pkg: 1.1.0
@@ -9702,7 +9705,7 @@ snapshots:
       '@typescript-eslint/types': 8.25.0
       '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 8.25.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -9717,7 +9720,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.2)
       '@typescript-eslint/utils': 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.2)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.21.0(jiti@2.4.2)
       ts-api-utils: 2.0.1(typescript@5.7.2)
       typescript: 5.7.2
@@ -9730,7 +9733,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.25.0
       '@typescript-eslint/visitor-keys': 8.25.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -9917,7 +9920,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -10633,7 +10636,7 @@ snapshots:
   cypress-vite@1.6.0(vite@6.2.0(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       chokidar: 3.6.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       vite: 6.2.0(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
@@ -10742,7 +10745,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-    optional: true
 
   decimal.js@10.5.0: {}
 
@@ -10972,7 +10974,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.0):
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.25.0
     transitivePeerDependencies:
       - supports-color
@@ -11105,7 +11107,7 @@ snapshots:
       '@types/doctrine': 0.0.9
       '@typescript-eslint/scope-manager': 8.25.0
       '@typescript-eslint/utils': 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.2)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       enhanced-resolve: 5.18.1
       eslint: 9.21.0(jiti@2.4.2)
@@ -11125,7 +11127,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.49.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 9.21.0(jiti@2.4.2)
       espree: 10.3.0
@@ -11188,7 +11190,7 @@ snapshots:
 
   eslint-plugin-toml@0.12.0(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.21.0(jiti@2.4.2)
       eslint-compat-utils: 0.6.4(eslint@9.21.0(jiti@2.4.2))
       lodash: 4.17.21
@@ -11238,7 +11240,7 @@ snapshots:
 
   eslint-plugin-yml@1.17.0(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 9.21.0(jiti@2.4.2)
       eslint-compat-utils: 0.6.4(eslint@9.21.0(jiti@2.4.2))
@@ -11283,7 +11285,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -11892,7 +11894,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11914,7 +11916,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11951,7 +11953,7 @@ snapshots:
   importx@0.5.2:
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.0)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.25.0
       jiti: 2.4.2
       pathe: 2.0.3
@@ -12183,7 +12185,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -12286,7 +12288,7 @@ snapshots:
 
   json-schema-resolver@2.0.0:
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       rfdc: 1.4.1
       uri-js: 4.4.1
     transitivePeerDependencies:
@@ -12420,7 +12422,7 @@ snapshots:
     dependencies:
       chalk: 5.4.1
       commander: 13.1.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       execa: 8.0.1
       lilconfig: 3.1.3
       listr2: 8.2.5
@@ -12861,7 +12863,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -14144,7 +14146,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.7.2)
       css-functions-list: 3.2.3
       css-tree: 3.1.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
       file-entry-cache: 10.0.6
@@ -14619,7 +14621,7 @@ snapshots:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
       chokidar: 3.6.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       fast-glob: 3.3.3
       local-pkg: 0.5.1
       magic-string: 0.30.17
@@ -14681,7 +14683,7 @@ snapshots:
   vite-node@2.1.9(@types/node@22.13.5)(terser@5.39.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
       vite: 5.4.14(@types/node@22.13.5)(terser@5.39.0)
@@ -14698,7 +14700,7 @@ snapshots:
 
   vite-plugin-pwa@0.21.1(vite@6.2.0(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(workbox-build@7.3.0)(workbox-window@7.3.0):
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.12
       vite: 6.2.0(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -14746,7 +14748,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.2.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       expect-type: 1.2.0
       magic-string: 0.30.17
       pathe: 1.1.2
@@ -14780,7 +14782,7 @@ snapshots:
 
   vue-eslint-parser@9.4.3(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.21.0(jiti@2.4.2)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3


### PR DESCRIPTION
# Contexte

Dans le cadre d'une possible orientation de Console vers un mode de fonctionnement plutôt SSR (Server Side Rendering), dans lequel `client` et `server` seraient fusionné en un seul projet `core` qui recevrait ensuite ses plugins via de l'injection de dépendance, il nous faut envisager que les plugins soient "auto-portés", c'est-à-dire qu'ils contiendront à la fois les parties d'API de backend, et à la fois les parties de Composant de FrontEnd. Les plugins pourraient alors être chargés indépendamment (au graphe de dépendance près) et alimenter ainsi la Console dans son ensemble, plutôt que d'être "hard-codés" tantôt côté `client`, tantôt côté `server`.

Pour permettre une transition de la Console vers ce possible mode de fonctionnement futur, il nous faut explorer la possibilité de faire un rendu, côté `server`, de composants Vue.js, de manière à progressivement transformer notre full-SPA (Single Page Application) en hybride SPA/SSR (via de l'hydration des composant Vue.js qui auront été rendus côté serveur).

De cette manière l'application Console pourrait grosso modo suivre le fonctionnement suivant:
- La partie fondamentale (`core`) serait initialement démarrée. Il s'agirait d'une application Vue.js SPA/SSR qui aurait ses composants basiques (home page, login, etc.) et les routes d'API qui vont avec.
- Les plugins, qui seraient tous _in fine_ externes à `console`, et qui seraient alors chargés au démarrage, chacun exposant des routes HTTP permettant de récupérer les composants Vue.js, et des routes HTTP d'API pour leur fonctionnement métier.

Si un fonctionnement tel qu'énoncé est possible, alors CPiN pourra devenir une "variante" de la Console avec ses plugins propres (ArgoCD, Vault, OpenCDS, etc.), et les autres utilisateurs de la Console pourront avoir "leurs" plugins (Flux, AWS Secret Manager, MonPluginCustom, etc.).

# Contenu de cette PR

- Ajout d'un composant Vue.js "standalone" (qui ne dépend ni de `apps/client`, ni de `apps/server`)
- Ce composant est sérialisé en `string` lors d'un appel de `client` vers `server` sur la route `GET /api/v1/opencds` (note: le JWT de session est passé afin d'éviter une 302 vers Keycloak :sweat_smile: )
- Vue.js récupère la chaîne brute et l'insère en `innerHTML` dans le template concerné de l'application cliente (ici j'ai créé un `ListServiceChainBis` qui me sert de placeholder, vu que `ListServiceChain` est déclaré dans le router. Je n'ai donc rien à recréer ici, je "squatte" la place)
- Une fois le DOM mis à jour, un `onUpdate` va se déclencher et déclencher un _deuxième_ rendu du composant ce qui permettra de le monter (au sens Vue.js du terme) et donc d'avoir les évènements du DOM qui vont avec (`@click`, par ex).

# Reste à faire
- Charger un "vrai" composant (typiquement le contenu de `ListServiceChain` qui est ici squatté) ce qui permettra de valider que tout un composant Vue.js avec sa diversité et sa complexité va fonctionner dans ce nouveau mode
- Tester le passage de "props" (ou du moins faire en sorte que ça soit le moins bricolé possible)

# Notes
- Pour l'instant le composant `plugins/opencds/app.js` est lié symboliquement (`ln -s`) en `client/src/opencds/app.js` et `server/src/opencds/app.js` afin de ne pas lutter contre les règles d'import Typescript qui imposent que tous les scripts imports soient localisés dans `src/`. Dans la cible, où `client` et `server` seraient fusionné, ce sujet serait caduc.