### PR TITLE
feat(shared): add admin role fine grained permissions

### DIFF
--- a/apps/client/cypress/e2e/specs/admin/projects.e2e.ts
+++ b/apps/client/cypress/e2e/specs/admin/projects.e2e.ts
@@ -299,6 +299,12 @@ describe('Administration projects', () => {
       .its('response.statusCode')
       .should('match', /^20\d$/)
 
+    cy.getByDataTestid('tableAdministrationProjects').within(() => {
+      cy.get('tr').contains(project.name)
+        .click()
+    })
+    cy.getByDataTestid('test-tab-team').click()
+
     cy.getByDataTestid('teamTable').get('tr').contains('Propriétaire')
       .should('have.length', 1)
       .parent()
@@ -316,6 +322,12 @@ describe('Administration projects', () => {
     cy.wait('@transferOwnership')
       .its('response.statusCode')
       .should('match', /^20\d$/)
+
+    cy.getByDataTestid('tableAdministrationProjects').within(() => {
+      cy.get('tr').contains(project.name)
+        .click()
+    })
+    cy.getByDataTestid('test-tab-team').click()
 
     cy.getByDataTestid('teamTable').get('tr').contains('Propriétaire')
       .should('have.length', 1)

--- a/apps/client/cypress/e2e/specs/admin/system-settings.e2e.ts
+++ b/apps/client/cypress/e2e/specs/admin/system-settings.e2e.ts
@@ -6,7 +6,6 @@ describe('Administration system settings', () => {
   const contactEmail = Cypress.env('CONTACT_EMAIL') || 'cloudpinative-relations@interieur.gouv.fr'
 
   beforeEach(() => {
-    cy.intercept('GET', 'api/v1/system/settings?key=maintenance').as('listMaintenanceSetting')
     cy.intercept('GET', 'api/v1/system/settings').as('listSystemSettings')
     cy.intercept('POST', 'api/v1/system/settings').as('upsertSystemSetting')
 
@@ -52,19 +51,6 @@ describe('Administration system settings', () => {
     cy.getByDataTestid('maintenance-notice')
       .should('not.exist')
     cy.visit('/projects')
-    // TODO à creuser : La requête est faite deux fois
-    // la première renvoie "off" alors qu'en bdd la valeur est à "on"
-    cy.wait('@listMaintenanceSetting').its('response').then(($response) => {
-      cy.log(JSON.stringify($response?.body))
-    })
-    cy.wait('@listMaintenanceSetting').its('response').then(($response) => {
-      cy.log(JSON.stringify($response?.body))
-      expect($response?.statusCode).to.match(/^20\d$/)
-      expect(JSON.stringify($response?.body)).to.equal(JSON.stringify([{
-        key: 'maintenance',
-        value: 'on',
-      }]))
-    })
     cy.wait('@listRoles')
     cy.getByDataTestid('maintenance-notice')
       .should('be.visible')
@@ -93,13 +79,6 @@ describe('Administration system settings', () => {
     })
 
     cy.visit('/projects')
-    cy.wait('@listMaintenanceSetting').its('response').then(($response) => {
-      expect($response?.statusCode).to.match(/^20\d$/)
-      expect(JSON.stringify($response?.body)).to.equal(JSON.stringify([{
-        key: 'maintenance',
-        value: 'on',
-      }]))
-    })
     cy.getByDataTestid('maintenance-notice')
       .should('not.exist')
     cy.url().should('contain', '/projects')

--- a/apps/client/cypress/e2e/specs/roles.e2e.ts
+++ b/apps/client/cypress/e2e/specs/roles.e2e.ts
@@ -82,9 +82,6 @@ describe('Project roles', () => {
       cy.getByDataTestid('replayHooksBtn').should('not.exist')
       cy.getByDataTestid('showSecretsBtn').should('not.exist')
 
-      cy.getByDataTestid('test-tab-resources').click()
-      cy.getByDataTestid('noEnvsTr').should('exist')
-      cy.getByDataTestid('noReposTr').should('exist')
       cy.getByDataTestid('test-tab-roles').should('exist')
     })
   })

--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -390,7 +390,7 @@ async function copyToClipboard(text: string) {
       :environment="selectedEnv"
       :is-editable="false"
       :is-project-locked="project.locked"
-      :can-manage="canManageEnvs || (AdminAuthorized.isAdmin(userStore.adminPerms) && asProfile === 'admin')"
+      :can-manage="canManageEnvs || (AdminAuthorized.Manage(userStore.adminPerms) && asProfile === 'admin')"
       @put-environment="(environmentUpdate: UpdateEnvironmentBody) => putEnvironment(environmentUpdate, selectedEnv!.id)"
       @delete-environment="() => deleteEnvironment(selectedEnv!.id)"
       @cancel="selectedEnv = undefined"

--- a/apps/client/src/components/SelectProject.vue
+++ b/apps/client/src/components/SelectProject.vue
@@ -2,9 +2,14 @@
 import router, { isInProject, selectedProjectSlug } from '../router/index.js'
 import { useUserStore } from '@/stores/user.js'
 import { useProjectStore } from '@/stores/project.js'
+import { AdminAuthorized } from '@cpn-console/shared'
 
 const projectStore = useProjectStore()
 const userStore = useUserStore()
+
+const canCreateProject = computed(() => {
+  return AdminAuthorized.ManageProjects(userStore.adminPerms)
+})
 
 watch(userStore, async () => {
   if (userStore.isLoggedIn && !projectStore.myProjects?.length) {
@@ -71,6 +76,7 @@ function selectProject(slug: string) {
       :icon-only="!!projectStore.myProjects.length"
       :label="!projectStore.myProjects.length ? 'Créer un nouveau projet' : ''"
       small
+      :disabled="!canCreateProject"
       @click="() => router.currentRoute.value.name !== 'CreateProject' && router.push({ name: 'CreateProject' })"
     />
   </div>

--- a/apps/client/src/components/SideMenu.vue
+++ b/apps/client/src/components/SideMenu.vue
@@ -3,6 +3,7 @@ import { isInProject } from '../router/index.js'
 import { useUserStore } from '@/stores/user.js'
 import { useServiceStore } from '@/stores/services-monitor.js'
 import { openCDSEnabled } from '@/utils/env.js'
+import { AdminAuthorized } from '@cpn-console/shared'
 
 const route = useRoute()
 const userStore = useUserStore()
@@ -148,7 +149,7 @@ onMounted(() => {
 
       <!-- Onglet Administration -->
       <DsfrSideMenuListItem
-        v-if="userStore.adminPerms"
+        v-if="AdminAuthorized.Manage(userStore.adminPerms)"
         v-bind="{
           focusFirstAnchor: false,
         }"

--- a/apps/client/src/components/TeamCt.vue
+++ b/apps/client/src/components/TeamCt.vue
@@ -27,6 +27,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   refresh: []
   leave: []
+  transfer: []
 }>()
 
 const projectStore = useProjectStore()
@@ -105,7 +106,8 @@ async function removeUserFromProject(userId: string) {
 async function transferOwnerShip() {
   if (nextOwnerId.value && props.project.members.find(member => member.userId === nextOwnerId.value)) {
     await props.project.Commands.update({ ownerId: nextOwnerId.value })
-      .finally(() => emit('refresh'))
+      .then(() => emit('transfer'))
+      .catch(() => emit('refresh'))
   }
 }
 </script>

--- a/apps/client/src/router/index.spec.ts
+++ b/apps/client/src/router/index.spec.ts
@@ -1,31 +1,102 @@
-import { describe, it, expect } from 'vitest'
-import { detectProjectslug } from './index.js'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { faker } from '@faker-js/faker'
+import type { ProjectV2 } from '@cpn-console/shared'
+import { detectProjectslug, createAppRouter } from './index.js'
+import { useUserStore } from '@/stores/user.js'
 import { useProjectStore } from '@/stores/project.js'
+import { useSystemSettingsStore } from '@/stores/system-settings.js'
 
-setActivePinia(createPinia())
-describe('test router functions: detectProjectslug', () => {
-  const projectStore = useProjectStore()
-  const slug = 'the-slug'
-  const uuid = crypto.randomUUID()
-  projectStore.updateStore([{
-    slug,
-    id: uuid,
-  }])
-  it('it should return project\'slug with uuid passed', () => {
-    const slugFound = detectProjectslug({
-      params: {
-        slug: uuid,
-      },
-    })
-    expect(slugFound).toEqual(slug)
+describe('router index', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
   })
 
-  it('it should return project\'slug with slug passed', () => {
-    const slugFound = detectProjectslug({
-      params: {
+  describe('detect project slug helper', () => {
+    let projectStore: ReturnType<typeof useProjectStore>
+    let slug: string
+    let uuid: string
+
+    beforeEach(() => {
+      projectStore = useProjectStore()
+      slug = faker.lorem.slug()
+      uuid = faker.string.uuid()
+      const recent = faker.date.recent()
+      const ownerId = faker.string.uuid()
+      const project: ProjectV2 = {
+        id: uuid,
+        clusterIds: [],
+        description: '',
+        everyonePerms: '0',
+        name: slug,
         slug,
-      },
+        locked: false,
+        owner: {
+          type: 'human',
+          id: ownerId,
+          firstName: faker.person.firstName(),
+          lastName: faker.person.lastName(),
+          email: faker.internet.email(),
+          createdAt: recent.toString(),
+          updatedAt: recent.toString(),
+          lastLogin: recent.toString(),
+        },
+        ownerId,
+        roles: [],
+        members: [],
+        createdAt: recent.toString(),
+        updatedAt: recent.toString(),
+        limitless: false,
+        hprodCpu: faker.number.int({ min: 0, max: 1000 }),
+        hprodGpu: faker.number.int({ min: 0, max: 1000 }),
+        hprodMemory: faker.number.int({ min: 0, max: 1000 }),
+        prodCpu: faker.number.int({ min: 0, max: 1000 }),
+        prodGpu: faker.number.int({ min: 0, max: 1000 }),
+        prodMemory: faker.number.int({ min: 0, max: 1000 }),
+        status: 'created',
+        lastSuccessProvisionningVersion: null,
+      }
+      projectStore.updateStore([project])
     })
-    expect(slugFound).toEqual(slug)
+
+    it('it should return project\'slug with uuid passed', () => {
+      const slugFound = detectProjectslug({
+        params: {
+          slug: uuid,
+        },
+      })
+      expect(slugFound).toEqual(slug)
+    })
+
+    it('it should return project\'slug with slug passed', () => {
+      const slugFound = detectProjectslug({
+        params: {
+          slug,
+        },
+      })
+      expect(slugFound).toEqual(slug)
+    })
+  })
+
+  describe('navigation with real router instance', () => {
+    it('renders home and navigates to projects', async () => {
+      const router = createAppRouter('')
+      const userStore = useUserStore()
+      const systemStore = useSystemSettingsStore()
+
+      // Ensure global guard does not redirect to /login
+      // by simulating an authenticated user.
+      userStore.isLoggedIn = true
+      userStore.setIsLoggedIn = async () => {}
+      systemStore.listSystemSettings = async () => {}
+      router.push('/')
+      await router.isReady()
+
+      expect(router.currentRoute.value.name).toEqual('Home')
+
+      await router.push('/projects')
+      await router.isReady()
+
+      expect(router.currentRoute.value.matched.some(r => r.name === 'Projects')).toBe(true)
+    })
   })
 })

--- a/apps/client/src/router/index.ts
+++ b/apps/client/src/router/index.ts
@@ -12,7 +12,7 @@ import { useSystemSettingsStore } from '@/stores/system-settings.js'
 
 import DsoHome from '@/views/DsoHome.vue'
 import NotFound from '@/views/NotFound.vue'
-import { swaggerUiPath } from '@cpn-console/shared'
+import { AdminAuthorized, swaggerUiPath } from '@cpn-console/shared'
 import { uuid } from '@/utils/regex.js'
 
 const AdminCluster = () => import('@/views/admin/AdminCluster.vue')
@@ -270,53 +270,43 @@ export const routes: Readonly<RouteRecordRaw[]> = [
   },
 ]
 
-const router = createRouter({
-  history: createWebHistory(import.meta.env?.BASE_URL || ''),
-  scrollBehavior: (to) => { if (to.hash && !/^#state=/.exec(to.hash)) return ({ el: to.hash }) },
-  routes,
-})
+export function createAppRouter(base?: string) {
+  const router = createRouter({
+    history: createWebHistory(base ?? (import.meta.env?.BASE_URL || '')),
+    scrollBehavior: (to) => { if (to.hash && !/^#state=/.exec(to.hash)) return ({ el: to.hash }) },
+    routes,
+  })
+  router.beforeEach((to) => {
+    const specificTitle = to.meta.title ? `${to.meta.title} - ` : ''
+    document.title = `${specificTitle}${MAIN_TITLE}`
+  })
+  router.beforeEach(async (to, _from, next) => {
+    const validPath = new Set(['Login', 'Home', 'Doc', 'NotFound', 'ServicesHealth', 'Maintenance', 'Logout', 'Swagger'])
+    const userStore = useUserStore()
+    const systemStore = useSystemSettingsStore()
+    await userStore.setIsLoggedIn()
+    if (
+      !validPath.has(to.name?.toString() ?? '')
+      && !userStore.isLoggedIn
+    ) {
+      return next('/login')
+    }
+    if (to.name === 'Login' && userStore.isLoggedIn) {
+      return next('/')
+    }
+    if (
+      !validPath.has(to.name?.toString() ?? '')
+      && userStore.isLoggedIn
+    ) {
+      await systemStore.listSystemSettings()
+      if (systemStore.systemSettingsByKey.maintenance?.value === 'on' && !AdminAuthorized.Manage(userStore.adminPerms)) return next('/maintenance')
+    }
+    next()
+  })
+  return router
+}
 
-/**
- * Set application title
- */
-router.beforeEach((to) => { // Cf. https://github.com/vueuse/head pour des transformations avancées de Head
-  const specificTitle = to.meta.title ? `${to.meta.title} - ` : ''
-  document.title = `${specificTitle}${MAIN_TITLE}`
-})
-
-/**
- * Redirect unlogged user to login view
- */
-router.beforeEach(async (to, _from, next) => {
-  const validPath = ['Login', 'Home', 'Doc', 'NotFound', 'ServicesHealth', 'Maintenance', 'Logout', 'Swagger']
-  const userStore = useUserStore()
-  const systemStore = useSystemSettingsStore()
-  await userStore.setIsLoggedIn()
-
-  // Redirige sur la page login si le path le requiert et l'utilisateur n'est pas connecté
-  if (
-    !validPath.includes(to.name?.toString() ?? '')
-    && !userStore.isLoggedIn
-  ) {
-    return next('/login')
-  }
-
-  // Redirige sur l'accueil si le path est Login et que l'utilisateur est connecté
-  if (to.name === 'Login' && userStore.isLoggedIn) {
-    return next('/')
-  }
-
-  // Redirige vers la page maintenance si la maintenance est activée
-  if (
-    !validPath.includes(to.name?.toString() ?? '')
-    && userStore.isLoggedIn
-  ) {
-    await systemStore.listSystemSettings('maintenance')
-    if (systemStore.systemSettingsByKey.maintenance?.value === 'on' && userStore.adminPerms === 0n) return next('/maintenance')
-  }
-
-  next()
-})
+const router = createAppRouter()
 
 export const isInProject = computed(() => router.currentRoute.value.matched.some(route => route.name === 'Project'))
 export const selectedProjectSlug = computed<string | undefined>(() => {

--- a/apps/client/src/stores/admin-role.ts
+++ b/apps/client/src/stores/admin-role.ts
@@ -22,7 +22,7 @@ export const useAdminRoleStore = defineStore('adminRole', () => {
     roles.value = await apiClient.AdminRoles.listAdminRoles().then((response: any) =>
       extractData(response, 200),
     )
-    if (AdminAuthorized.isAdmin(userStore.adminPerms)) {
+    if (AdminAuthorized.ListRoles(userStore.adminPerms)) {
       await countMembersRoles()
     }
     return roles.value

--- a/apps/client/src/stores/system-settings.ts
+++ b/apps/client/src/stores/system-settings.ts
@@ -1,8 +1,10 @@
 import { defineStore } from 'pinia'
+import type {
+  UpsertSystemSettingBody,
+  SystemSettings,
+  systemSettingsContract,
+} from '@cpn-console/shared'
 import {
-  type SystemSetting,
-  type SystemSettings,
-  type UpsertSystemSettingBody,
   resourceListToDictByKey,
 } from '@cpn-console/shared'
 import { apiClient, extractData } from '@/api/xhr-client.js'
@@ -11,8 +13,8 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   const systemSettings = ref<SystemSettings>([])
   const systemSettingsByKey = computed(() => resourceListToDictByKey(systemSettings.value))
 
-  const listSystemSettings = async (key?: SystemSetting['key']) => {
-    systemSettings.value = await apiClient.SystemSettings.listSystemSettings({ query: { key } })
+  const listSystemSettings = async (query: typeof systemSettingsContract.listSystemSettings.query._type = {}) => {
+    systemSettings.value = await apiClient.SystemSettings.listSystemSettings(query)
       .then((response: any) => extractData(response, 200))
   }
 

--- a/apps/client/src/views/CreateProject.vue
+++ b/apps/client/src/views/CreateProject.vue
@@ -1,10 +1,11 @@
 <script lang="ts" setup>
 import type { Ref } from 'vue'
-import { computed, ref } from 'vue'
+import { computed, onBeforeMount, ref } from 'vue'
 import type {
   projectContract,
 } from '@cpn-console/shared'
 import {
+  AdminAuthorized,
   ProjectSchemaV2,
   descriptionMaxLength,
   instanciateSchema,
@@ -34,6 +35,12 @@ const project = ref<typeof projectContract.createProject.body._type>({
   prodCpu: 0,
   prodGpu: 0,
   prodMemory: 0,
+})
+
+onBeforeMount(() => {
+  if (!AdminAuthorized.ManageProjects(userStore.adminPerms)) {
+    router.replace({ name: 'Projects' })
+  }
 })
 
 const remainingCharacters = computed(() => {

--- a/apps/client/src/views/ProjectDashboard.vue
+++ b/apps/client/src/views/ProjectDashboard.vue
@@ -192,6 +192,7 @@ async function saveProject() {
             :can-transfer="asProfile === 'admin' || project.ownerId === userStore.userProfile?.id"
             @refresh="refreshMembers"
             @leave="leaveProject"
+            @transfer="unSelectProject"
           />
         </DsfrTabContent>
 

--- a/apps/client/src/views/ServicesHealth.vue
+++ b/apps/client/src/views/ServicesHealth.vue
@@ -49,7 +49,7 @@ onBeforeMount(async () => {
     />
     <div class="flex gap-2">
       <DsfrButton
-        v-if="AdminAuthorized.isAdmin(userStore.adminPerms)"
+        v-if="AdminAuthorized.ListSystem(userStore.adminPerms)"
         data-testid="serviceCauseBtn"
         :title="!serviceStore.displayCause ? 'Afficher les messages d\'erreur' : 'Masquer les messages d\'erreur'"
         secondary
@@ -67,7 +67,7 @@ onBeforeMount(async () => {
         @click="checkServicesHealth"
       />
       <DsfrButton
-        v-if="AdminAuthorized.isAdmin(userStore.adminPerms)"
+        v-if="AdminAuthorized.ManageSystem(userStore.adminPerms)"
         data-testid="refresh-btn"
         label="Effacer le cache"
         secondary

--- a/apps/client/src/views/projects/DsoProjects.vue
+++ b/apps/client/src/views/projects/DsoProjects.vue
@@ -1,11 +1,16 @@
 <script lang="ts" setup>
 import type { ProjectV2 } from '@cpn-console/shared'
+import { AdminAuthorized } from '@cpn-console/shared'
 import { useProjectStore } from '@/stores/project.js'
 import router from '@/router/index.js'
 import { useUserStore } from '@/stores/user.js'
 
 const projectStore = useProjectStore()
 const userStore = useUserStore()
+
+const canCreateProject = computed(() => {
+  return AdminAuthorized.ManageProjects(userStore.adminPerms)
+})
 
 const projectList = computed(() => projectStore.myProjects
   .map(project => ({
@@ -45,6 +50,8 @@ onBeforeMount(async () => {
       tertiary
       class="fr-mt-2v <md:mb-2"
       icon="ri:add-line"
+      :disabled="!canCreateProject"
+      :title="canCreateProject ? 'Créer un nouveau projet' : 'Vous n\'avez pas les droits pour créer un projet'"
       @click="goToCreateProject()"
     />
   </div>

--- a/apps/server/src/prisma/migrations/20260217144930_enable_legacy_permissions/migration.sql
+++ b/apps/server/src/prisma/migrations/20260217144930_enable_legacy_permissions/migration.sql
@@ -1,0 +1,5 @@
+-- Enable legacy default permissions flag
+INSERT INTO "SystemSetting"
+    ("key", "value")
+VALUES
+    ('refined-permissions', 'off');

--- a/apps/server/src/resources/admin-role/router.spec.ts
+++ b/apps/server/src/resources/admin-role/router.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { adminRoleContract } from '@cpn-console/shared'
+import { adminRoleContract, ADMIN_PERMS } from '@cpn-console/shared'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
 import { BadRequest400 } from '../../utils/errors.js'
@@ -22,6 +22,9 @@ describe('test adminRoleContract', () => {
 
   describe('listAdminRoles', () => {
     it('should return list of admin roles', async () => {
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_ROLES)
+      authUserMock.mockResolvedValueOnce(user)
+
       const roles = [{ id: faker.string.uuid(), name: 'Role 1', oidcGroup: '', position: 0, permissions: '1', type: 'custom' }]
       businessListRolesMock.mockResolvedValueOnce(roles)
 
@@ -37,7 +40,7 @@ describe('test adminRoleContract', () => {
 
   describe('createAdminRole', () => {
     it('should create a role for authorized users', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ROLES)
       const newRole = { id: 'newRole', name: 'New Role' }
       const roleData = { name: 'New Role' }
 
@@ -55,7 +58,7 @@ describe('test adminRoleContract', () => {
     })
 
     it('should return 403 for unauthorized users', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -73,7 +76,7 @@ describe('test adminRoleContract', () => {
     const updatedRoles = [{ id: faker.string.uuid(), name: 'Role 1', oidcGroup: '', position: 0, permissions: '1', type: 'custom' }]
     const rolesData = [{ id: updatedRoles[0].id, name: 'Updated Role', type: 'custom' }]
     it('should update roles for authorized users', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ROLES)
 
       authUserMock.mockResolvedValueOnce(user)
       businessPatchRolesMock.mockResolvedValueOnce(updatedRoles)
@@ -89,7 +92,7 @@ describe('test adminRoleContract', () => {
     })
 
     it('should return error if business logic fails', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ROLES)
 
       authUserMock.mockResolvedValueOnce(user)
       businessPatchRolesMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -104,7 +107,7 @@ describe('test adminRoleContract', () => {
     })
 
     it('should return 403 for unauthorized users', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -120,7 +123,7 @@ describe('test adminRoleContract', () => {
 
   describe('adminRoleMemberCounts', () => {
     it('should return counts of role members for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ROLES)
       const counts = { role1: 5, role2: 3 }
 
       authUserMock.mockResolvedValueOnce(user)
@@ -136,7 +139,7 @@ describe('test adminRoleContract', () => {
     })
 
     it('should return 403 if user is not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_USERS)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -152,7 +155,7 @@ describe('test adminRoleContract', () => {
   describe('deleteAdminRole', () => {
     const roleId = faker.string.uuid()
     it('should delete a role for authorized users', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ROLES)
 
       authUserMock.mockResolvedValueOnce(user)
       businessDeleteRoleMock.mockResolvedValueOnce(null)
@@ -166,7 +169,7 @@ describe('test adminRoleContract', () => {
     })
 
     it('should return 403 for unauthorized users', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 

--- a/apps/server/src/resources/admin-role/router.ts
+++ b/apps/server/src/resources/admin-role/router.ts
@@ -24,7 +24,8 @@ export function adminRoleRouter() {
 
     createAdminRole: async ({ request: req, body }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageRoles(perms.adminPermissions)) return new Forbidden403()
 
       const resBody = await createRole(body)
 
@@ -36,7 +37,8 @@ export function adminRoleRouter() {
 
     patchAdminRoles: async ({ request: req, body }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageRoles(perms.adminPermissions)) return new Forbidden403()
 
       const resBody = await patchRoles(body)
       if (resBody instanceof ErrorResType) return resBody
@@ -49,7 +51,8 @@ export function adminRoleRouter() {
 
     adminRoleMemberCounts: async ({ request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageRoles(perms.adminPermissions)) return new Forbidden403()
 
       const resBody = await countRolesMembers()
 
@@ -61,7 +64,8 @@ export function adminRoleRouter() {
 
     deleteAdminRole: async ({ request: req, params }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageRoles(perms.adminPermissions)) return new Forbidden403()
 
       const resBody = await deleteRole(params.roleId)
       if (resBody instanceof ErrorResType) return resBody

--- a/apps/server/src/resources/admin-token/router.spec.ts
+++ b/apps/server/src/resources/admin-token/router.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ExposedAdminToken } from '@cpn-console/shared'
-import { adminTokenContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, adminTokenContract } from '@cpn-console/shared'
 import type { AdminToken } from '@prisma/client'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
@@ -22,7 +22,7 @@ describe('test adminTokenContract', () => {
 
   describe('listAdminTokens', () => {
     it('should return list of admin tokens', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_ADMIN_TOKEN)
       authUserMock.mockResolvedValueOnce(user)
 
       const tokens: AdminToken[] = [{
@@ -46,7 +46,7 @@ describe('test adminTokenContract', () => {
     })
 
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -60,7 +60,7 @@ describe('test adminTokenContract', () => {
 
   describe('createAdminToken', () => {
     it('should create a token for authorized users', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ADMIN_TOKEN)
 
       const newToken = {
         id: faker.string.uuid(),
@@ -92,7 +92,7 @@ describe('test adminTokenContract', () => {
     })
 
     it('should return 403 for unauthorized users', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -110,7 +110,7 @@ describe('test adminTokenContract', () => {
     })
 
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ADMIN_TOKEN)
 
       authUserMock.mockResolvedValueOnce(user)
       businessCreateTokenMock.mockResolvedValueOnce(new BadRequest400('Invalid date'))
@@ -132,7 +132,7 @@ describe('test adminTokenContract', () => {
   describe('deleteAdminToken', () => {
     const tokenId = faker.string.uuid()
     it('should delete a token for authorized users', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ADMIN_TOKEN)
 
       authUserMock.mockResolvedValueOnce(user)
       businessDeleteTokenMock.mockResolvedValueOnce(null)
@@ -146,7 +146,7 @@ describe('test adminTokenContract', () => {
     })
 
     it('should return 403 for unauthorized users', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 

--- a/apps/server/src/resources/admin-token/router.ts
+++ b/apps/server/src/resources/admin-token/router.ts
@@ -8,7 +8,8 @@ export function adminTokenRouter() {
   return serverInstance.router(adminTokenContract, {
     listAdminTokens: async ({ request: req, query }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ListAdminToken(perms.adminPermissions)) return new Forbidden403()
       const body = await listTokens(query)
 
       return {
@@ -20,7 +21,7 @@ export function adminTokenRouter() {
     createAdminToken: async ({ request: req, body: data }) => {
       const perms = await authUser(req)
 
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+      if (!AdminAuthorized.ManageAdminToken(perms.adminPermissions)) return new Forbidden403()
       const body = await createToken(data)
       if (body instanceof ErrorResType) return body
 
@@ -32,7 +33,8 @@ export function adminTokenRouter() {
 
     deleteAdminToken: async ({ request: req, params }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageAdminToken(perms.adminPermissions)) return new Forbidden403()
       await deleteToken(params.tokenId)
 
       return {

--- a/apps/server/src/resources/cluster/router.spec.ts
+++ b/apps/server/src/resources/cluster/router.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClusterDetails, Environment } from '@cpn-console/shared'
-import { clusterContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, clusterContract } from '@cpn-console/shared'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
 import { getUserMockInfos } from '../../utils/mocks.js'
@@ -24,7 +24,7 @@ describe('test clusterContract', () => {
   })
   describe('listClusters', () => {
     it('as non admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -39,7 +39,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('as admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_CLUSTERS)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -73,7 +73,7 @@ describe('test clusterContract', () => {
           user: {},
         },
       }
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetDetailsMock.mockResolvedValueOnce(cluster)
@@ -86,7 +86,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -105,7 +105,7 @@ describe('test clusterContract', () => {
         gpu: faker.number.float({ min: 0, max: 10, fractionDigits: 1 }),
         memory: faker.number.float({ min: 0, max: 10, fractionDigits: 1 }),
       }
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetUsageMock.mockResolvedValueOnce(resources)
@@ -118,7 +118,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -133,7 +133,7 @@ describe('test clusterContract', () => {
   describe('getClusterEnvironments', () => {
     it('should return cluster environments', async () => {
       const envs: Environment[] = []
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetEnvironmentsMock.mockResolvedValueOnce(envs)
@@ -146,7 +146,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -177,7 +177,7 @@ describe('test clusterContract', () => {
     }
 
     it('should return created cluster', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce(cluster)
@@ -190,7 +190,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(201)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -202,7 +202,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -233,7 +233,7 @@ describe('test clusterContract', () => {
     }
 
     it('should return created cluster', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce({ id: clusterId, ...cluster })
@@ -246,7 +246,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -258,7 +258,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -272,7 +272,7 @@ describe('test clusterContract', () => {
 
   describe('deleteCluster', () => {
     it('should return empty when delete', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(null)
@@ -284,7 +284,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(204)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_CLUSTERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -295,7 +295,7 @@ describe('test clusterContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()

--- a/apps/server/src/resources/cluster/router.ts
+++ b/apps/server/src/resources/cluster/router.ts
@@ -20,7 +20,7 @@ export function clusterRouter() {
       const { adminPermissions, user } = await authUser(req)
 
       let body: AsyncReturnType<typeof listClusters> = []
-      if (AdminAuthorized.isAdmin(adminPermissions)) {
+      if (AdminAuthorized.ListClusters(adminPermissions)) {
         body = await listClusters()
       } else if (user) {
         body = await listClusters(user.id)
@@ -34,7 +34,8 @@ export function clusterRouter() {
 
     getClusterDetails: async ({ params, request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ListClusters(perms.adminPermissions)) return new Forbidden403()
 
       const clusterId = params.clusterId
       const cluster = await getClusterDetailsBusiness(clusterId)
@@ -47,7 +48,8 @@ export function clusterRouter() {
 
     getClusterUsage: async ({ params, request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ListClusters(perms.adminPermissions)) return new Forbidden403()
 
       const clusterId = params.clusterId
       const usage = await getClusterUsage(clusterId)
@@ -60,7 +62,8 @@ export function clusterRouter() {
 
     createCluster: async ({ request: req, body: data }) => {
       const { adminPermissions, user } = await authUser(req)
-      if (!AdminAuthorized.isAdmin(adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageClusters(adminPermissions)) return new Forbidden403()
 
       if (!user) return new Unauthorized401('Require to be requested from user not api key')
       const body = await createCluster(data, user.id, req.id)
@@ -74,7 +77,8 @@ export function clusterRouter() {
 
     getClusterEnvironments: async ({ request: req, params }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ListClusters(perms.adminPermissions)) return new Forbidden403()
 
       const clusterId = params.clusterId
       const environments = await getClusterAssociatedEnvironments(clusterId)
@@ -87,7 +91,8 @@ export function clusterRouter() {
 
     updateCluster: async ({ request: req, params, body: data }) => {
       const { user, adminPermissions } = await authUser(req)
-      if (!AdminAuthorized.isAdmin(adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageClusters(adminPermissions)) return new Forbidden403()
       if (!user) return new Unauthorized401('Require to be requested from user not api key')
 
       const clusterId = params.clusterId
@@ -103,7 +108,8 @@ export function clusterRouter() {
 
     deleteCluster: async ({ request: req, params, query: { force } }) => {
       const { user, adminPermissions, tokenId } = await authUser(req)
-      if (!AdminAuthorized.isAdmin(adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageClusters(adminPermissions)) return new Forbidden403()
       if (!user?.id && !tokenId) return new Unauthorized401('Your identity has not been found')
 
       const clusterId = params.clusterId

--- a/apps/server/src/resources/environment/router.spec.ts
+++ b/apps/server/src/resources/environment/router.spec.ts
@@ -39,7 +39,7 @@ describe('environmentRouter tests', () => {
   describe('listEnvironments', () => {
     it('should return environments for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetProjectEnvironmentsMock.mockResolvedValueOnce([])
@@ -54,9 +54,9 @@ describe('environmentRouter tests', () => {
       expect(response.json()).toEqual([])
     })
 
-    it('should return empty for non member of projectId query ', async () => {
+    it('should return 403 for non member of projectId query ', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -65,14 +65,14 @@ describe('environmentRouter tests', () => {
         .end()
 
       expect(businessGetProjectEnvironmentsMock).toHaveBeenCalledTimes(0)
-      expect(response.json()).toEqual([])
+      expect(response.statusCode).toEqual(403)
     })
   })
 
   describe('createEnvironment', () => {
     it('should create environment for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCheckEnvironmentCreateMock.mockResolvedValueOnce({ success: true })
@@ -90,9 +90,9 @@ describe('environmentRouter tests', () => {
       expect(response.statusCode).toEqual(201)
     })
 
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -100,12 +100,12 @@ describe('environmentRouter tests', () => {
         .body(environmentData)
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -119,7 +119,7 @@ describe('environmentRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -133,7 +133,7 @@ describe('environmentRouter tests', () => {
 
     it('should return 403 if not permited', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -145,7 +145,7 @@ describe('environmentRouter tests', () => {
     })
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCheckEnvironmentCreateMock.mockResolvedValueOnce({ success: true, message: 'pas d erreur' })
@@ -159,7 +159,7 @@ describe('environmentRouter tests', () => {
     })
     it('should pass invalid reason error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCheckEnvironmentCreateMock.mockResolvedValueOnce({ isError: true, message: 'une erreur' })
@@ -182,9 +182,10 @@ describe('environmentRouter tests', () => {
         autosync: faker.datatype.boolean(),
       }
     })
+
     it('should update environment for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCheckEnvironmentUpdateMock.mockResolvedValueOnce({ success: true, value: true })
@@ -200,8 +201,8 @@ describe('environmentRouter tests', () => {
     })
 
     it('should return 403 for unauthorized user', async () => {
-      const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -212,22 +213,9 @@ describe('environmentRouter tests', () => {
       expect(response.statusCode).toEqual(403)
     })
 
-    it('should return 404 for unauthorized user', async () => {
-      const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
-      authUserMock.mockResolvedValueOnce(user)
-
-      const response = await app.inject()
-        .put(environmentContract.updateEnvironment.path.replace(':environmentId', environmentId))
-        .body(updateData)
-        .end()
-
-      expect(response.statusCode).toEqual(404)
-    })
-
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -241,7 +229,7 @@ describe('environmentRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -253,21 +241,9 @@ describe('environmentRouter tests', () => {
       expect(response.json()).toEqual({ message: 'Le projet est verrouillé' })
     })
 
-    it('should return 404 if not permited', async () => {
-      const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(false, undefined, projectPerms)
-      authUserMock.mockResolvedValueOnce(user)
-
-      const response = await app.inject()
-        .put(environmentContract.updateEnvironment.path.replace(':environmentId', environmentId))
-        .body(updateData)
-        .end()
-
-      expect(response.statusCode).toEqual(404)
-    })
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateEnvironmentMock.mockResolvedValueOnce({ isError: true, value: 'une erreur' })
@@ -278,9 +254,10 @@ describe('environmentRouter tests', () => {
 
       expect(response.statusCode).toEqual(500)
     })
+
     it('should pass invalid reason error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCheckEnvironmentUpdateMock.mockResolvedValueOnce({ isError: true, value: 'une erreur' })
@@ -296,7 +273,7 @@ describe('environmentRouter tests', () => {
   describe('deleteEnvironment', () => {
     it('should delete environment for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteEnvironmentMock.mockResolvedValueOnce({ success: true })
@@ -308,21 +285,9 @@ describe('environmentRouter tests', () => {
       expect(response.statusCode).toEqual(204)
     })
 
-    it('should return 404 for unauthorized user', async () => {
-      const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
-      authUserMock.mockResolvedValueOnce(user)
-
-      const response = await app.inject()
-        .delete(environmentContract.deleteEnvironment.path.replace(':environmentId', environmentId))
-        .end()
-
-      expect(response.statusCode).toEqual(404)
-    })
-
     it('should return 403 for unauthorized user', async () => {
-      const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -334,7 +299,7 @@ describe('environmentRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -347,7 +312,7 @@ describe('environmentRouter tests', () => {
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -360,7 +325,7 @@ describe('environmentRouter tests', () => {
 
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteEnvironmentMock.mockResolvedValueOnce({ isError: true, value: 'une erreur' })

--- a/apps/server/src/resources/environment/router.ts
+++ b/apps/server/src/resources/environment/router.ts
@@ -2,7 +2,7 @@ import { ProjectAuthorized, environmentContract } from '@cpn-console/shared'
 import { checkEnvironmentCreate, checkEnvironmentUpdate, createEnvironment, deleteEnvironment, getProjectEnvironments, updateEnvironment } from './business.js'
 import { serverInstance } from '@/app.js'
 import { authUser } from '@/utils/controller.js'
-import { BadRequest400, Forbidden403, Internal500, NotFound404, Unauthorized401 } from '@/utils/errors.js'
+import { BadRequest400, Forbidden403, Internal500, Unauthorized401 } from '@/utils/errors.js'
 
 export function environmentRouter() {
   return serverInstance.router(environmentContract, {
@@ -10,13 +10,12 @@ export function environmentRouter() {
       const projectId = query.projectId
       const perms = await authUser(req, { id: projectId })
 
-      const environments = ProjectAuthorized.ListEnvironments(perms)
-        ? await getProjectEnvironments(projectId)
-        : []
+      if (!ProjectAuthorized.ListEnvironments(perms)) return new Forbidden403()
+      const body = await getProjectEnvironments(projectId)
 
       return {
         status: 200,
-        body: environments,
+        body,
       }
     },
 
@@ -25,7 +24,6 @@ export function environmentRouter() {
       const perms = await authUser(req, { id: projectId })
 
       if (!perms.user) return new Unauthorized401('Require to be requested from user not api key')
-      if (!perms.projectPermissions) return new NotFound404()
       if (!ProjectAuthorized.ManageEnvironments(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
@@ -58,7 +56,6 @@ export function environmentRouter() {
       const { environmentId } = params
       const perms = await authUser(req, { environmentId })
       if (!perms.user) return new Unauthorized401('Require to be requested from user not api key')
-      if (!ProjectAuthorized.ListEnvironments(perms)) return new NotFound404()
       if (!ProjectAuthorized.ManageEnvironments(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
@@ -87,7 +84,6 @@ export function environmentRouter() {
     deleteEnvironment: async ({ request: req, params }) => {
       const { environmentId } = params
       const perms = await authUser(req, { environmentId })
-      if (!perms.projectPermissions) return new NotFound404()
       if (!ProjectAuthorized.ManageEnvironments(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')

--- a/apps/server/src/resources/log/router.spec.ts
+++ b/apps/server/src/resources/log/router.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { logContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, logContract } from '@cpn-console/shared'
 import { faker } from '@faker-js/faker'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
@@ -17,7 +17,7 @@ describe('test logContract', () => {
 
   describe('getLogs', () => {
     it('should return logs for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_SYSTEM)
       const logs = []
       const total = 1
 
@@ -36,7 +36,7 @@ describe('test logContract', () => {
     })
 
     it('should return 403 for non-admin, no projectId', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -52,7 +52,7 @@ describe('test logContract', () => {
 
     it('should return logs for non-admin, with projectId', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 1n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       const projectId = faker.string.uuid()
 
       const logs = []
@@ -73,7 +73,7 @@ describe('test logContract', () => {
 
     it('should not return logs for non-admin, with projectId', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       const projectId = faker.string.uuid()
 
       const logs = []

--- a/apps/server/src/resources/log/router.ts
+++ b/apps/server/src/resources/log/router.ts
@@ -14,10 +14,8 @@ export function logRouter() {
         ? await authUser(req, { id: query.projectId })
         : await authUser(req)
 
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) {
-        if (!perms.projectPermissions) {
-          return new Forbidden403()
-        }
+      if (!AdminAuthorized.ListSystem(perms.adminPermissions)) {
+        if (!perms.projectPermissions) return new Forbidden403()
         query.clean = true
       }
 

--- a/apps/server/src/resources/project-member/router.spec.ts
+++ b/apps/server/src/resources/project-member/router.spec.ts
@@ -25,8 +25,8 @@ describe('projectMemberRouter tests', () => {
 
   describe('listMembers', () => {
     it('should return members for authorized user', async () => {
-      const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_MEMBERS })
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessListMembersMock.mockResolvedValueOnce([])
@@ -35,21 +35,21 @@ describe('projectMemberRouter tests', () => {
         .get(projectMemberContract.listMembers.path.replace(':projectId', projectId))
         .end()
 
-      expect(businessListMembersMock).toHaveBeenCalledWith(projectId)
       expect(response.statusCode).toEqual(200)
       expect(response.json()).toEqual([])
     })
 
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
         .get(projectMemberContract.listMembers.path.replace(':projectId', projectId))
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(businessListMembersMock).toHaveBeenCalledTimes(0)
+      expect(response.statusCode).toEqual(403)
     })
   })
 
@@ -60,7 +60,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should add member for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
       const newMember = {
         ...memberData,
@@ -83,7 +83,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
       businessAddMemberMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
 
@@ -94,9 +94,9 @@ describe('projectMemberRouter tests', () => {
 
       expect(response.statusCode).toEqual(400)
     })
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -104,12 +104,12 @@ describe('projectMemberRouter tests', () => {
         .body(memberData)
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -123,7 +123,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -141,7 +141,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should patch members for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessPatchMembersMock.mockResolvedValueOnce([])
@@ -155,9 +155,9 @@ describe('projectMemberRouter tests', () => {
       expect(response.statusCode).toEqual(200)
     })
 
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -165,12 +165,12 @@ describe('projectMemberRouter tests', () => {
         .body(patchData)
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 if not permited', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -183,7 +183,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -197,7 +197,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -213,7 +213,7 @@ describe('projectMemberRouter tests', () => {
   describe('removeMember', () => {
     it('should remove member for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessRemoveMemberMock.mockResolvedValueOnce([])
@@ -228,7 +228,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should be able leave a project', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessRemoveMemberMock.mockResolvedValueOnce([])
@@ -241,21 +241,21 @@ describe('projectMemberRouter tests', () => {
       expect(response.statusCode).toEqual(200)
     })
 
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
         .delete(projectMemberContract.removeMember.path.replace(':projectId', projectId).replace(':userId', userId))
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 if not permited', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -267,7 +267,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -280,7 +280,7 @@ describe('projectMemberRouter tests', () => {
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()

--- a/apps/server/src/resources/project-member/router.ts
+++ b/apps/server/src/resources/project-member/router.ts
@@ -1,4 +1,4 @@
-import { AdminAuthorized, ProjectAuthorized, projectMemberContract } from '@cpn-console/shared'
+import { ProjectAuthorized, projectMemberContract } from '@cpn-console/shared'
 import {
   addMember,
   listMembers,
@@ -7,15 +7,15 @@ import {
 } from './business.js'
 import { serverInstance } from '@/app.js'
 import { authUser } from '@/utils/controller.js'
-import { ErrorResType, Forbidden403, NotFound404, Unauthorized401 } from '@/utils/errors.js'
+import { ErrorResType, Forbidden403, Unauthorized401 } from '@/utils/errors.js'
 
 export function projectMemberRouter() {
   return serverInstance.router(projectMemberContract, {
     listMembers: async ({ request: req, params }) => {
       const { projectId } = params
       const perms = await authUser(req, { id: projectId })
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
 
+      if (!ProjectAuthorized.ListMembers(perms)) return new Forbidden403()
       const body = await listMembers(projectId)
 
       return {
@@ -29,7 +29,6 @@ export function projectMemberRouter() {
       const perms = await authUser(req, { id: projectId })
 
       if (!perms.user) return new Unauthorized401('Require to be requested from user not api key')
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
       if (!ProjectAuthorized.ManageMembers(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
@@ -47,7 +46,6 @@ export function projectMemberRouter() {
       const { projectId } = params
       const perms = await authUser(req, { id: projectId })
 
-      if (!perms.projectPermissions) return new NotFound404()
       if (!ProjectAuthorized.ManageMembers(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
@@ -65,11 +63,8 @@ export function projectMemberRouter() {
       const perms = await authUser(req, { id: projectId })
 
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
-      if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
-
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
-
       if (!ProjectAuthorized.ManageMembers(perms) && userId !== perms.user?.id) return new Forbidden403()
+      if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
 
       const resBody = await removeMember(projectId, params.userId)
 

--- a/apps/server/src/resources/project-role/router.spec.ts
+++ b/apps/server/src/resources/project-role/router.spec.ts
@@ -15,7 +15,6 @@ const businessCreateRoleMock = vi.spyOn(business, 'createRole')
 const businessDeleteRoleMock = vi.spyOn(business, 'deleteRole')
 const businessListRolesMock = vi.spyOn(business, 'listRoles')
 const businessPatchRolesMock = vi.spyOn(business, 'patchRoles')
-const businessCountRolesMembersMock = vi.spyOn(business, 'countRolesMembers')
 
 describe('tests projectRoleContract', () => {
   beforeEach(() => {
@@ -26,9 +25,9 @@ describe('tests projectRoleContract', () => {
   const roleId = faker.string.uuid()
 
   describe('listProjectRoles', () => {
-    it('should return roles for authorized user', async () => {
+    it('should return 403 for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.SEE_SECRETS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessListRolesMock.mockResolvedValueOnce([])
@@ -37,27 +36,26 @@ describe('tests projectRoleContract', () => {
         .get(projectRoleContract.listProjectRoles.path.replace(':projectId', projectId))
         .end()
 
-      expect(response.statusCode).toEqual(200)
-      expect(response.json()).toEqual([])
+      expect(response.statusCode).toEqual(403)
     })
 
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
         .get(projectRoleContract.listProjectRoles.path.replace(':projectId', projectId))
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
   })
 
   describe('createProjectRole', () => {
     it('should create role for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateRoleMock.mockResolvedValueOnce([])
@@ -73,7 +71,7 @@ describe('tests projectRoleContract', () => {
 
     it('should return 403 for locked project', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -87,7 +85,7 @@ describe('tests projectRoleContract', () => {
 
     it('should return 403 if not permited', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.SEE_SECRETS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -98,9 +96,9 @@ describe('tests projectRoleContract', () => {
       expect(response.statusCode).toEqual(403)
     })
 
-    it('should return 404 if non-member', async () => {
+    it('should return 403 if non-member', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -108,12 +106,12 @@ describe('tests projectRoleContract', () => {
         .body({ name: 'nouveau rôle' })
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 for archived project', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -129,7 +127,7 @@ describe('tests projectRoleContract', () => {
   describe('patchProjectRoles', () => {
     it('should patch roles for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessPatchRolesMock.mockResolvedValueOnce([])
@@ -145,7 +143,7 @@ describe('tests projectRoleContract', () => {
 
     it('should return 403 for locked project', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -159,7 +157,7 @@ describe('tests projectRoleContract', () => {
 
     it('should return 403 if not permited', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.SEE_SECRETS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -170,9 +168,9 @@ describe('tests projectRoleContract', () => {
       expect(response.statusCode).toEqual(403)
     })
 
-    it('should return 404 if non-member', async () => {
+    it('should return 403 if non-member', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -180,12 +178,12 @@ describe('tests projectRoleContract', () => {
         .body([{ id: roleId, name: 'nouveau rôle' }])
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 for archived project', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -199,7 +197,7 @@ describe('tests projectRoleContract', () => {
 
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessPatchRolesMock.mockResolvedValue(new BadRequest400('une erreur'))
@@ -213,38 +211,23 @@ describe('tests projectRoleContract', () => {
   })
 
   describe('projectRoleMemberCounts', () => {
-    it('should return member counts for authorized user', async () => {
-      const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.SEE_SECRETS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
-      authUserMock.mockResolvedValueOnce(user)
-
-      businessCountRolesMembersMock.mockResolvedValueOnce({})
-
-      const response = await app.inject()
-        .get(projectRoleContract.projectRoleMemberCounts.path.replace(':projectId', projectId))
-        .end()
-
-      expect(response.statusCode).toEqual(200)
-      expect(response.json()).toEqual({})
-    })
-
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
         .get(projectRoleContract.projectRoleMemberCounts.path.replace(':projectId', projectId))
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
   })
 
   describe('deleteProjectRole', () => {
     it('should delete role for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteRoleMock.mockResolvedValueOnce(null)
@@ -257,7 +240,7 @@ describe('tests projectRoleContract', () => {
 
     it('should return 403 for locked project', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateRoleMock.mockResolvedValueOnce([])
@@ -272,7 +255,7 @@ describe('tests projectRoleContract', () => {
 
     it('should return 403 if not permited', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.SEE_SECRETS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateRoleMock.mockResolvedValueOnce([])
@@ -286,7 +269,7 @@ describe('tests projectRoleContract', () => {
 
     it('should return 404 if non-member', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateRoleMock.mockResolvedValueOnce([])
@@ -295,12 +278,12 @@ describe('tests projectRoleContract', () => {
         .delete(projectRoleContract.deleteProjectRole.path.replace(':projectId', projectId).replace(':roleId', roleId))
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 for archived project', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_ROLES, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateRoleMock.mockResolvedValueOnce([])

--- a/apps/server/src/resources/project-role/router.ts
+++ b/apps/server/src/resources/project-role/router.ts
@@ -1,4 +1,4 @@
-import { AdminAuthorized, ProjectAuthorized, projectRoleContract } from '@cpn-console/shared'
+import { ProjectAuthorized, projectRoleContract } from '@cpn-console/shared'
 import {
   countRolesMembers,
   createRole,
@@ -8,7 +8,7 @@ import {
 } from './business.js'
 import { serverInstance } from '@/app.js'
 import { authUser } from '@/utils/controller.js'
-import { ErrorResType, Forbidden403, NotFound404 } from '@/utils/errors.js'
+import { ErrorResType, Forbidden403 } from '@/utils/errors.js'
 
 export function projectRoleRouter() {
   return serverInstance.router(projectRoleContract, {
@@ -16,7 +16,7 @@ export function projectRoleRouter() {
     listProjectRoles: async ({ request: req, params }) => {
       const { projectId } = params
       const perms = await authUser(req, { id: projectId })
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
+      if (!ProjectAuthorized.ListRoles(perms)) return new Forbidden403()
 
       const body = await listRoles(projectId)
 
@@ -29,7 +29,6 @@ export function projectRoleRouter() {
     createProjectRole: async ({ request: req, params: { projectId }, body }) => {
       const perms = await authUser(req, { id: projectId })
 
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
       if (!ProjectAuthorized.ManageRoles(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
@@ -46,7 +45,6 @@ export function projectRoleRouter() {
     patchProjectRoles: async ({ request: req, params: { projectId }, body }) => {
       const perms = await authUser(req, { id: projectId })
 
-      if (!perms.projectPermissions) return new NotFound404()
       if (!ProjectAuthorized.ManageRoles(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
@@ -63,7 +61,7 @@ export function projectRoleRouter() {
     projectRoleMemberCounts: async ({ request: req, params }) => {
       const { projectId } = params
       const perms = await authUser(req, { id: projectId })
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
+      if (!ProjectAuthorized.ListRoles(perms)) return new Forbidden403()
 
       const resBody = await countRolesMembers(projectId)
 
@@ -75,7 +73,6 @@ export function projectRoleRouter() {
 
     deleteProjectRole: async ({ request: req, params: { projectId, roleId } }) => {
       const perms = await authUser(req, { id: projectId })
-      if (!perms.projectPermissions) return new NotFound404()
       if (!ProjectAuthorized.ManageRoles(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')

--- a/apps/server/src/resources/project-service/router.spec.ts
+++ b/apps/server/src/resources/project-service/router.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { PROJECT_PERMS, projectServiceContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, PROJECT_PERMS, projectServiceContract } from '@cpn-console/shared'
 import { faker } from '@faker-js/faker'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
@@ -21,7 +21,7 @@ describe('projectServiceRouter tests', () => {
   describe('getServices', () => {
     it('should return services for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetServicesMock.mockResolvedValueOnce([])
@@ -38,7 +38,7 @@ describe('projectServiceRouter tests', () => {
 
     it('should not return admin services for non admin', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetServicesMock.mockResolvedValueOnce([])
@@ -54,7 +54,7 @@ describe('projectServiceRouter tests', () => {
 
     it('should return services for admin', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.GUEST })
-      const user = getUserMockInfos(true, undefined, projectPerms)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetServicesMock.mockResolvedValueOnce([])
@@ -68,16 +68,16 @@ describe('projectServiceRouter tests', () => {
       expect(response.json()).toEqual([])
     })
 
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
         .get(projectServiceContract.getServices.path.replace(':projectId', projectId))
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
   })
 
@@ -86,7 +86,7 @@ describe('projectServiceRouter tests', () => {
 
     it('should update services for project manager', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateServicesMock.mockResolvedValueOnce(null)
@@ -102,7 +102,7 @@ describe('projectServiceRouter tests', () => {
 
     it('should update services for project admin', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE })
-      const user = getUserMockInfos(true, undefined, projectPerms)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateServicesMock.mockResolvedValueOnce(null)
@@ -116,9 +116,9 @@ describe('projectServiceRouter tests', () => {
       expect(response.statusCode).toEqual(204)
     })
 
-    it('should return 404 for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -126,12 +126,12 @@ describe('projectServiceRouter tests', () => {
         .body(updateData)
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -145,7 +145,7 @@ describe('projectServiceRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()

--- a/apps/server/src/resources/project-service/router.ts
+++ b/apps/server/src/resources/project-service/router.ts
@@ -2,15 +2,15 @@ import { AdminAuthorized, ProjectAuthorized, projectServiceContract } from '@cpn
 import { getProjectServices, updateProjectServices } from './business.js'
 import { serverInstance } from '@/app.js'
 import { authUser } from '@/utils/controller.js'
-import { Forbidden403, NotFound404 } from '@/utils/errors.js'
+import { Forbidden403 } from '@/utils/errors.js'
 
 export function projectServiceRouter() {
   return serverInstance.router(projectServiceContract, {
   // Récupérer les services d'un projet
     getServices: async ({ request: req, params: { projectId }, query }) => {
       const perms = await authUser(req, { id: projectId })
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions) && query.permissionTarget === 'admin') return new Forbidden403('Vous ne pouvez pas demander les paramètres admin')
+      if (!perms.projectPermissions && !ProjectAuthorized.Manage(perms)) return new Forbidden403()
+      if (query.permissionTarget === 'admin' && !AdminAuthorized.Manage(perms.adminPermissions)) return new Forbidden403('Vous ne pouvez pas demander les paramètres admin')
 
       const body = await getProjectServices(projectId, query.permissionTarget)
 
@@ -22,11 +22,11 @@ export function projectServiceRouter() {
 
     updateProjectServices: async ({ request: req, params: { projectId }, body }) => {
       const perms = await authUser(req, { id: projectId })
-      if (!ProjectAuthorized.Manage(perms)) return new NotFound404()
+      if (!ProjectAuthorized.Manage(perms) && !perms.projectPermissions) return new Forbidden403()
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
 
-      const allowedRoles: Array<'user' | 'admin'> = AdminAuthorized.isAdmin(perms.adminPermissions) ? ['user', 'admin'] : ['user']
+      const allowedRoles: Array<'user' | 'admin'> = AdminAuthorized.Manage(perms.adminPermissions) ? ['user', 'admin'] : ['user']
 
       const resBody = await updateProjectServices(projectId, body, allowedRoles)
       return {

--- a/apps/server/src/resources/project/router.spec.ts
+++ b/apps/server/src/resources/project/router.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProjectV2 } from '@cpn-console/shared'
-import { PROJECT_PERMS, projectContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, PROJECT_PERMS, projectContract } from '@cpn-console/shared'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
 import { getProjectMockInfos, getRandomRequestor, getUserMockInfos } from '../../utils/mocks.js'
@@ -61,7 +61,7 @@ describe('test projectContract', () => {
     // UPDATE
     it('on Update', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -70,13 +70,13 @@ describe('test projectContract', () => {
         .end()
 
       expect(businessUpdateMock).toHaveBeenCalledTimes(0)
-      expect(response.statusCode).toEqual(404)
-      expect(response.json()).toEqual({ message: 'Not Found' })
+      expect(response.statusCode).toEqual(403)
+      expect(response.json()).toEqual({ message: 'Forbidden' })
     })
 
     it('on Update without enough perms', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -92,7 +92,7 @@ describe('test projectContract', () => {
     // REPLAY
     it('on replay', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -100,14 +100,14 @@ describe('test projectContract', () => {
         .end()
 
       expect(businessSyncMock).toHaveBeenCalledTimes(0)
-      expect(response.statusCode).toEqual(404)
-      expect(response.json()).toEqual({ message: 'Not Found' })
+      expect(response.statusCode).toEqual(403)
+      expect(response.json()).toEqual({ message: 'Forbidden' })
     })
 
     // SECRETS
     it('on see secret', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -115,14 +115,14 @@ describe('test projectContract', () => {
         .end()
 
       expect(businessGetSecretsMock).toHaveBeenCalledTimes(0)
-      expect(response.statusCode).toEqual(404)
-      expect(response.json()).toEqual({ message: 'Not Found' })
+      expect(response.statusCode).toEqual(403)
+      expect(response.json()).toEqual({ message: 'Forbidden' })
     })
 
     // ARCHIVE
     it('on archive', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -130,15 +130,15 @@ describe('test projectContract', () => {
         .end()
 
       expect(businessDeleteMock).toHaveBeenCalledTimes(0)
-      expect(response.statusCode).toEqual(404)
-      expect(response.json()).toEqual({ message: 'Not Found' })
+      expect(response.statusCode).toEqual(403)
+      expect(response.json()).toEqual({ message: 'Forbidden' })
     })
   })
   describe('listProjects', () => {
     it('should return list of projects', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
-      const projects = []
+      const projects: any[] = []
       businessListMock.mockResolvedValueOnce(projects)
       const response = await app.inject()
         .get(projectContract.listProjects.path)
@@ -148,20 +148,53 @@ describe('test projectContract', () => {
       expect(response.json()).toEqual(projects)
       expect(response.statusCode).toEqual(200)
     })
-    it('should return 400 for non-admin with "all" filter', async () => {
-      const user = getUserMockInfos(false)
+    it('should return 403 for non-admin with "all" filter', async () => {
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
+      const projects: any[] = []
+      businessListMock.mockResolvedValueOnce(projects)
+
       const response = await app.inject()
-        .get(`${projectContract.listProjects.path}?filter=all`)
+        .get(projectContract.listProjects.path)
+        .query({ filter: 'all' })
         .end()
 
-      expect(response.statusCode).toEqual(400)
+      expect(businessListMock).toHaveBeenCalledTimes(0)
+      expect(response.statusCode).toEqual(403)
+    })
+
+    it('should return list of projects for admin', async () => {
+      const projects: any[] = []
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE)
+      authUserMock.mockResolvedValueOnce(user)
+      businessListMock.mockResolvedValueOnce(projects)
+
+      const response = await app.inject()
+        .get(projectContract.listProjects.path)
+        .query({ filter: 'all' })
+        .end()
+
+      expect(businessListMock).toHaveBeenCalledTimes(1)
+      expect(response.statusCode).toEqual(200)
+    })
+
+    it('should return 403 for unauthorized user', async () => {
+      const user = getUserMockInfos(0n)
+      authUserMock.mockResolvedValueOnce(user)
+
+      const response = await app.inject()
+        .post(projectContract.createProject.path)
+        .body(project)
+        .end()
+
+      expect(businessCreateMock).toHaveBeenCalledTimes(0)
+      expect(response.statusCode).toEqual(403)
     })
   })
 
   describe('createProject', () => {
     it('should create and return project for authorized user', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_PROJECTS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce({ id: projectId, ...project })
@@ -176,7 +209,7 @@ describe('test projectContract', () => {
     })
 
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_PROJECTS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -193,7 +226,7 @@ describe('test projectContract', () => {
     const projectUpdated: Partial<ProjectV2> = { description: faker.string.alpha({ length: 5 }) }
 
     it('should update and return project for authorized user', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce({ id: projectId, ...project, ...projectUpdated })
@@ -211,7 +244,7 @@ describe('test projectContract', () => {
       const userDetails = getRandomRequestor()
       const projectPerms = getProjectMockInfos({ projectOwnerId: faker.string.uuid(), projectPermissions: PROJECT_PERMS.MANAGE })
       const projectUpdated = { ownerId: faker.string.uuid(), description: faker.lorem.words() }
-      const user = getUserMockInfos(false, userDetails as UserDetails, projectPerms)
+      const user = getUserMockInfos(0n, userDetails as UserDetails, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce({ id: projectId, ...project, ...projectUpdated })
@@ -229,7 +262,7 @@ describe('test projectContract', () => {
       const requestor = getRandomRequestor()
       const projectPerms = getProjectMockInfos({ projectOwnerId: requestor.id, projectPermissions: PROJECT_PERMS.MANAGE })
       const projectUpdated = { ownerId: faker.string.uuid(), description: faker.lorem.words() }
-      const user = getUserMockInfos(false, requestor as UserDetails, projectPerms)
+      const user = getUserMockInfos(0n, requestor as UserDetails, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce({ id: projectId, ...project, ...projectUpdated })
@@ -244,7 +277,7 @@ describe('test projectContract', () => {
     })
 
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -260,7 +293,7 @@ describe('test projectContract', () => {
 
   describe('archiveProject', () => {
     it('should archive project for authorized user', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(null)
@@ -274,7 +307,7 @@ describe('test projectContract', () => {
     })
 
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -286,7 +319,7 @@ describe('test projectContract', () => {
     })
     it('should return projects data for admin', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -301,7 +334,7 @@ describe('test projectContract', () => {
   describe('getProjectSecrets', () => {
     it('should return project secrets for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.SEE_SECRETS })
-      const user = getUserMockInfos(true, undefined, projectPerms)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_PROJECTS, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const secrets = {}
@@ -317,7 +350,7 @@ describe('test projectContract', () => {
 
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE })
-      const user = getUserMockInfos(true, undefined, projectPerms)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_PROJECTS, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetSecretsMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -329,7 +362,7 @@ describe('test projectContract', () => {
     })
     it('should return 403 for unauthorized access to secrets', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -343,7 +376,7 @@ describe('test projectContract', () => {
   describe('replayHooksForProject', () => {
     it('should replay hooks for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE })
-      const user = getUserMockInfos(true, undefined, projectPerms)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_PROJECTS, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessSyncMock.mockResolvedValueOnce(null)
@@ -358,7 +391,7 @@ describe('test projectContract', () => {
 
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE })
-      const user = getUserMockInfos(true, undefined, projectPerms)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_PROJECTS, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessSyncMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -370,7 +403,7 @@ describe('test projectContract', () => {
     })
     it('should return 403 for unauthorized access to replay hooks', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
       const response = await app.inject()
         .put(projectContract.replayHooksForProject.path.replace(':projectId', projectId))
@@ -382,7 +415,7 @@ describe('test projectContract', () => {
 
   describe('getProjectsData', () => {
     it('should return projects data for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE)
       authUserMock.mockResolvedValueOnce(user)
 
       const data = ''
@@ -397,7 +430,7 @@ describe('test projectContract', () => {
     })
 
     it('should return 403 for non-admin user', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -411,7 +444,7 @@ describe('test projectContract', () => {
   describe('bulkActionProject', () => {
     it('should executebulk for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE })
-      const user = getUserMockInfos(true, undefined, projectPerms)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessSyncMock.mockResolvedValueOnce(null)
@@ -427,7 +460,7 @@ describe('test projectContract', () => {
 
     it('should return 403 for unauthorized access to bulk update', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_ENVIRONMENTS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
       const response = await app.inject()
         .post(projectContract.bulkActionProject.path)

--- a/apps/server/src/resources/project/router.ts
+++ b/apps/server/src/resources/project/router.ts
@@ -13,7 +13,7 @@ import {
 } from './business.js'
 import { serverInstance } from '@/app.js'
 import { authUser } from '@/utils/controller.js'
-import { BadRequest400, ErrorResType, Forbidden403, NotFound404, Unauthorized401 } from '@/utils/errors.js'
+import { ErrorResType, Forbidden403, NotFound404, Unauthorized401 } from '@/utils/errors.js'
 
 export function projectRouter() {
   return serverInstance.router(projectContract, {
@@ -26,8 +26,8 @@ export function projectRouter() {
       if (adminPermissions && !user) { // c'est donc un compte de service
         query.filter = 'all'
       }
-      if (query.filter === 'all' && !AdminAuthorized.isAdmin(adminPermissions)) {
-        return new BadRequest400('Seuls les admins avec les droits de visionnage des projets peuvent utiliser le filtre \'all\'')
+      if (query.filter === 'all' && !AdminAuthorized.Manage(adminPermissions)) {
+        return new Forbidden403('Seuls les admins avec les droits de visionnage des projets peuvent utiliser le filtre \'all\'')
       }
 
       body = await listProjects(
@@ -45,7 +45,6 @@ export function projectRouter() {
     getProjectSecrets: async ({ request: req, params }) => {
       const projectId = params.projectId
       const perms = await authUser(req, { id: projectId })
-      if (!perms.projectPermissions) return new NotFound404()
       if (!ProjectAuthorized.SeeSecrets(perms)) return new Forbidden403()
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
 
@@ -63,6 +62,8 @@ export function projectRouter() {
     createProject: async ({ request: req, body: data }) => {
       const perms = await authUser(req)
       if (perms.user?.type !== 'human') return new Unauthorized401('Cannot find requestor in database')
+      if (!AdminAuthorized.ManageProjects(perms.adminPermissions)) return new Forbidden403()
+
       const body = await createProject(data, perms.user, req.id)
 
       if (body instanceof ErrorResType) return body
@@ -77,17 +78,10 @@ export function projectRouter() {
     getProject: async ({ request: req, params }) => {
       const projectId = params.projectId
       const perms = await authUser(req, { id: projectId })
-      const isAdmin = AdminAuthorized.isAdmin(perms.adminPermissions)
 
       if (!perms.projectId) return new NotFound404()
-      if (!isAdmin) {
-        if (!perms.projectPermissions) {
-          return new NotFound404()
-        }
-        if (perms.projectStatus === 'archived') {
-          return new NotFound404()
-        }
-      }
+      if (!perms.projectPermissions && !AdminAuthorized.Manage(perms.adminPermissions)) return new Forbidden403()
+      if (perms.projectStatus === 'archived') return new NotFound404()
 
       const body = await getProject(projectId)
 
@@ -103,22 +97,18 @@ export function projectRouter() {
       const perms = await authUser(req, { id: projectId })
 
       if (!perms.user) return new Unauthorized401('Cannot find requestor in database')
-      const isAdmin = AdminAuthorized.isAdmin(perms.adminPermissions)
-      const isOwner = perms.projectOwnerId === perms.user.id
+      if (!ProjectAuthorized.Manage(perms)) return new Forbidden403()
 
-      if (!perms.projectPermissions && !isAdmin) return new NotFound404()
-      if (!isAdmin) { // filtrage des clés par niveau de permissions
+      const isAdmin = AdminAuthorized.Manage(perms.adminPermissions)
+      const isOwner = perms.projectOwnerId === perms.user.id
+      if (!isAdmin) {
         delete data.locked
-        if (!isOwner) {
-          delete data.ownerId // impossible de toucher à cette clé
-        }
+        if (!isOwner) delete data.ownerId // impossible de toucher à cette clé
       }
       if (perms.projectLocked) {
         if (!isAdmin) return new Forbidden403('Le projet est verrouillé')
         if (data.locked !== false) return new Forbidden403('Veuillez déverrouiler le projet pour le mettre à jour')
       }
-
-      if (!ProjectAuthorized.Manage(perms)) return new Forbidden403()
 
       const body = await updateProject(data, projectId, perms.user, req.id)
 
@@ -133,9 +123,7 @@ export function projectRouter() {
     replayHooksForProject: async ({ request: req, params }) => {
       const projectId = params.projectId
       const perms = await authUser(req, { id: projectId })
-      const isAdmin = AdminAuthorized.isAdmin(perms.adminPermissions)
 
-      if (!perms.projectPermissions && !isAdmin) return new NotFound404()
       if (!ProjectAuthorized.ReplayHooks(perms)) return new Forbidden403()
 
       const body = await replayHooks({
@@ -156,10 +144,8 @@ export function projectRouter() {
     archiveProject: async ({ request: req, params }) => {
       const projectId = params.projectId
       const perms = await authUser(req, { id: projectId })
-      const isAdmin = AdminAuthorized.isAdmin(perms.adminPermissions)
 
       if (!perms.user) return new Unauthorized401('Cannot find requestor in database')
-      if (!perms.projectPermissions && !isAdmin) return new NotFound404()
       if (!ProjectAuthorized.Manage(perms)) return new Forbidden403()
 
       const body = await archiveProject(projectId, perms.user, req.id)
@@ -173,7 +159,8 @@ export function projectRouter() {
     // Récupérer les données de tous les projets pour export
     getProjectsData: async ({ request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.Manage(perms.adminPermissions)) return new Forbidden403()
       const body = await generateProjectsData()
 
       return {
@@ -186,7 +173,7 @@ export function projectRouter() {
       const perms = await authUser(req)
 
       if (!perms.user) return new Unauthorized401('Cannot find requestor in database')
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+      if (!AdminAuthorized.Manage(perms.adminPermissions)) return new Forbidden403()
 
       await bulkActionProject(body, perms.user, req.id)
 

--- a/apps/server/src/resources/repository/router.spec.ts
+++ b/apps/server/src/resources/repository/router.spec.ts
@@ -35,7 +35,7 @@ describe('repositoryRouter tests', () => {
   describe('listRepositories', () => {
     it('should return repositories for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetProjectRepositoriesMock.mockResolvedValueOnce([])
@@ -50,9 +50,9 @@ describe('repositoryRouter tests', () => {
       expect(response.statusCode).toEqual(200)
     })
 
-    it('should return empty for unauthorized user', async () => {
+    it('should return 403 for unauthorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.REPLAY_HOOKS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -61,14 +61,14 @@ describe('repositoryRouter tests', () => {
         .end()
 
       expect(businessGetProjectRepositoriesMock).toHaveBeenCalledTimes(0)
-      expect(response.json()).toEqual([])
+      expect(response.statusCode).toEqual(403)
     })
   })
 
   describe('syncRepository', () => {
     it('should synchronize repository for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessSyncMock.mockResolvedValueOnce(null)
@@ -84,7 +84,7 @@ describe('repositoryRouter tests', () => {
 
     it('should return 403 for forbidden sync attempt', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.SEE_SECRETS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -97,7 +97,7 @@ describe('repositoryRouter tests', () => {
 
     it('should return 403 for archived project', async () => {
       const projectPerms = getProjectMockInfos({ projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -109,9 +109,9 @@ describe('repositoryRouter tests', () => {
       expect(response.json()).toEqual({ message: 'Le projet est archivé' })
     })
 
-    it('should return 404 for non-member', async () => {
+    it('should return 403 for non-member', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -119,12 +119,12 @@ describe('repositoryRouter tests', () => {
         .body({ branchName: 'main', syncAllBranches: false })
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessSyncMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -140,7 +140,7 @@ describe('repositoryRouter tests', () => {
   describe('createRepository', () => {
     it('should create repository for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce({ id: repositoryId, ...repositoryData, ...atDates })
@@ -155,7 +155,7 @@ describe('repositoryRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -169,7 +169,7 @@ describe('repositoryRouter tests', () => {
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -181,9 +181,9 @@ describe('repositoryRouter tests', () => {
       expect(response.statusCode).toEqual(403)
     })
 
-    it('should return 404 for non-member', async () => {
+    it('should return 403 for non-member', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -191,11 +191,11 @@ describe('repositoryRouter tests', () => {
         .body(repositoryData)
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
     it('should return 403 for insuficient permissions', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -207,7 +207,7 @@ describe('repositoryRouter tests', () => {
     })
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -224,7 +224,7 @@ describe('repositoryRouter tests', () => {
     const repoUpdateData = { isInfra: true }
     it('should update repository for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce({ id: repositoryId, ...repositoryData, ...repoUpdateData, ...atDates })
@@ -239,7 +239,7 @@ describe('repositoryRouter tests', () => {
 
     it('should update repository and drop creds if is not private', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const repoUpdateData = { isPrivate: false, externalUserName: 'test' }
@@ -256,7 +256,7 @@ describe('repositoryRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -270,7 +270,7 @@ describe('repositoryRouter tests', () => {
 
     it('should return 403 if not enough permissions', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -281,9 +281,9 @@ describe('repositoryRouter tests', () => {
       expect(response.statusCode).toEqual(403)
     })
 
-    it('should return 404 if non-member', async () => {
+    it('should return 403 if non-member', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -291,12 +291,12 @@ describe('repositoryRouter tests', () => {
         .body(repoUpdateData)
         .end()
 
-      expect(response.statusCode).toEqual(404)
+      expect(response.statusCode).toEqual(403)
     })
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -310,7 +310,7 @@ describe('repositoryRouter tests', () => {
 
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -327,7 +327,7 @@ describe('repositoryRouter tests', () => {
   describe('deleteRepository', () => {
     it('should delete repository for authorized user', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(null)
@@ -340,7 +340,7 @@ describe('repositoryRouter tests', () => {
 
     it('should return 403 if project is locked', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES, projectLocked: true })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -353,7 +353,7 @@ describe('repositoryRouter tests', () => {
 
     it('should return 403 if project is archived', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES, projectStatus: 'archived' })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -364,20 +364,9 @@ describe('repositoryRouter tests', () => {
       expect(response.statusCode).toEqual(403)
     })
 
-    it('should return 404 for non-member', async () => {
+    it('should return 403 for non-member', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: 0n })
-      const user = getUserMockInfos(false, undefined, projectPerms)
-      authUserMock.mockResolvedValueOnce(user)
-
-      const response = await app.inject()
-        .delete(repositoryContract.deleteRepository.path.replace(':repositoryId', repositoryId))
-        .end()
-
-      expect(response.statusCode).toEqual(404)
-    })
-    it('should return 403 if not enough privilege', async () => {
-      const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_MEMBERS })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -386,9 +375,22 @@ describe('repositoryRouter tests', () => {
 
       expect(response.statusCode).toEqual(403)
     })
+
+    it('should return 403 if not enough privilege', async () => {
+      const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.LIST_MEMBERS })
+      const user = getUserMockInfos(0n, undefined, projectPerms)
+      authUserMock.mockResolvedValueOnce(user)
+
+      const response = await app.inject()
+        .delete(repositoryContract.deleteRepository.path.replace(':repositoryId', repositoryId))
+        .end()
+
+      expect(response.statusCode).toEqual(403)
+    })
+
     it('should pass business error', async () => {
       const projectPerms = getProjectMockInfos({ projectPermissions: PROJECT_PERMS.MANAGE_REPOSITORIES })
-      const user = getUserMockInfos(false, undefined, projectPerms)
+      const user = getUserMockInfos(0n, undefined, projectPerms)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(new BadRequest400('une erreur'))

--- a/apps/server/src/resources/repository/router.ts
+++ b/apps/server/src/resources/repository/router.ts
@@ -1,4 +1,4 @@
-import { AdminAuthorized, ProjectAuthorized, fakeToken, repositoryContract } from '@cpn-console/shared'
+import { ProjectAuthorized, fakeToken, repositoryContract } from '@cpn-console/shared'
 import {
   createRepository,
   deleteRepository,
@@ -10,7 +10,7 @@ import { serverInstance } from '@/app.js'
 
 import { filterObjectByKeys } from '@/utils/queries-tools.js'
 import { authUser } from '@/utils/controller.js'
-import { ErrorResType, Forbidden403, NotFound404, Unauthorized401 } from '@/utils/errors.js'
+import { ErrorResType, Forbidden403, Unauthorized401 } from '@/utils/errors.js'
 
 export function repositoryRouter() {
   return serverInstance.router(repositoryContract, {
@@ -19,9 +19,8 @@ export function repositoryRouter() {
       const projectId = query.projectId
       const perms = await authUser(req, { id: projectId })
 
-      const body = ProjectAuthorized.ListRepositories(perms)
-        ? await getProjectRepositories(projectId)
-        : []
+      if (!ProjectAuthorized.ListRepositories(perms)) return new Forbidden403()
+      const body = await getProjectRepositories(projectId)
 
       return {
         status: 200,
@@ -34,7 +33,6 @@ export function repositoryRouter() {
       const { repositoryId } = params
       const perms = await authUser(req, { repositoryId })
       if (!perms.user) return new Unauthorized401('Require to be requested from user not api key')
-      if (!perms.projectPermissions) return new NotFound404()
       if (!ProjectAuthorized.ManageRepositories(perms)) return new Forbidden403()
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
 
@@ -55,7 +53,6 @@ export function repositoryRouter() {
       const perms = await authUser(req, { id: projectId })
 
       if (!perms.user) return new Unauthorized401('Require to be requested from user not api key')
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
       if (!ProjectAuthorized.ManageRepositories(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
@@ -75,7 +72,6 @@ export function repositoryRouter() {
       const perms = await authUser(req, { repositoryId })
 
       if (!perms.user) return new Unauthorized401('Require to be requested from user not api key')
-      if (!perms.projectPermissions && !AdminAuthorized.isAdmin(perms.adminPermissions)) return new NotFound404()
       if (!ProjectAuthorized.ManageRepositories(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')
@@ -116,7 +112,6 @@ export function repositoryRouter() {
       const perms = await authUser(req, { repositoryId })
 
       if (!perms.user) return new Unauthorized401('Require to be requested from user not api key')
-      if (!perms.projectPermissions) return new NotFound404()
       if (!ProjectAuthorized.ManageRepositories(perms)) return new Forbidden403()
       if (perms.projectLocked) return new Forbidden403('Le projet est verrouillé')
       if (perms.projectStatus === 'archived') return new Forbidden403('Le projet est archivé')

--- a/apps/server/src/resources/service-chain/router.spec.ts
+++ b/apps/server/src/resources/service-chain/router.spec.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ServiceChain, ServiceChainDetails, ServiceChainFlows } from '@cpn-console/shared'
 import {
+  ADMIN_PERMS,
   ServiceChainDetailsSchema,
   ServiceChainFlowsSchema,
   ServiceChainListSchema,
@@ -34,7 +35,7 @@ describe('test ServiceChainContract', () => {
   })
   describe('listServiceChains', () => {
     it('as non admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -48,7 +49,7 @@ describe('test ServiceChainContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('as admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_SYSTEM)
       const serviceChainList = faker.helpers.multiple<ServiceChain>(() => ({
         id: faker.string.uuid(),
         state: faker.helpers.arrayElement(serviceChainStateEnum),
@@ -108,7 +109,7 @@ describe('test ServiceChainContract', () => {
           .map(e => `${e}/32`), // We want a CIDR here
         sslOutgoing: faker.datatype.boolean(),
       }
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_SYSTEM)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetServiceChainDetailsMock.mockResolvedValueOnce(serviceChainDetails)
@@ -129,7 +130,7 @@ describe('test ServiceChainContract', () => {
       expect(businessGetServiceChainDetailsMock).toHaveBeenCalledTimes(1)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app
@@ -149,7 +150,7 @@ describe('test ServiceChainContract', () => {
 
   describe('retryServiceChain', () => {
     it('should return 204', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_SYSTEM)
       authUserMock.mockResolvedValueOnce(user)
 
       businessRetryServiceChainMock.mockResolvedValueOnce({
@@ -171,7 +172,7 @@ describe('test ServiceChainContract', () => {
       expect(response.statusCode).toEqual(204)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app
@@ -191,7 +192,7 @@ describe('test ServiceChainContract', () => {
 
   describe('validateServiceChain', () => {
     it('should return 204', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_SYSTEM)
       authUserMock.mockResolvedValueOnce(user)
 
       businessValidateServiceChainMock.mockResolvedValueOnce({
@@ -213,7 +214,7 @@ describe('test ServiceChainContract', () => {
       expect(response.statusCode).toEqual(204)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app
@@ -265,7 +266,7 @@ describe('test ServiceChainContract', () => {
           updatedAt: faker.date.recent(),
         },
       }
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_SYSTEM)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetServiceChainsFlowsMock.mockResolvedValueOnce(serviceChainFlows)
@@ -286,7 +287,7 @@ describe('test ServiceChainContract', () => {
       expect(businessGetServiceChainsFlowsMock).toHaveBeenCalledTimes(1)
     })
     it('should return 403 if not admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app

--- a/apps/server/src/resources/service-chain/router.ts
+++ b/apps/server/src/resources/service-chain/router.ts
@@ -18,7 +18,7 @@ export function serviceChainRouter() {
       const { adminPermissions } = await authUser(req)
 
       let body: AsyncReturnType<typeof listServiceChainsBusiness> = []
-      if (AdminAuthorized.isAdmin(adminPermissions)) {
+      if (AdminAuthorized.ListSystem(adminPermissions)) {
         body = await listServiceChainsBusiness()
       }
 
@@ -30,7 +30,8 @@ export function serviceChainRouter() {
 
     getServiceChainDetails: async ({ params, request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions))
+
+      if (!AdminAuthorized.ListSystem(perms.adminPermissions))
         return new Forbidden403()
 
       const serviceChainId = params.serviceChainId
@@ -45,7 +46,8 @@ export function serviceChainRouter() {
 
     retryServiceChain: async ({ params, request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions))
+
+      if (!AdminAuthorized.ManageSystem(perms.adminPermissions))
         return new Forbidden403()
 
       const serviceChainId = params.serviceChainId
@@ -59,7 +61,8 @@ export function serviceChainRouter() {
 
     validateServiceChain: async ({ params, request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions))
+
+      if (!AdminAuthorized.ManageSystem(perms.adminPermissions))
         return new Forbidden403()
 
       const serviceChainId = params.validationId
@@ -73,7 +76,8 @@ export function serviceChainRouter() {
 
     getServiceChainFlows: async ({ params, request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions))
+
+      if (!AdminAuthorized.ListSystem(perms.adminPermissions))
         return new Forbidden403()
 
       const serviceChainId = params.serviceChainId

--- a/apps/server/src/resources/service-monitor/router.spec.ts
+++ b/apps/server/src/resources/service-monitor/router.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { MonitorStatus, serviceContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, MonitorStatus, serviceContract } from '@cpn-console/shared'
 import type { ServiceStatus } from '@cpn-console/hooks'
 import app from '../../app.js'
 import * as business from './business.js'
@@ -17,7 +17,7 @@ describe('test serviceContract', () => {
   const servicesComplete: ServiceStatus[] = [{ cause: 'error', interval: 1, lastUpdateTimestamp: 1, message: 'OK', name: 'A service', status: MonitorStatus.OK }]
 
   it('should return complete services, with cause', async () => {
-    const user = getUserMockInfos(true)
+    const user = getUserMockInfos(ADMIN_PERMS.LIST_SYSTEM)
 
     authUserMock.mockResolvedValueOnce(user)
     businessCheckMock.mockReturnValue(servicesComplete)
@@ -30,7 +30,7 @@ describe('test serviceContract', () => {
   })
 
   it('should not return complete services, forbidden', async () => {
-    const user = getUserMockInfos(false)
+    const user = getUserMockInfos(0n)
 
     authUserMock.mockResolvedValueOnce(user)
     businessCheckMock.mockReturnValue(servicesComplete)
@@ -52,7 +52,7 @@ describe('test serviceContract', () => {
   })
 
   it('should refresh services', async () => {
-    const user = getUserMockInfos(true)
+    const user = getUserMockInfos(ADMIN_PERMS.MANAGE_SYSTEM)
 
     authUserMock.mockResolvedValueOnce(user)
     businessRefreshMock.mockResolvedValue(servicesComplete)
@@ -65,7 +65,7 @@ describe('test serviceContract', () => {
   })
 
   it('should refresh services, cause forbidden', async () => {
-    const user = getUserMockInfos(false)
+    const user = getUserMockInfos(0n)
 
     authUserMock.mockResolvedValueOnce(user)
     businessRefreshMock.mockResolvedValue(servicesComplete)

--- a/apps/server/src/resources/service-monitor/router.ts
+++ b/apps/server/src/resources/service-monitor/router.ts
@@ -18,7 +18,7 @@ export function serviceMonitorRouter() {
     getCompleteServiceHealth: async ({ request: req }) => {
       const { adminPermissions } = await authUser(req)
 
-      if (!AdminAuthorized.isAdmin(adminPermissions)) return new Forbidden403()
+      if (!AdminAuthorized.ListSystem(adminPermissions)) return new Forbidden403()
       const serviceData = checkServicesHealth()
 
       return {
@@ -29,7 +29,8 @@ export function serviceMonitorRouter() {
 
     refreshServiceHealth: async ({ request: req }) => {
       const { adminPermissions } = await authUser(req)
-      if (!AdminAuthorized.isAdmin(adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageSystem(adminPermissions)) return new Forbidden403()
 
       await refreshServicesHealth()
       const serviceData = checkServicesHealth()

--- a/apps/server/src/resources/stage/router.spec.ts
+++ b/apps/server/src/resources/stage/router.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Stage } from '@cpn-console/shared'
-import { stageContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, stageContract } from '@cpn-console/shared'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
 import { getUserMockInfos } from '../../utils/mocks.js'
@@ -23,7 +23,9 @@ describe('test stageContract', () => {
 
   describe('listStages', () => {
     it('should return list of stages', async () => {
-      const stages = []
+      const stages: any[] = []
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_STAGES)
+      authUserMock.mockResolvedValueOnce(user)
       businessListMock.mockResolvedValueOnce(stages)
 
       const response = await app.inject()
@@ -38,8 +40,8 @@ describe('test stageContract', () => {
 
   describe('getStageEnvironments', () => {
     it('should return stage environments for admin', async () => {
-      const environments = []
-      const user = getUserMockInfos(true)
+      const environments: any = []
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_STAGES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetEnvironmentsMock.mockResolvedValueOnce(environments)
@@ -52,7 +54,7 @@ describe('test stageContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_STAGES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessGetEnvironmentsMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -63,7 +65,7 @@ describe('test stageContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -79,7 +81,7 @@ describe('test stageContract', () => {
     const stage: Stage = { id: faker.string.uuid(), name: faker.string.alpha({ length: 5 }), clusterIds: [] }
 
     it('should create and return stage for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_STAGES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce(stage)
@@ -93,7 +95,7 @@ describe('test stageContract', () => {
       expect(response.statusCode).toEqual(201)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_STAGES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -105,7 +107,7 @@ describe('test stageContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -123,7 +125,7 @@ describe('test stageContract', () => {
     const stage = { name: faker.string.alpha({ length: 5 }), clusterIds: [] }
 
     it('should update and return stage for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_STAGES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce({ id: stageId, ...stage })
@@ -137,7 +139,7 @@ describe('test stageContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_STAGES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -149,7 +151,7 @@ describe('test stageContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -164,7 +166,7 @@ describe('test stageContract', () => {
 
   describe('deleteStage', () => {
     it('should delete stage for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_STAGES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(null)
@@ -177,7 +179,7 @@ describe('test stageContract', () => {
       expect(response.statusCode).toEqual(204)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_STAGES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -188,7 +190,7 @@ describe('test stageContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()

--- a/apps/server/src/resources/stage/router.ts
+++ b/apps/server/src/resources/stage/router.ts
@@ -27,7 +27,8 @@ export function stageRouter() {
     // Récupérer les environnements associés au stage
     getStageEnvironments: async ({ request: req, params }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ListStages(perms.adminPermissions)) return new Forbidden403()
 
       const stageId = params.stageId
       const body = await getStageAssociatedEnvironments(stageId)
@@ -42,7 +43,8 @@ export function stageRouter() {
     // Créer un stage
     createStage: async ({ request: req, body: data }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageStages(perms.adminPermissions)) return new Forbidden403()
 
       const body = await createStage(data)
       if (body instanceof ErrorResType) return body
@@ -56,7 +58,8 @@ export function stageRouter() {
     // Modifier une association stage / clusters
     updateStage: async ({ request: req, params, body: data }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageStages(perms.adminPermissions)) return new Forbidden403()
 
       const stageId = params.stageId
 
@@ -72,7 +75,8 @@ export function stageRouter() {
     // Supprimer un stage
     deleteStage: async ({ request: req, params }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageStages(perms.adminPermissions)) return new Forbidden403()
 
       const stageId = params.stageId
 

--- a/apps/server/src/resources/system/config/router.spec.ts
+++ b/apps/server/src/resources/system/config/router.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { systemPluginContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, systemPluginContract } from '@cpn-console/shared'
 import app from '../../../app.js'
 import * as utilsController from '../../../utils/controller.js'
 import { getUserMockInfos } from '../../../utils/mocks.js'
@@ -18,8 +18,8 @@ describe('test systemPluginContract', () => {
 
   describe('getPluginsConfig', () => {
     it('should return plugin configurations for authorized users', async () => {
-      const user = getUserMockInfos(true)
-      const pluginsConfig = []
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_SYSTEM)
+      const pluginsConfig: any[] = []
 
       authUserMock.mockResolvedValueOnce(user)
       businessGetPluginsConfigMock.mockResolvedValueOnce(pluginsConfig)
@@ -34,7 +34,7 @@ describe('test systemPluginContract', () => {
     })
 
     it('should return 403 for unauthorized users', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -50,7 +50,7 @@ describe('test systemPluginContract', () => {
   describe('updatePluginsConfig', () => {
     const newConfig = { plugin1: { keyId: 'value' } }
     it('should update plugin configurations for authorized users', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_SYSTEM)
 
       authUserMock.mockResolvedValueOnce(user)
       businessUpdatePluginConfigMock.mockResolvedValueOnce(newConfig)
@@ -65,7 +65,7 @@ describe('test systemPluginContract', () => {
     })
 
     it('should return 403 for unauthorized users', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 
@@ -79,7 +79,7 @@ describe('test systemPluginContract', () => {
     })
 
     it('should return error if business logic fails', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_SYSTEM)
 
       authUserMock.mockResolvedValueOnce(user)
       businessUpdatePluginConfigMock.mockResolvedValueOnce(new BadRequest400('une erreur'))

--- a/apps/server/src/resources/system/config/router.ts
+++ b/apps/server/src/resources/system/config/router.ts
@@ -9,7 +9,8 @@ export function pluginConfigRouter() {
   // Récupérer les configurations plugins
     getPluginsConfig: async ({ request: req }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ListSystem(perms.adminPermissions)) return new Forbidden403()
 
       const services = await getPluginsConfig()
 
@@ -22,7 +23,8 @@ export function pluginConfigRouter() {
     // Mettre à jour les configurations plugins
     updatePluginsConfig: async ({ request: req, body }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageSystem(perms.adminPermissions)) return new Forbidden403()
 
       const resBody = await updatePluginConfig(body)
       if (resBody instanceof ErrorResType) return resBody

--- a/apps/server/src/resources/system/settings/router.spec.ts
+++ b/apps/server/src/resources/system/settings/router.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { systemSettingsContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, systemSettingsContract } from '@cpn-console/shared'
 import app from '../../../app.js'
 import * as utilsController from '../../../utils/controller.js'
 import { getUserMockInfos } from '../../../utils/mocks.js'
@@ -17,8 +17,8 @@ describe('test systemSettingsContract', () => {
 
   describe('listSystemSettings', () => {
     it('should return plugin configurations for authorized users', async () => {
-      const user = getUserMockInfos(true)
-      const systemSettings = []
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_SYSTEM)
+      const systemSettings: any[] = []
 
       authUserMock.mockResolvedValueOnce(user)
       businessGetSystemSettingsMock.mockResolvedValueOnce(systemSettings)
@@ -31,12 +31,27 @@ describe('test systemSettingsContract', () => {
       expect(response.json()).toEqual(systemSettings)
       expect(response.statusCode).toEqual(200)
     })
+
+    it('should return 200 for anybody', async () => {
+      const user = getUserMockInfos(0n)
+      const systemSettings: any[] = []
+
+      authUserMock.mockResolvedValueOnce(user)
+      businessGetSystemSettingsMock.mockResolvedValueOnce(systemSettings)
+
+      const response = await app.inject()
+        .get(systemSettingsContract.listSystemSettings.path)
+        .end()
+
+      expect(businessGetSystemSettingsMock).toHaveBeenCalledTimes(1)
+      expect(response.statusCode).toEqual(200)
+    })
   })
 
   describe('upsertSystemSetting', () => {
     const newConfig = { key: 'key1', value: 'value1' }
     it('should update system setting, authorized users', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_SYSTEM)
 
       authUserMock.mockResolvedValueOnce(user)
       businessUpsertSystemSettingMock.mockResolvedValueOnce(newConfig)
@@ -51,7 +66,7 @@ describe('test systemSettingsContract', () => {
     })
 
     it('should return 403 for unauthorized users', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
 
       authUserMock.mockResolvedValueOnce(user)
 

--- a/apps/server/src/resources/system/settings/router.ts
+++ b/apps/server/src/resources/system/settings/router.ts
@@ -17,7 +17,8 @@ export function systemSettingsRouter() {
 
     upsertSystemSetting: async ({ request: req, body: data }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageSystem(perms.adminPermissions)) return new Forbidden403()
 
       const systemSetting = await upsertSystemSetting(data)
 

--- a/apps/server/src/resources/user/router.spec.ts
+++ b/apps/server/src/resources/user/router.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { userContract } from '@cpn-console/shared'
+import { userContract, ADMIN_PERMS } from '@cpn-console/shared'
 import { faker } from '@faker-js/faker'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
@@ -20,7 +20,7 @@ describe('test userContract', () => {
 
   describe('getMatchingUsers', () => {
     it('should return matching users', async () => {
-      const usersMatching = []
+      const usersMatching: any[] = []
       businessGetMatchingMock.mockResolvedValueOnce(usersMatching)
 
       const response = await app.inject()
@@ -43,10 +43,13 @@ describe('test userContract', () => {
         updatedAt: (new Date()).toISOString(),
         email: faker.internet.email(),
         firstName: faker.person.firstName(),
-        type: 'human',
+        type: 'human' as const,
         lastName: faker.person.lastName(),
+        lastLogin: (new Date()).toISOString(),
       }
+      // @ts-ignore
       setRequestor(user)
+      // @ts-ignore
       businessLogViaSessionMock.mockResolvedValueOnce({ user, adminPerms: 0n })
 
       const response = await app.inject()
@@ -61,8 +64,8 @@ describe('test userContract', () => {
 
   describe('getAllUsers', () => {
     it('should return all users for admin', async () => {
-      const user = getUserMockInfos(true)
-      const users = []
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_USERS)
+      const users: any[] = []
       authUserMock.mockResolvedValueOnce(user)
       businessGetUsersMock.mockResolvedValueOnce(users)
 
@@ -77,7 +80,7 @@ describe('test userContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ROLES)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -108,7 +111,7 @@ describe('test userContract', () => {
     }]
 
     it('should patch and return users for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_USERS)
       authUserMock.mockResolvedValueOnce(user)
 
       businessPatchMock.mockResolvedValueOnce(usersReturn)
@@ -123,7 +126,7 @@ describe('test userContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ROLES)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()

--- a/apps/server/src/resources/user/router.ts
+++ b/apps/server/src/resources/user/router.ts
@@ -37,7 +37,7 @@ export function userRouter() {
     getAllUsers: async ({ request: req, query: { relationType, ...query } }) => {
       const perms = await authUser(req)
 
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+      if (!AdminAuthorized.ManageUsers(perms.adminPermissions)) return new Forbidden403()
 
       const body = await getUsers(query, relationType)
       if (body instanceof ErrorResType) return body
@@ -50,7 +50,8 @@ export function userRouter() {
 
     patchUsers: async ({ request: req, body }) => {
       const perms = await authUser(req)
-      if (!AdminAuthorized.isAdmin(perms.adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageUsers(perms.adminPermissions)) return new Forbidden403()
 
       const users = await patchUsers(body)
 

--- a/apps/server/src/resources/zone/router.spec.ts
+++ b/apps/server/src/resources/zone/router.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Zone } from '@cpn-console/shared'
-import { zoneContract } from '@cpn-console/shared'
+import { ADMIN_PERMS, zoneContract } from '@cpn-console/shared'
 import app from '../../app.js'
 import * as utilsController from '../../utils/controller.js'
 import { getUserMockInfos } from '../../utils/mocks.js'
@@ -22,7 +22,9 @@ describe('test zoneContract', () => {
 
   describe('listZones', () => {
     it('should return list of zones', async () => {
-      const zones = []
+      const zones: any[] = []
+      const user = getUserMockInfos(ADMIN_PERMS.LIST_ZONES)
+      authUserMock.mockResolvedValueOnce(user)
       businessListMock.mockResolvedValueOnce(zones)
 
       const response = await app.inject()
@@ -39,7 +41,7 @@ describe('test zoneContract', () => {
     const zone = { id: faker.string.uuid(), label: faker.string.alpha({ length: 5 }), argocdUrl: faker.internet.url(), slug: faker.string.alpha({ length: 5, casing: 'lower' }), description: '' }
 
     it('should create and return zone for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ZONES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce(zone)
@@ -53,7 +55,7 @@ describe('test zoneContract', () => {
       expect(response.statusCode).toEqual(201)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ZONES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessCreateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -65,7 +67,7 @@ describe('test zoneContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -83,7 +85,7 @@ describe('test zoneContract', () => {
     const zone: Omit<Zone, 'id'> = { label: faker.string.alpha({ length: 5 }), slug: faker.string.alpha({ length: 5, casing: 'lower' }), argocdUrl: faker.internet.url(), description: '' }
 
     it('should update and return zone for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ZONES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce({ id: zoneId, ...zone })
@@ -97,7 +99,7 @@ describe('test zoneContract', () => {
       expect(response.statusCode).toEqual(200)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ZONES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessUpdateMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -109,7 +111,7 @@ describe('test zoneContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()
@@ -124,7 +126,7 @@ describe('test zoneContract', () => {
 
   describe('deleteZone', () => {
     it('should delete zone for admin', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ZONES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(null)
@@ -137,7 +139,7 @@ describe('test zoneContract', () => {
       expect(response.statusCode).toEqual(204)
     })
     it('should pass business error', async () => {
-      const user = getUserMockInfos(true)
+      const user = getUserMockInfos(ADMIN_PERMS.MANAGE_ZONES)
       authUserMock.mockResolvedValueOnce(user)
 
       businessDeleteMock.mockResolvedValueOnce(new BadRequest400('une erreur'))
@@ -148,7 +150,7 @@ describe('test zoneContract', () => {
       expect(response.statusCode).toEqual(400)
     })
     it('should return 403 for non-admin', async () => {
-      const user = getUserMockInfos(false)
+      const user = getUserMockInfos(0n)
       authUserMock.mockResolvedValueOnce(user)
 
       const response = await app.inject()

--- a/apps/server/src/resources/zone/router.ts
+++ b/apps/server/src/resources/zone/router.ts
@@ -18,7 +18,8 @@ export function zoneRouter() {
 
     createZone: async ({ request: req, body: data }) => {
       const { user, adminPermissions } = await authUser(req)
-      if (!AdminAuthorized.isAdmin(adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageZones(adminPermissions)) return new Forbidden403()
       if (!user) return new Unauthorized401('Require to be requested from user not api key')
 
       const body = await createZone(data, user.id, req.id)
@@ -32,7 +33,8 @@ export function zoneRouter() {
 
     updateZone: async ({ request: req, params, body: data }) => {
       const { user, adminPermissions } = await authUser(req)
-      if (!AdminAuthorized.isAdmin(adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageZones(adminPermissions)) return new Forbidden403()
       if (!user) return new Unauthorized401('Require to be requested from user not api key')
 
       const zoneId = params.zoneId
@@ -48,7 +50,8 @@ export function zoneRouter() {
 
     deleteZone: async ({ request: req, params }) => {
       const { user, adminPermissions } = await authUser(req)
-      if (!AdminAuthorized.isAdmin(adminPermissions)) return new Forbidden403()
+
+      if (!AdminAuthorized.ManageZones(adminPermissions)) return new Forbidden403()
       if (!user) return new Unauthorized401('Require to be requested from user not api key')
       const zoneId = params.zoneId
 

--- a/apps/server/src/utils/mocks.ts
+++ b/apps/server/src/utils/mocks.ts
@@ -18,8 +18,8 @@ export function getRequestor() {
 }
 
 export async function mockSessionPlugin() {
-  const sessionPlugin = (app, opt, next) => {
-    app.addHook('onRequest', (req, res, next) => {
+  const sessionPlugin = (app: any, opt: any, next: any) => {
+    app.addHook('onRequest', (req: any, res: any, next: any) => {
       req.session = { user: getRequestor() }
       next()
     })
@@ -126,11 +126,11 @@ export function getRandomRequestor(user?: Requestor): Partial<UserDetails> {
   }
 }
 
-export function getUserMockInfos(isAdmin: boolean, user?: UserDetails): utilsController.UserProfile & utilsController.ProjectPermState
-export function getUserMockInfos(isAdmin: boolean, user?: UserDetails, project?: utilsController.ProjectPermState): utilsController.UserProjectProfile & utilsController.ProjectPermState
-export function getUserMockInfos(isAdmin: boolean, user = getRandomRequestor(), project?: utilsController.ProjectPermState): utilsController.UserProfile | utilsController.UserProjectProfile {
+export function getUserMockInfos(adminPermissions?: bigint, user?: UserDetails): utilsController.UserProfile & utilsController.ProjectPermState
+export function getUserMockInfos(adminPermissions?: bigint, user?: UserDetails, project?: utilsController.ProjectPermState): utilsController.UserProjectProfile & utilsController.ProjectPermState
+export function getUserMockInfos(adminPermissions: bigint = 0n, user = getRandomRequestor(), project?: utilsController.ProjectPermState): utilsController.UserProfile | utilsController.UserProjectProfile {
   return {
-    adminPermissions: isAdmin ? 2n : 0n,
+    adminPermissions,
     user,
     ...project,
   }

--- a/packages/shared/src/utils/permissions.ts
+++ b/packages/shared/src/utils/permissions.ts
@@ -54,12 +54,30 @@ export const PROJECT_PERMS = { // project permissions
   REPLAY_HOOKS: bit(7n),
   LIST_ENVIRONMENTS: bit(8n),
   LIST_REPOSITORIES: bit(9n),
+  LIST_MEMBERS: bit(10n),
+  LIST_ROLES: bit(11n),
 }
 
 // Be very careful and think to apply corresponding updates in database if you modify these values, You'll have to do binary updates in SQL, good luck !
 export const ADMIN_PERMS = { // admin permissions
   LIST: bit(0n),
   MANAGE: bit(1n),
+  MANAGE_USERS: bit(2n),
+  MANAGE_PROJECTS: bit(3n),
+  MANAGE_ROLES: bit(4n),
+  MANAGE_CLUSTERS: bit(5n),
+  MANAGE_ZONES: bit(6n),
+  MANAGE_STAGES: bit(7n),
+  MANAGE_SYSTEM: bit(8n),
+  LIST_USERS: bit(9n),
+  LIST_PROJECTS: bit(10n),
+  LIST_ROLES: bit(11n),
+  LIST_CLUSTERS: bit(12n),
+  LIST_ZONES: bit(13n),
+  LIST_STAGES: bit(14n),
+  LIST_SYSTEM: bit(15n),
+  MANAGE_ADMIN_TOKEN: bit(16n),
+  LIST_ADMIN_TOKEN: bit(17n),
 }
 
 export type ProjectPermsKeys = keyof typeof PROJECT_PERMS
@@ -73,33 +91,53 @@ interface ProjectAuthorizedParams { adminPermissions?: bigint | string | null, p
 export const toBigInt = (value?: bigint | number | string | undefined | null) => value ? BigInt(value) : 0n
 
 export const AdminAuthorized = {
-  isAdmin: (perms?: bigint | string | null) => !!(toBigInt(perms) & ADMIN_PERMS.MANAGE),
+  Manage: (perms?: bigint | string | null) => !!(toBigInt(perms) & ADMIN_PERMS.MANAGE),
+  ManageUsers: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.MANAGE_USERS | ADMIN_PERMS.MANAGE)),
+  ManageProjects: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.MANAGE_PROJECTS | ADMIN_PERMS.MANAGE)),
+  ManageRoles: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.MANAGE_ROLES | ADMIN_PERMS.MANAGE)),
+  ManageClusters: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.MANAGE_CLUSTERS | ADMIN_PERMS.MANAGE)),
+  ManageZones: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.MANAGE_ZONES | ADMIN_PERMS.MANAGE)),
+  ManageStages: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.MANAGE_STAGES | ADMIN_PERMS.MANAGE)),
+  ManageSystem: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.MANAGE_SYSTEM | ADMIN_PERMS.MANAGE)),
+  ManageAdminToken: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.MANAGE_ADMIN_TOKEN | ADMIN_PERMS.MANAGE)),
+  ListUsers: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.LIST_USERS | ADMIN_PERMS.MANAGE_USERS | ADMIN_PERMS.LIST | ADMIN_PERMS.MANAGE)),
+  ListProjects: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.LIST_PROJECTS | ADMIN_PERMS.MANAGE_PROJECTS | ADMIN_PERMS.LIST | ADMIN_PERMS.MANAGE)),
+  ListRoles: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.LIST_ROLES | ADMIN_PERMS.MANAGE_ROLES | ADMIN_PERMS.LIST | ADMIN_PERMS.MANAGE)),
+  ListClusters: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.LIST_CLUSTERS | ADMIN_PERMS.MANAGE_CLUSTERS | ADMIN_PERMS.LIST | ADMIN_PERMS.MANAGE)),
+  ListZones: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.LIST_ZONES | ADMIN_PERMS.MANAGE_ZONES | ADMIN_PERMS.LIST | ADMIN_PERMS.MANAGE)),
+  ListStages: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.LIST_STAGES | ADMIN_PERMS.MANAGE_STAGES | ADMIN_PERMS.LIST | ADMIN_PERMS.MANAGE)),
+  ListSystem: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.LIST_SYSTEM | ADMIN_PERMS.MANAGE_SYSTEM | ADMIN_PERMS.LIST | ADMIN_PERMS.MANAGE)),
+  ListAdminToken: (perms?: bigint | string | null) => !!(toBigInt(perms) & (ADMIN_PERMS.LIST_ADMIN_TOKEN | ADMIN_PERMS.MANAGE_ADMIN_TOKEN | ADMIN_PERMS.LIST | ADMIN_PERMS.MANAGE)),
 } as const
 
 export const ProjectAuthorized = {
-  Manage: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  Manage: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & PROJECT_PERMS.MANAGE),
 
-  ListEnvironments: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  ListEnvironments: (perms: ProjectAuthorizedParams) => AdminAuthorized.ListProjects(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.LIST_ENVIRONMENTS | PROJECT_PERMS.MANAGE_ENVIRONMENTS | PROJECT_PERMS.MANAGE)),
-  ListRepositories: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  ListRepositories: (perms: ProjectAuthorizedParams) => AdminAuthorized.ListProjects(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.LIST_REPOSITORIES | PROJECT_PERMS.MANAGE_REPOSITORIES | PROJECT_PERMS.MANAGE)),
+  ListMembers: (perms: ProjectAuthorizedParams) => AdminAuthorized.ListProjects(perms.adminPermissions)
+    || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.LIST_MEMBERS | PROJECT_PERMS.MANAGE_MEMBERS | PROJECT_PERMS.MANAGE)),
+  ListRoles: (perms: ProjectAuthorizedParams) => AdminAuthorized.ListProjects(perms.adminPermissions)
+    || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.LIST_ROLES | PROJECT_PERMS.MANAGE_ROLES | PROJECT_PERMS.MANAGE)),
 
-  ManageEnvironments: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  ManageEnvironments: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.MANAGE_ENVIRONMENTS | PROJECT_PERMS.MANAGE)),
-  ManageRepositories: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  ManageRepositories: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.MANAGE_REPOSITORIES | PROJECT_PERMS.MANAGE)),
 
-  ManageMembers: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  ManageMembers: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.MANAGE_MEMBERS | PROJECT_PERMS.MANAGE)),
 
-  ManageRoles: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  ManageRoles: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.MANAGE_ROLES | PROJECT_PERMS.MANAGE)),
 
-  ReplayHooks: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  ReplayHooks: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.REPLAY_HOOKS | PROJECT_PERMS.MANAGE)),
 
-  SeeSecrets: (perms: ProjectAuthorizedParams) => AdminAuthorized.isAdmin(perms.adminPermissions)
+  SeeSecrets: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.SEE_SECRETS | PROJECT_PERMS.MANAGE)),
 } as const
 
@@ -123,6 +161,14 @@ export const projectPermsDetails: PermDetails<ProjectPermsKeys> = [{
     key: 'MANAGE_MEMBERS',
     label: 'Gérer les membres du projet',
     hint: 'Permet d\'inviter des utilisateurs et de les retirer',
+  }, {
+    key: 'LIST_ROLES',
+    label: 'Voir les rôles du projet',
+    hint: 'Permet de visualiser les rôles du projet',
+  }, {
+    key: 'LIST_MEMBERS',
+    label: 'Voir les membres du projet',
+    hint: 'Permet de visualiser les membres du projet',
   }, {
     key: 'SEE_SECRETS',
     label: 'Afficher les secrets',
@@ -168,6 +214,92 @@ export const adminPermsDetails: PermDetails<AdminPermsKeys> = [{
     key: 'MANAGE',
     label: 'Administration globale',
     hint: 'Administration globale de toute la console et de ses ressources',
+  }, {
+    key: 'LIST',
+    label: 'Lecture seule globale',
+    hint: 'Accès en lecture seule à toute la console et ses ressources',
+  }],
+}, {
+  name: 'Gestion des utilisateurs',
+  perms: [{
+    key: 'MANAGE_USERS',
+    label: 'Gérer les utilisateurs',
+    hint: 'Permet de gérer les utilisateurs de la console',
+  }, {
+    key: 'LIST_USERS',
+    label: 'Voir les utilisateurs',
+    hint: 'Permet de voir les utilisateurs de la console',
+  }],
+}, {
+  name: 'Gestion des projets',
+  perms: [{
+    key: 'MANAGE_PROJECTS',
+    label: 'Gérer les projets',
+    hint: 'Permet de gérer les projets de la console',
+  }, {
+    key: 'LIST_PROJECTS',
+    label: 'Voir les projets',
+    hint: 'Permet de voir les projets de la console',
+  }],
+}, {
+  name: 'Gestion des rôles',
+  perms: [{
+    key: 'MANAGE_ROLES',
+    label: 'Gérer les rôles',
+    hint: 'Permet de gérer les rôles de la console',
+  }, {
+    key: 'LIST_ROLES',
+    label: 'Voir les rôles',
+    hint: 'Permet de voir les rôles de la console',
+  }],
+}, {
+  name: 'Infrastructure',
+  perms: [{
+    key: 'MANAGE_CLUSTERS',
+    label: 'Gérer les clusters',
+    hint: 'Permet de gérer les clusters de la console',
+  }, {
+    key: 'LIST_CLUSTERS',
+    label: 'Voir les clusters',
+    hint: 'Permet de voir les clusters de la console',
+  }, {
+    key: 'MANAGE_ZONES',
+    label: 'Gérer les zones',
+    hint: 'Permet de gérer les zones de la console',
+  }, {
+    key: 'LIST_ZONES',
+    label: 'Voir les zones',
+    hint: 'Permet de voir les zones de la console',
+  }, {
+    key: 'MANAGE_STAGES',
+    label: 'Gérer les types d\'environnement',
+    hint: 'Permet de gérer les types d\'environnement de la console',
+  }, {
+    key: 'LIST_STAGES',
+    label: 'Voir les types d\'environnement',
+    hint: 'Permet de voir les types d\'environnement de la console',
+  }],
+}, {
+  name: 'Système',
+  perms: [{
+    key: 'MANAGE_SYSTEM',
+    label: 'Gérer le système',
+    hint: 'Permet de gérer les configurations et logs du système',
+  }, {
+    key: 'LIST_SYSTEM',
+    label: 'Voir le système',
+    hint: 'Permet de voir les configurations et logs du système',
+  }],
+}, {
+  name: 'Jetons d’API',
+  perms: [{
+    key: 'MANAGE_ADMIN_TOKEN',
+    label: 'Gérer les jetons d’API',
+    hint: 'Permet de créer et révoquer des jetons d’API admin',
+  }, {
+    key: 'LIST_ADMIN_TOKEN',
+    label: 'Voir les jetons d’API',
+    hint: 'Permet de lister les jetons d’API admin',
   }],
 }] as const
 
@@ -187,4 +319,16 @@ export function getProjectPermLabelsByValue(value: bigint | string) {
     .flat()
     .filter(permDetail => PROJECT_PERMS[permDetail.key] & value)
     .map(permDetail => permDetail.label)
+}
+
+export function getEffectiveAdminPermissions(
+  rawPerms: bigint | number | string,
+  options: { refined?: boolean },
+): bigint {
+  let perms = toBigInt(rawPerms)
+  const refinedEnabled = options.refined ?? true
+  if (!refinedEnabled) {
+    perms |= ADMIN_PERMS.MANAGE_PROJECTS | ADMIN_PERMS.LIST_STAGES | ADMIN_PERMS.LIST_ZONES | ADMIN_PERMS.LIST_PROJECTS
+  }
+  return perms
 }

--- a/packages/test-utils/src/imports/data.ts
+++ b/packages/test-utils/src/imports/data.ts
@@ -2187,6 +2187,10 @@ export const data = {
       key: 'maintenance',
       value: 'off',
     },
+    {
+      key: 'refined-permissions',
+      value: 'off',
+    },
   ],
   associations: [
     [


### PR DESCRIPTION

This changes the behaviour of admin access from a single toggle to fine-tuned permissions.
The permissions hierarchy basically works as follows: Manage > ManageXXX > List.
There are a few exceptions, such as the project hierarchy, in which the Manage permission from admin roles gives access to certain resources inside a project, while ManageProjects only manages the resource itself.
This means that Manage acts as a sort of equivalent to sudo; it's an intermediary design choice, but it needs revising.

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I07287d8d2c8fd287a9fbaefc9019f81a6a6a6964
