### PR TITLE
chore(ci): fix trivy action version to avoid suppy-chain compromision

### DIFF
--- a/.github/workflows/job-scan.yml
+++ b/.github/workflows/job-scan.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner on images
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ matrix.images.name }}:${{ inputs.TAG }}"
           format: template
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner on config files
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-ref: .
           scan-type: config


### PR DESCRIPTION
Oups

https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise

Qui c'est qui utilisait `master` ? :sweat_smile: 