### PR TITLE
Revert "fix: remove opencds-mockoon depends_on (optional service)"

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -76,6 +76,8 @@ services:
         condition: service_started
       keycloak:
         condition: service_healthy
+      opencds-mockoon:
+        condition: service_healthy
     env_file:
       - ../apps/server-nestjs/.env.docker
     environment:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -124,6 +124,8 @@ services:
         condition: service_healthy
       postgres:
         condition: service_started
+      opencds-mockoon:
+        condition: service_healthy
     env_file:
       - ../apps/server-nestjs/.env.docker
     develop:

--- a/docker/docker-compose.integ.yml
+++ b/docker/docker-compose.integ.yml
@@ -98,6 +98,8 @@ services:
     depends_on:
       postgres:
         condition: service_started
+      opencds-mockoon:
+        condition: service_healthy
     ports:
       - 3001:3001
     volumes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #2218
* #2217
* #2216

This reverts commit ab10c14cd447186a8e8c6f5a73c0f992304905e5.