### PR TITLE
Fix sonarqube action using master

### DIFF
--- a/.github/workflows/job-tests-unit.yml
+++ b/.github/workflows/job-tests-unit.yml
@@ -150,7 +150,7 @@ jobs:
           echo "SONAR_ARGS_BRANCH=-Dsonar.branch.name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@v1.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
@@ -169,7 +169,7 @@ jobs:
 
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check
-        uses: sonarsource/sonarqube-quality-gate-action@master
+        uses: sonarsource/sonarqube-quality-gate-action@v1.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
Au cas où il faut préciser le pourquoi du comment (_«explicit in better than implicit»_): ne pas fixer la version de quelque dépendance que ce soit nous expose à télécharger du code non-approuvé et surtout non-contrôlé, ce qui peut permettre des attaques de chaîne d'approvisionnement du logiciel (cf la dernière sur Trivy: https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise).

Figer les versions permet d'éviter de tirer n'importe quoi, même si la contrepartie est qu'il faudra revoir les versions régulièrement. Mais c'est ce qu'on est de toute façon sensés faire :grin: 