### PR TITLE
feat: :sparkles: add support for SonarQube and Harbor internal url

### DIFF
--- a/plugins/harbor/src/utils.ts
+++ b/plugins/harbor/src/utils.ts
@@ -5,11 +5,13 @@ import type { VaultRobotSecret } from './robot.js'
 
 const config: {
   url?: string
+  internalUrl?: string
   host?: string
 } = {}
 
 export function getConfig(): Required<typeof config> {
   config.url = config.url ?? removeTrailingSlash(requiredEnv('HARBOR_URL'))
+  config.internalUrl = config.internalUrl ?? removeTrailingSlash(requiredEnv('HARBOR_INTERNAL_URL'))
   config.host = config.host ?? config?.url?.split('://')[1]
   // @ts-ignore
   return config
@@ -21,7 +23,7 @@ function getApiConfig() {
       username: requiredEnv('HARBOR_ADMIN'),
       password: requiredEnv('HARBOR_ADMIN_PASSWORD'),
     },
-    baseURL: `${getConfig().url}/api/v2.0/`,
+    baseURL: `${getConfig().internalUrl}/api/v2.0/`,
   }
 }
 

--- a/plugins/sonarqube/src/tech.ts
+++ b/plugins/sonarqube/src/tech.ts
@@ -3,19 +3,21 @@ import { removeTrailingSlash, requiredEnv } from '@cpn-console/shared'
 
 const config: {
   url?: string
+  internalUrl?: string
   user?: string
   password?: string
 } = {}
 
 export function getConfig(): Required<typeof config> {
   config.url = config.url ?? removeTrailingSlash(requiredEnv('SONARQUBE_URL'))
+  config.internalUrl = config.internalUrl ?? removeTrailingSlash(requiredEnv('SONARQUBE_INTERNAL_URL'))
   config.user = config.user ?? requiredEnv('SONAR_API_TOKEN')
   // @ts-ignore
   return config
 }
 export function getAxiosOptions() {
   return {
-    baseURL: `${getConfig().url}/api/`,
+    baseURL: `${getConfig().internalUrl}/api/`,
     auth: {
       username: getConfig().user,
       password: '', // Token is used, so password is useless


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/765

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Missing internal url for SonarQube and Harbor.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Add the above.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Yes, Console will communicate directly with SonarQube and Harbor services.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Should we fallback on public url like others plugins do or should we enforce the usage of internal url?