### PR TITLE
Add a dedicated entrypoint script for nginx-strangler

### DIFF
--- a/apps/nginx-strangler/Dockerfile
+++ b/apps/nginx-strangler/Dockerfile
@@ -7,15 +7,18 @@ RUN rm /etc/nginx/conf.d/default.conf
 # Config principale
 COPY apps/nginx-strangler/nginx.conf /etc/nginx/nginx.conf
 
-# Template de routing (sera substitué au démarrage)
-COPY apps/nginx-strangler/conf.d/routing.conf /etc/nginx/templates/routing.conf.template
+# Template de routing (sera modifié par l'entrypoint)
+COPY apps/nginx-strangler/conf.d/routing.conf /etc/nginx/conf.d/routing.conf
+
+# Copie du script qui va préparer la config et lancer le process nginx
+COPY ./apps/nginx-strangler/entrypoint.sh  /entrypoint.sh
 
 # Donner à l'utilisateur nginx les droits d'écriture sur conf.d/ (pour envsubst au démarrage)
 # et sur les répertoires de logs/pid nécessaires en mode non-root
 RUN chown -R nginx:nginx \
+      /entrypoint.sh \
       /etc/nginx/nginx.conf \
       /etc/nginx/conf.d \
-      /etc/nginx/templates \
       /etc/nginx/mime.types \
       /var/cache/nginx \
       /var/log/nginx \
@@ -30,7 +33,6 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
 # Entrypoint : envsubst substitue les variables d'env dans les templates,
 # puis démarre nginx en foreground
 # Les variables substituées : LEGACY_UPSTREAM, NESTJS_UPSTREAM
-CMD ["/bin/sh", "-c", \
-  "envsubst '${LEGACY_UPSTREAM} ${NESTJS_UPSTREAM}' < /etc/nginx/templates/routing.conf.template > /etc/nginx/conf.d/routing.conf && nginx -t && nginx -g 'daemon off;'"]
+ENTRYPOINT [ "/entrypoint.sh" ]
 
 EXPOSE 8080

--- a/apps/nginx-strangler/entrypoint.sh
+++ b/apps/nginx-strangler/entrypoint.sh
@@ -3,8 +3,8 @@
 ROUTING_CONFIG_FILE=/etc/nginx/conf.d/routing.conf
 
 echo "Replacing env constants in NGINX configuration"
-sed -i "s|\${LEGACY_UPSTREAM}|${LEGACY_UPSTREAM}|g" $ROUTING_CONFIG_FILE
-sed -i "s|\${NESTJS_UPSTREAM}|${NESTJS_UPSTREAM}|g" $ROUTING_CONFIG_FILE
+sed -i 's|'${LEGACY_UPSTREAM}'|'${LEGACY_UPSTREAM}'|g' $ROUTING_CONFIG_FILE
+sed -i 's|'${NESTJS_UPSTREAM}'|'${NESTJS_UPSTREAM}'|g' $ROUTING_CONFIG_FILE
 
 nginx -t
 

--- a/apps/nginx-strangler/entrypoint.sh
+++ b/apps/nginx-strangler/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+ROUTING_CONFIG_FILE=/etc/nginx/conf.d/routing.conf
+
+echo "Replacing env constants in NGINX configuration"
+sed -i "s|\${LEGACY_UPSTREAM}|${LEGACY_UPSTREAM}|g" $ROUTING_CONFIG_FILE
+sed -i "s|\${NESTJS_UPSTREAM}|${NESTJS_UPSTREAM}|g" $ROUTING_CONFIG_FILE
+
+nginx -t
+
+nginx -g 'daemon off;'


### PR DESCRIPTION
Fait pour permettre le déploiement côté Integ MI (gestion des utilisateurs sur OpenShift différente de celle qu'on a sur nos cluster kube)