### PR TITLE
chore(ci): remove merge-group check in main workflow

### DIFF
--- a/.github/workflows/workflow-continuous-integration.yml
+++ b/.github/workflows/workflow-continuous-integration.yml
@@ -104,11 +104,11 @@ jobs:
     with:
       REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
       NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
-      TAG: pr-${{ github.event.pull_request.number || github.event.number }}
+      TAG: pr-${{ github.event.pull_request.number || github.event.number || github.merge_group.merge_group.head_sha }}
       BUILD_AMD64: ${{ needs.expose-vars.outputs.BUILD_AMD64 == 'true' }}
       BUILD_ARM64: ${{ needs.expose-vars.outputs.BUILD_ARM64 == 'true' }}
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
-      PR_NUMBER: ${{ github.event.pull_request.number || github.event.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.number || github.merge_group.merge_group.head_sha }}
     secrets:
       ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
 
@@ -129,7 +129,7 @@ jobs:
       - build
     with:
       NODE_VERSION: ${{ needs.expose-vars.outputs.NODE_VERSION }}
-      TAG: pr-${{ github.event.pull_request.number || github.event.number }}
+      TAG: pr-${{ github.event.pull_request.number || github.event.number || github.merge_group.merge_group.head_sha }}
 
   cypress-tests:
     uses: ./.github/workflows/job-tests-e2e.yml
@@ -141,7 +141,7 @@ jobs:
       - build
     with:
       NODE_VERSION: ${{ needs.expose-vars.outputs.NODE_VERSION }}
-      TAG: pr-${{ github.event.pull_request.number || github.event.number }}
+      TAG: pr-${{ github.event.pull_request.number || github.event.number || github.merge_group.merge_group.head_sha }}
       BROWSERS: "${{ github.base_ref == 'main' && 'chrome,firefox' || 'firefox' }}"
 
   scan-vuln:
@@ -152,7 +152,7 @@ jobs:
     with:
       REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
       NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
-      TAG: pr-${{ github.event.pull_request.number || github.event.number }}
+      TAG: pr-${{ github.event.pull_request.number || github.event.number || github.merge_group.merge_group.head_sha }}
 
   # Workaround for required status check in protection branches (see. https://github.com/orgs/community/discussions/13690)
   all-jobs-passed:


### PR DESCRIPTION
On a un souci d'alimentation de `PR_NUMBER` dans le cas de l'evènement `merge-group` des Merge Queues.
Je désactive donc le workflow de CI dans la Merge Queue le temps d'y voir un peu plus clair. Ce n'est pas un problème en soi car on exige de toute façon que la CI ait tourné sur une branche à jour dans chaque CI.