### PR TITLE
docs: :memo: use Nexus internal url for CI jobs

### DIFF
--- a/misc/plugins.md
+++ b/misc/plugins.md
@@ -65,4 +65,3 @@ Note: Si un module réutilise son propre payload, il doit penser à renvoyer le 
 La communication des services associés à la chaîne DSO se fait au maximum en direct par les services Kubernetes via les url internes. On note toutefois les exceptions suivantes :
 - Argocd communique avec l'url publique de Gitlab peu importe s'ils sont sur le même cluster.
 - L'url publique de Harbor est utilisée dans les jobs de CI : il faudrait sinon une `imagePullSecret` avec url interne pour les jobs de CI et une avec url publique pour les pods des clusters applicatifs.
-- L'url publique de Nexus est utilisée dans les jobs de CI : une redirection de http vers https empêche l'utilisation de l'url interne.


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/765

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Documentation is stating that we are using Nexus public url for CI jobs.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Removing the related line since we can now use Nexus internal url for CI jobs.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
See https://github.com/cloud-pi-native/socle/pull/934.