### PR TITLE
feat: :sparkles: distinguish between public and internal gitlab url

### DIFF
--- a/plugins/argocd/src/functions.ts
+++ b/plugins/argocd/src/functions.ts
@@ -36,7 +36,7 @@ export const upsertProject: StepCall<Project> = async (payload) => {
 
     const infraRepositories = project.repositories.filter(repo => repo.isInfra)
     const sourceRepositories = [
-      `${await gitlabApi.getGroupUrl()}/**`,
+      `${await gitlabApi.getPublicGroupUrl()}/**`,
       ...splitExtraRepositories(payload.config.argocd?.extraRepositories),
       ...splitExtraRepositories(project.store.argocd?.extraRepositories),
     ]
@@ -116,7 +116,7 @@ export const upsertProject: StepCall<Project> = async (payload) => {
         return Promise.all(infraRepositories.map(async (repository) => {
           const application = findApplication(applications, repository.internalRepoName, environment.name)
           const applicationName = generateApplicationName(project.slug, environment.name, repository.internalRepoName)
-          const repoURL = await gitlabApi.getRepoUrl(repository.internalRepoName)
+          const repoURL = await gitlabApi.getPublicRepoUrl(repository.internalRepoName)
 
           if (application) {
             const minimalPatch = getMinimalApplicationObject({
@@ -259,7 +259,7 @@ async function getArgoRepoSource(repoName: string, env: string, gitlabApi: Gitla
   const valueFiles = [] // Empty means not a Helm repository
   let path = '.'
   const repoId = await gitlabApi.getProjectId(repoName)
-  const repoURL = await gitlabApi.getRepoUrl(repoName)
+  const repoURL = await gitlabApi.getPublicRepoUrl(repoName)
   try {
     const files = await gitlabApi.listFiles(repoId, { path: '/', ref: 'HEAD', recursive: false })
     const result = files.find(f => f.name === 'values.yaml')

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cpn-console/gitlab-plugin",
   "type": "module",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "private": false,
   "description": "",
   "main": "dist/index.js",

--- a/plugins/gitlab/src/class.ts
+++ b/plugins/gitlab/src/class.ts
@@ -276,7 +276,11 @@ export class GitlabProjectApi extends GitlabApi {
     return this.createProjectGroup()
   }
 
-  public async getGroupUrl() {
+  public async getPublicGroupUrl() {
+    return `${config().publicUrl}/${config().projectsRootDir}/${this.project.slug}`
+  }
+
+  public async getInternalGroupUrl() {
     return `${config().internalUrl}/${config().projectsRootDir}/${this.project.slug}`
   }
 
@@ -367,8 +371,12 @@ export class GitlabProjectApi extends GitlabApi {
   }
 
   // Repositories
-  public async getRepoUrl(repoName: string) {
-    return `${await this.getGroupUrl()}/${repoName}.git`
+  public async getPublicRepoUrl(repoName: string) {
+    return `${await this.getPublicGroupUrl()}/${repoName}.git`
+  }
+
+  public async getInternalRepoUrl(repoName: string) {
+    return `${await this.getInternalGroupUrl()}/${repoName}.git`
   }
 
   public async listRepositories() {

--- a/plugins/gitlab/src/repositories.ts
+++ b/plugins/gitlab/src/repositories.ts
@@ -68,7 +68,7 @@ async function ensureRepositoryExists(gitlabRepositories: CondensedProjectSchema
     gitInputPassword = currentVaultSecret.data.GIT_INPUT_PASSWORD
   }
 
-  const internalRepoUrl = await gitlabApi.getRepoUrl(repository.internalRepoName)
+  const internalRepoUrl = await gitlabApi.getInternalRepoUrl(repository.internalRepoName)
 
   const { data: gitlabSecret } = await vaultApi.read('tech/GITLAB_MIRROR', { throwIfNoEntry: false })
   const mirrorSecretData = {


### PR DESCRIPTION
## Issues liées

Issues : https://github.com/cloud-pi-native/socle/issues/765

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Our achitecture design is allowing to have other Argocd located in a separate cluster. Thus, the communication can only be done through ingress.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
We are distinguishing public and internal gitlab url because we can still use internal url for Gitlab runner jobs.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Related to https://github.com/cloud-pi-native/console/pull/1782/commits/9e8835b4c7a5b89caa8e630c03f95161c01610ab