### PR TITLE
fix: NestJS CJS and module

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -11,12 +11,9 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "types/index.d.ts",
   "files": [
     "dist",
     "types"

--- a/packages/hooks/src/hooks/hook-project.ts
+++ b/packages/hooks/src/hooks/hook-project.ts
@@ -1,4 +1,4 @@
-import type { PluginApi } from '@/utils/utils.js'
+import type { PluginApi } from '../utils/utils.js'
 import type { Hook } from './hook.js'
 import { createHook } from './hook.js'
 import type { ClusterObject, ExternalRepoUrl, InternalRepoName, IsInfra, IsPrivate, UserObject } from './index.js'

--- a/packages/hooks/src/utils/plugin-result-handler.ts
+++ b/packages/hooks/src/utils/plugin-result-handler.ts
@@ -1,4 +1,4 @@
-import type { PluginResult, PluginResultStore, PluginResultStoreValue } from '@/hooks/hook.js'
+import type { PluginResult, PluginResultStore, PluginResultStoreValue } from '../hooks/hook.js'
 import { parseError } from './logger.js'
 
 export class PluginResultBuilder {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,12 +11,9 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "types/index.d.ts",
   "files": [
     "dist",
     "types"


### PR DESCRIPTION

Tsconfig alias break NestJS build because it doesn't care about the dist, it looks at the TypeScript sources directly.

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>

***

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/cloud-pi-native/console/pull/2003).
* #1980
* #1958
* #1995
* #1994
* __->__ #2003