### PR TITLE
Enable merge queues by leveraging main CI workflow

### DIFF
--- a/.github/workflows/workflow-continuous-integration.yml
+++ b/.github/workflows/workflow-continuous-integration.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - "**"
   workflow_dispatch:
+  merge_group:
 
 env:
   NODE_VERSION: 24.13.1


### PR DESCRIPTION
## Issues liées

Issues numéro: #1938 

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

> If your repository uses GitHub Actions to perform required checks on pull requests in your repository, you need to update the workflows to include the merge_group event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. The merge will fail as the required status check will not be reported. The merge_group event is separate from the pull_request and push events.