### PR TITLE
fix: keycloak HTTPS required error on dev with Docker Desktop Mac

### DIFF
--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -18,7 +18,7 @@ services:
       keycloak-fetch-theme:
         condition: service_completed_successfully
     ports:
-      - 8090:8080
+      - 127.0.0.1:8090:8080
     volumes:
       - ../keycloak/realms:/opt/bitnami/keycloak/data/import
       - ../keycloak/data/dev:/opt/bitnami/keycloak/data/h2


### PR DESCRIPTION
## Issues liées

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Impossible d'accéder à keycloak en local via http://localhost:8090/admin sur un Mac (M2 Tahoe 26.2) avec Docker Desktop 4.57.0

<img width="1202" height="636" alt="Screenshot 2026-01-20 at 12 00 36" src="https://github.com/user-attachments/assets/6a84e636-5239-4af1-84c1-0224a1bf1351" />

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
keycloak en local de nouveau accessible

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
N/A
## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
N/A