### PR TITLE
fix: prisma not loading dotenv

### DIFF
--- a/apps/server/prisma.config.ts
+++ b/apps/server/prisma.config.ts
@@ -1,5 +1,18 @@
 import path from 'node:path'
 import { defineConfig } from 'prisma/config'
+import * as dotenv from 'dotenv'
+
+if (process.env.DOCKER !== 'true') {
+  dotenv.config({ path: '.env' })
+}
+
+if (process.env.INTEGRATION === 'true') {
+  const envInteg = dotenv.config({ path: '.env.integ' })
+  process.env = {
+    ...process.env,
+    ...(envInteg?.parsed ?? {}),
+  }
+}
 
 export default defineConfig({
   schema: path.join('src', 'prisma', 'schema'),


### PR DESCRIPTION

When running outside of apps/server as per the readme, prisma migrate will fails.

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/cloud-pi-native/console/pull/1850).
* #1851
* __->__ #1850