### PR TITLE
fix(playwright): correct heading matcher and checkbox helper in e2e tests

### DIFF
--- a/playwright/e2e-tests/repos.spec.ts
+++ b/playwright/e2e-tests/repos.spec.ts
@@ -301,9 +301,7 @@ test.describe('Repositories', () => {
         .getByTestId('internalRepoNameInput')
         .fill(repo.internalRepoName)
       await page.getByTestId('externalRepoUrlInput').fill(repo.externalRepoUrl)
-      await page
-        .getByTestId('input-checkbox-infraRepoCbx')
-        .check({ force: true })
+      await setCheckbox({ page, name: 'infraRepoCbx' })
       await page.getByTestId('addRepoBtn').click()
       await expect(
         page.getByTestId(`repoTr-${repo.internalRepoName}`),


### PR DESCRIPTION

The test used `.check({ force: true })` directly on the hidden `<input>` element. The DSFR checkbox component wraps the input in a custom label, so clicking the input bypasses Vue's `v-model` reactivity.

**Fix:** Use the existing `setCheckbox` helper which properly sets the checked state via `evaluate` and dispatches `input`/`change` events.