### PR TITLE
Add postmerge workflow

### DIFF
--- a/.github/workflows/job-npm.yml
+++ b/.github/workflows/job-npm.yml
@@ -43,6 +43,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   path-filter:
     if: ${{ inputs.CHECK_CHANGES }}
@@ -120,18 +123,6 @@ jobs:
           else
             echo "WARNING=false" >> $GITHUB_OUTPUT
           fi
-
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v2
-        if: ${{ steps.check.outputs.WARNING == 'true' }}
-        with:
-          message: |
-            🤖 Hey !
-
-            The __${{ steps.check.outputs.PACKAGE_NAME }} (v${{ steps.check.outputs.PACKAGE_VERSION }})__ package already exists [on npm](https://www.npmjs.com/package/${{ steps.check.outputs.PACKAGE_NAME }}/v/${{ steps.check.outputs.PACKAGE_VERSION }}) but the source code has changed, you should consider updating the package version.
-
-            *The version update warning should be ignored in the case of modifications that do not affect the code once it has been built, such as code formatting, etc...*
-          comment_tag: npm-check-${{ matrix.packages }}
 
   matrix:
     name: Generate matrix
@@ -225,14 +216,26 @@ jobs:
           restore-keys: |
             node-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Install dependencies
+      - name: Install base dependencies
         if: ${{ steps.check-version.outputs.REMOTE == 'false' }}
         run: pnpm install --frozen-lockfile
 
-      - name: Publish packages
+      - name: Build internal dependencies
+        if: ${{ steps.check-version.outputs.REMOTE == 'false' }}
+        run: pnpm --filter @cpn-console/shared run build
+
+      - name: Update dependencies after building internal dependencies
+        if: ${{ steps.check-version.outputs.REMOTE == 'false' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
         if: ${{ steps.check-version.outputs.REMOTE == 'false' }}
         run: |
           pnpm --filter ${{ matrix.modules.name }} run build
+
+      - name: Publish package
+        if: ${{ steps.check-version.outputs.REMOTE == 'false' }}
+        run: |
           pnpm --filter ${{ matrix.modules.name }} publish --no-git-checks --report-summary
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/workflow-continuous-integration.yml
+++ b/.github/workflows/workflow-continuous-integration.yml
@@ -68,21 +68,6 @@ jobs:
       - name: Exposing env vars
         run: echo "Exposing env vars."
 
-  npm-check:
-    uses: ./.github/workflows/job-npm.yml
-    if: ${{ github.base_ref == 'main' && needs.path-filter.outputs.packages == 'true' }}
-    needs:
-      - path-filter
-      - expose-vars
-    with:
-      NODE_VERSION: ${{ needs.expose-vars.outputs.NODE_VERSION }}
-      PUBLISH_APPS: false
-      PUBLISH_PACKAGES: false
-      PUBLISH_PLUGINS: false
-      CHECK_CHANGES: true
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   lint:
     uses: ./.github/workflows/job-lint.yml
     needs:

--- a/.github/workflows/workflow-post-merge.yml
+++ b/.github/workflows/workflow-post-merge.yml
@@ -1,0 +1,79 @@
+name: Post-merge
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  NODE_VERSION: 24.13.1
+
+permissions:
+  contents: read
+
+jobs:
+  path-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      apps: ${{ steps.filter.outputs.apps }}
+      packages: ${{ steps.filter.outputs.packages }}
+    steps:
+      - name: Checks-out repository
+        uses: actions/checkout@v4
+
+      - name: Check updated files paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            apps:
+              - 'apps/**'
+            packages:
+              - 'packages/**'
+              - 'plugins/**'
+
+  expose-vars:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    outputs:
+      NODE_VERSION: ${{ env.NODE_VERSION }}
+    steps:
+      - name: Exposing env vars
+        run: echo "Exposing env vars."
+
+  npm-publish:
+    uses: ./.github/workflows/job-npm.yml
+    needs:
+      - path-filter
+      - expose-vars
+    with:
+      NODE_VERSION: ${{ needs.expose-vars.outputs.NODE_VERSION }}
+      PUBLISH_APPS: true
+      PUBLISH_PACKAGES: true
+      PUBLISH_PLUGINS: true
+      CHECK_CHANGES: true
+
+  # Workaround for required status check in protection branches (see. https://github.com/orgs/community/discussions/13690)
+  all-jobs-passed:
+    name: Check jobs status
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - path-filter
+      - expose-vars
+      - npm-publish
+    steps:
+      - name: Check status of all required jobs
+        run: |-
+          NEEDS_CONTEXT='${{ toJson(needs) }}'
+          JOB_IDS=$(echo "$NEEDS_CONTEXT" | jq -r 'keys[]')
+          for JOB_ID in $JOB_IDS; do
+            RESULT=$(echo "$NEEDS_CONTEXT" | jq -r ".[\"$JOB_ID\"].result")
+            echo "$JOB_ID job result: $RESULT"
+            if [[ $RESULT != "success" && $RESULT != "skipped" ]]; then
+              echo "***"
+              echo "Error: The $JOB_ID job did not pass."
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped."


### PR DESCRIPTION
Le refacto de la CI a fait qu'on ne publiait plus, mais d'un autre côté le token qu'on utilisait pour publier était obsolète.

Maintenant qu'on a une relation OIDC saine entre Github et NPM, on peut remettre en fonction un workflow qui permettra, post-merge sur `main` de faire la publication sur NPM des modules concernés