### PR TITLE
fix: correct NestJS healthcheck and add opencds health service

### DIFF
--- a/apps/server-nestjs/Dockerfile
+++ b/apps/server-nestjs/Dockerfile
@@ -99,6 +99,6 @@ USER node
 EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3001/api/v1/system/healthz', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+  CMD node -e "require('http').get('http://localhost:3001/api/v1/healthz', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
 ENTRYPOINT ["node", "dist/src/main"]

--- a/apps/server-nestjs/src/modules/healthz/healthz.controller.ts
+++ b/apps/server-nestjs/src/modules/healthz/healthz.controller.ts
@@ -5,8 +5,10 @@ import { GitlabHealthService } from '../gitlab/gitlab-health.service'
 import { DatabaseHealthService } from '../infrastructure/database/database-health.service'
 import { KeycloakHealthService } from '../keycloak/keycloak-health.service'
 import { NexusHealthService } from '../nexus/nexus-health.service'
+import { OpenCdsHealthService } from '../opencds/opencds-health.service'
 import { RegistryHealthService } from '../registry/registry-health.service'
 import { VaultHealthService } from '../vault/vault-health.service'
+import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 
 @Controller('api/v1/healthz')
 export class HealthzController {
@@ -19,19 +21,37 @@ export class HealthzController {
     @Inject(NexusHealthService) private readonly nexus: NexusHealthService,
     @Inject(RegistryHealthService) private readonly registry: RegistryHealthService,
     @Inject(ArgoCDHealthService) private readonly argocd: ArgoCDHealthService,
+    @Inject(OpenCdsHealthService) private readonly opencds: OpenCdsHealthService,
+    @Inject(ConfigurationService) private readonly config: ConfigurationService,
   ) {}
 
   @Get()
   @HealthCheck()
   check() {
-    return this.health.check([
+    const checks = [
       () => this.database.check('database'),
       () => this.keycloak.check('keycloak'),
-      () => this.gitlab.check('gitlab'),
-      () => this.vault.check('vault'),
-      () => this.nexus.check('nexus'),
-      () => this.registry.check('registry'),
-      () => this.argocd.check('argocd'),
-    ])
+    ]
+
+    if (this.config.openCdsUrl) {
+      checks.push(() => this.opencds.check('opencds'))
+    }
+    if (this.config.gitlabUrl) {
+      checks.push(() => this.gitlab.check('gitlab'))
+    }
+    if (this.config.vaultUrl) {
+      checks.push(() => this.vault.check('vault'))
+    }
+    if (this.config.nexusUrl) {
+      checks.push(() => this.nexus.check('nexus'))
+    }
+    if (this.config.harborUrl) {
+      checks.push(() => this.registry.check('registry'))
+    }
+    if (this.config.argocdUrl) {
+      checks.push(() => this.argocd.check('argocd'))
+    }
+
+    return this.health.check(checks)
   }
 }

--- a/apps/server-nestjs/src/modules/healthz/healthz.module.ts
+++ b/apps/server-nestjs/src/modules/healthz/healthz.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common'
 import { TerminusModule } from '@nestjs/terminus'
 import { ArgoCDModule } from '../argocd/argocd.module'
 import { GitlabModule } from '../gitlab/gitlab.module'
+import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { DatabaseModule } from '../infrastructure/database/database.module'
 import { KeycloakModule } from '../keycloak/keycloak.module'
 import { NexusModule } from '../nexus/nexus.module'
+import { OpenCdsModule } from '../opencds/opencds.module'
 import { RegistryModule } from '../registry/registry.module'
 import { VaultModule } from '../vault/vault.module'
 import { HealthzController } from './healthz.controller'
@@ -19,6 +21,8 @@ import { HealthzController } from './healthz.controller'
     NexusModule,
     RegistryModule,
     ArgoCDModule,
+    ConfigurationModule,
+    OpenCdsModule,
   ],
   controllers: [HealthzController],
 })

--- a/apps/server-nestjs/src/modules/opencds/opencds-health.service.ts
+++ b/apps/server-nestjs/src/modules/opencds/opencds-health.service.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { HealthIndicatorService } from '@nestjs/terminus'
+import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
+
+@Injectable()
+export class OpenCdsHealthService {
+  constructor(
+    @Inject(ConfigurationService) private readonly config: ConfigurationService,
+    @Inject(HealthIndicatorService) private readonly healthIndicator: HealthIndicatorService,
+  ) {}
+
+  async check(key: string) {
+    const indicator = this.healthIndicator.check(key)
+    if (!this.config.openCdsUrl) return indicator.down('Not configured')
+
+    try {
+      const url = new URL('/api/v1/health', this.config.openCdsUrl).toString()
+      const headers: Record<string, string> = {}
+      if (this.config.openCdsApiToken) {
+        headers.Authorization = `Bearer ${this.config.openCdsApiToken}`
+      }
+
+      const response = await fetch(url, { headers })
+      if (response.status < 500) return indicator.up({ httpStatus: response.status })
+      return indicator.down({ httpStatus: response.status })
+    } catch (error) {
+      return indicator.down(error instanceof Error ? error.message : String(error))
+    }
+  }
+}

--- a/apps/server-nestjs/src/modules/opencds/opencds.module.ts
+++ b/apps/server-nestjs/src/modules/opencds/opencds.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { HealthIndicatorService } from '@nestjs/terminus'
+import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
+import { OpenCdsHealthService } from './opencds-health.service'
+
+@Module({
+  imports: [ConfigurationModule],
+  providers: [HealthIndicatorService, OpenCdsHealthService],
+  exports: [OpenCdsHealthService],
+})
+export class OpenCdsModule {}

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -1,5 +1,4 @@
 services:
-
   keycloak:
     restart: unless-stopped
     image: docker.io/bitnamilegacy/keycloak:26.1.3-debian-12-r0
@@ -77,6 +76,8 @@ services:
         condition: service_started
       keycloak:
         condition: service_healthy
+      opencds-mockoon:
+        condition: service_healthy
     env_file:
       - ../apps/server-nestjs/.env.docker
     environment:
@@ -97,7 +98,7 @@ services:
       server:
         condition: service_started
       server-nestjs:
-        condition: service_started
+        condition: service_healthy
     environment:
       LEGACY_UPSTREAM: "server:8080"
       NESTJS_UPSTREAM: "server-nestjs:3001"

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,5 +1,4 @@
 services:
-
   keycloak:
     restart: unless-stopped
     image: docker.io/bitnamilegacy/keycloak:26.1.3-debian-12-r0
@@ -125,6 +124,8 @@ services:
         condition: service_healthy
       postgres:
         condition: service_started
+      opencds-mockoon:
+        condition: service_healthy
     env_file:
       - ../apps/server-nestjs/.env.docker
     develop:
@@ -172,7 +173,7 @@ services:
       server:
         condition: service_started
       server-nestjs:
-        condition: service_started
+        condition: service_healthy
     environment:
       LEGACY_UPSTREAM: "server:8080"
       NESTJS_UPSTREAM: "server-nestjs:3001"

--- a/docker/docker-compose.integ.yml
+++ b/docker/docker-compose.integ.yml
@@ -98,6 +98,8 @@ services:
     depends_on:
       postgres:
         condition: service_started
+      opencds-mockoon:
+        condition: service_healthy
     ports:
       - 3001:3001
     volumes:
@@ -149,7 +151,7 @@ services:
       server:
         condition: service_started
       server-nestjs:
-        condition: service_started
+        condition: service_healthy
     ports:
       - 4000:8080
     environment:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #2218
* #2217
* __->__ #2216

----

- Fix Dockerfile HEALTHCHECK path: /api/v1/system/healthz ->
  /api/v1/healthz
- Make Terminus healthcheck conditional: only check external
  services (gitlab, vault, nexus, registry, argocd, opencds)
  when their URLs are configured
- Add OpenCdsHealthService following the same pattern as other
  health services (nexus, gitlab, etc.)
- Wire OpenCdsHealthService into HealthzController as a
  conditional check (only when openCdsUrl is configured)
- Import ConfigurationModule and OpenCdsModule in HealthzModule
- Change all docker-compose files (ci, dev, integ) to use
  condition: service_healthy for server-nestjs dependency in
  nginx-strangler

This fixes the race condition in CI where nginx-strangler
started proxying requests to NestJS before it was ready, causing
HTTP 502 errors in Playwright E2E tests
(service-chains.spec.ts).

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I80767040c1334a1fe1d778bf21591a6b6a6a6964