### PR TITLE
chore(ci): use node.js v24

### DIFF
--- a/.github/workflows/job-lint.yml
+++ b/.github/workflows/job-lint.yml
@@ -12,7 +12,6 @@ on:
         description: Nodejs version used to run tests
         required: true
         type: string
-        default: 22.14.0
 
 jobs:
   lint:

--- a/.github/workflows/job-npm.yml
+++ b/.github/workflows/job-npm.yml
@@ -27,7 +27,6 @@ on:
         description: Nodejs version used
         required: true
         type: string
-        default: 22.14.0
       PUBLISH_APPS:
         description: Publish apps modules
         required: true

--- a/.github/workflows/job-playwright.yml
+++ b/.github/workflows/job-playwright.yml
@@ -14,7 +14,6 @@ on:
         description: Nodejs version used to run tests
         required: true
         type: string
-        default: 22.14.0
       TAG:
         description: Container images version to use for console client and server
         required: true

--- a/.github/workflows/job-tests-component.yml
+++ b/.github/workflows/job-tests-component.yml
@@ -15,7 +15,6 @@ on:
         description: Nodejs version used to run tests
         required: true
         type: string
-        default: 22.14.0
       BROWSERS:
         description: Comma separeted browser list to run tests on (Options are 'electron', 'chrome', 'edge', 'firefox')
         required: false

--- a/.github/workflows/job-tests-e2e.yml
+++ b/.github/workflows/job-tests-e2e.yml
@@ -18,7 +18,6 @@ on:
         description: Nodejs version used to run tests
         required: true
         type: string
-        default: 22.14.0
       TAG:
         description: Image tag used to run tests
         required: true

--- a/.github/workflows/job-tests-unit.yml
+++ b/.github/workflows/job-tests-unit.yml
@@ -19,7 +19,6 @@ on:
         description: Nodejs version used to run tests
         required: true
         type: string
-        default: 22.14.0
 
 jobs:
   unit-tests:

--- a/.github/workflows/workflow-continuous-integration.yml
+++ b/.github/workflows/workflow-continuous-integration.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 22.14.0
+  NODE_VERSION: 24.13.1
   REGISTRY: ghcr.io
   NAMESPACE: "${{ github.repository }}"
   BUILD_AMD64: true

--- a/.github/workflows/workflow-create-or-update-release.yml
+++ b/.github/workflows/workflow-create-or-update-release.yml
@@ -12,7 +12,7 @@ env:
   BUILD_AMD64: true
   BUILD_ARM64: true
   USE_QEMU: false
-  NODE_VERSION: 22.14.0
+  NODE_VERSION: 24.13.1
 
 jobs:
   expose-vars:


### PR DESCRIPTION
For consistency with the rest of our stack (local dev, Dockerfiles, etc.)