### PR TITLE
Restore Sonarqube quality gate check

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -210,3 +210,12 @@ jobs:
             -Dsonar.scm.provider=git
             ${{ github.event_name == 'pull_request' && steps.sonar-args.outputs.SONAR_ARGS_PR || steps.sonar-args.outputs.SONAR_ARGS_BRANCH }}
         continue-on-error: true
+
+      - name: SonarQube Quality Gate check
+        id: sonarqube-quality-gate-check
+        uses: sonarsource/sonarqube-quality-gate-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        timeout-minutes: 5
+        continue-on-error: true


### PR DESCRIPTION
Revert du commit bf4a3303c5ed4a6c6e37a98237f3117fbdd6c34b.

Maintenant qu'une QG dédiée à CPiN a été crée côté https://sonarqube.fabrique-numerique.fr, nous pouvons rétablir le contrôle côté GitHub actions.

