### PR TITLE
fix: :bug: public url for Harbor image pull secret

### DIFF
--- a/plugins/harbor/src/utils.ts
+++ b/plugins/harbor/src/utils.ts
@@ -12,7 +12,7 @@ const config: {
 export function getConfig(): Required<typeof config> {
   config.url = config.url ?? removeTrailingSlash(requiredEnv('HARBOR_URL'))
   config.internalUrl = config.internalUrl ?? removeTrailingSlash(requiredEnv('HARBOR_INTERNAL_URL'))
-  config.host = config.host ?? config?.internalUrl?.split('://')[1]
+  config.host = config.host ?? config?.url?.split('://')[1]
   // @ts-ignore
   return config
 }


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/765

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Consequences of https://github.com/cloud-pi-native/console/pull/1782/commits/9e8835b4c7a5b89caa8e630c03f95161c01610ab is that this image pull secret is also used in applications cluster which cannot communicate directly to a service from the Socle cluster.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
We revert back the modification to use Harbor ingress for all cases.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
We can use internal url for Gitlab CI pipelines but it involves creating another image pull secret for this specific usage.