### PR TITLE
chore: remove precommit and prepush

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-pnpx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-pnpm run test


### PR DESCRIPTION
- On a une CI désormais optimisée aux petits oignons :onion: 
- On veut committer régulièrement :runner: :dash: 
- `lint-staged` est buggé (il regarde tout le diff plutôt que ce qui est en staging), et il est de toute façon redondant avec la CI :no_good: 
- Lancer tous les tests en local est redondant, et on n'a pas besoin de rajouter une couche supplémentaire avec `turbo` pour se demander quoi lancer :no_good: 