### PR TITLE
fix: :bug: switch to sequential deletion

### DIFF
--- a/plugins/nexus/src/maven.ts
+++ b/plugins/nexus/src/maven.ts
@@ -172,7 +172,7 @@ export async function createMavenRepo(axiosInstance: AxiosInstance, projectName:
   return names
 }
 
-export function deleteMavenRepo(axiosInstance: AxiosInstance, projectName: string) {
+export async function deleteMavenRepo(axiosInstance: AxiosInstance, projectName: string) {
   const names = getRepoNames(projectName)
   const repoPaths = [names.group, ...names.hosted]
   const privileges = [...names.hosted, names.group]
@@ -182,7 +182,9 @@ export function deleteMavenRepo(axiosInstance: AxiosInstance, projectName: strin
     // delete local repo maven snapshot
     ...repoPaths.map(repo => `/repositories/${repo.repo}`),
   ]
-  return pathsToDelete.map(path => deleteIfExists(path, axiosInstance))
+  for (const path of pathsToDelete) {
+    await deleteIfExists(path, axiosInstance)
+  }
 }
 
 export function getMavenUrls(projectName: string) {

--- a/plugins/nexus/src/npm.ts
+++ b/plugins/nexus/src/npm.ts
@@ -145,7 +145,7 @@ export async function createNpmRepo(axiosInstance: AxiosInstance, projectName: s
   return names
 }
 
-export function deleteNpmRepo(axiosInstance: AxiosInstance, projectName: string) {
+export async function deleteNpmRepo(axiosInstance: AxiosInstance, projectName: string) {
   const names = getRepoNames(projectName)
   const repoPaths = [names.group, ...names.hosted]
   const privileges = [...names.hosted, names.group]
@@ -155,7 +155,9 @@ export function deleteNpmRepo(axiosInstance: AxiosInstance, projectName: string)
     // delete local repo maven snapshot
     ...repoPaths.map(repo => `/repositories/${repo.repo}`),
   ]
-  return pathsToDelete.map(path => deleteIfExists(path, axiosInstance))
+  for (const path of pathsToDelete) {
+    await deleteIfExists(path, axiosInstance)
+  }
 }
 
 export function getNpmUrls(projectName: string) {

--- a/plugins/nexus/src/project.ts
+++ b/plugins/nexus/src/project.ts
@@ -13,9 +13,9 @@ export const deleteNexusProject: StepCall<Project> = async ({ args: project }) =
   const axiosInstance = getAxiosInstance()
   const projectName = project.slug
   try {
+    await deleteMavenRepo(axiosInstance, projectName)
+    await deleteNpmRepo(axiosInstance, projectName)
     await Promise.all([
-      ...deleteMavenRepo(axiosInstance, projectName),
-      ...deleteNpmRepo(axiosInstance, projectName),
       // delete role
       deleteIfExists(`/security/roles/${projectName}-ID`, axiosInstance),
       // delete user
@@ -87,7 +87,7 @@ export const createNexusProject: StepCall<Project> = async (payload) => {
         })
         privilegesToAccess.push(names.group.privilege, ...names.hosted.map(({ privilege }) => privilege))
       } else {
-        await Promise.all(deleteMavenRepo(axiosInstance, projectName))
+        await deleteMavenRepo(axiosInstance, projectName)
       }
     } catch (error) {
       failedProvisionning.maven = { error, message: `Maven failed to ${techUsed.maven ? 'provision' : 'delete'} repositories please try again in few minutes` }
@@ -98,7 +98,7 @@ export const createNexusProject: StepCall<Project> = async (payload) => {
         const names = await createNpmRepo(axiosInstance, projectName, options.npmWritePolicy as WritePolicy)
         privilegesToAccess.push(names.group.privilege, ...names.hosted.map(({ privilege }) => privilege))
       } else {
-        await Promise.all(deleteNpmRepo(axiosInstance, projectName))
+        await deleteNpmRepo(axiosInstance, projectName)
       }
     } catch (error) {
       failedProvisionning.npm = { error, message: `Npm failed to ${techUsed.npm ? 'provision' : 'delete'} repositories please try again in few minutes` }


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
When deleting a project using Nexus Maven plugin, we are facing the following error.
```
error:"{"message":"Request failed with status code 500","name":"AxiosError","stack":"AxiosError: Request failed with status code 500\n at settle (file:///app/node_modules/.pnpm/axios@1.12.2/node_modules/axios/lib/core/settle.js:19:12)\n at IncomingMessage.handleStreamEnd (file:///app/node_modules/.pnpm/axios@1.12.2/node_modules/axios/lib/adapters/http.js:617:11)\n at IncomingMessage.emit (node:events:530:35)\n at endReadableNT (node:internal/streams/readable:1698:12)\n at process.processTicksAndRejections (node:internal/process/task_queues:90:21)\n at Axios.request (file:///app/node_modules/.pnpm/axios@1.12.2/node_modules/axios/lib/core/Axios.js:45:41)\n at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n at async Promise.all (index 4)\n at async Object.deleteNexusProject [as nexus] (file:///app/node_modules/.pnpm/@cpn-console+nexus-plugin@file++++app+plugins+nexus/node_modules/@cpn-console/nexus-plugin/dist/project.js:12:9)\n at async file:///app/node_modules/.pnpm/@cpn-console+hooks@file++++app+packages+hooks/node_modules/@cpn-console/hooks/dist/hooks/hook.js:29:26\n at async Promise.all (index 3)\n at async executeStep (file:///app/node_modules/.pnpm/@cpn-console+hooks@file++++app+packages+hooks/node_modules/@cpn-console/hooks/dist/hooks/hook.js:33:21)\n at async Object.execute (file:///app/node_modules/.pnpm/@cpn-console+hooks@file++++app+packages+hooks/node_modules/@cpn-console/hooks/dist/hooks/hook.js:72:23)\n at async Object.delete (file:///app/dist/utils/hook-wrapper.js:47:25)","config":{"transitional":{"silentJSONParsing":true,"forcedJSONParsing":true,"clarifyTimeoutError":false},"adapter":["xhr","http","fetch"],"transformRequest":[null],"transformResponse":[null],"timeout":0,"xsrfCookieName":"XSRF-TOKEN","xsrfHeaderName":"X-XSRF-TOKEN","maxContentLength":-1,"maxBodyLength":-1,"env":{},"headers":"MASKED","baseURL":"http://nexus.dso-nexus.svc.cluster.local:8081/service/rest/v1/","auth":{"username":"MASKED","password":"MASKED"},"method":"delete","url":"/repositories/socleprojecttest-repository-release","allowAbsoluteUrls":true},"code":"ERR_BAD_RESPONSE","status":500}"
```
Nexus logs show `java.util.ConcurrentModificationException`.
```
2025-12-10 11:24:53,143+0000 WARN [qtp1899061171-30] admin org.sonatype.nexus.siesta.internal.UnexpectedExceptionMapper - (ID fe4befbf-19ef-4082-9e72-a3a38e998848) Response: [500] 'ERROR: (ID fe4befbf-19ef-4082-9e72-a3a38e998848) java.util.ConcurrentModificationException'; mapped from: java.util.ConcurrentModificationException 2025-12-10 11:24:53,148+0000 INFO [qtp1899061171-30] *SYSTEM org.eclipse.jetty.server.RequestLog - 100.64.9.35 - admin [10/Dec/2025:11:24:53 +0000] "DELETE /service/rest/v1/repositories/socleprojecttest-repository-release HTTP/1.1" 500 - 90 58 "axios/1.12.2" [qtp1899061171-30]
```

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Avoid concurrent modification exception by sequentializing deletion.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
No.