### PR TITLE
fix: shared package for nodenext module resolution

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -8,6 +8,12 @@
     "type": "git",
     "url": "https://github.com/cloud-pi-native/console"
   },
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "types/index.d.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,12 @@
     "type": "git",
     "url": "https://github.com/cloud-pi-native/console"
   },
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION

Running tests using vitest in the server-nestjs package seems to break module resolution because of nodenext module resolution.

```
Error: Failed to resolve entry for package "@cpn-console/shared". The package may have incorrect main/module/exports specified in its package.json.
```

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/cloud-pi-native/console/pull/1974).
* #1996
* #1980
* #1958
* #1995
* __->__ #1974