### PR TITLE
fix(release-please): restore default versioning strategy

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "versioning": "always-bump-patch",
+  "versioning": "default",
   "pull-request-title-pattern": "chore${scope}: Release${component} v${version}",
   "release-type": "node",
   "changelog-type": "default",


### PR DESCRIPTION
À contrôler lors des prochaines créations de versions, car `release-please` a changé ça de lui-même :thinking: 
(je ne me suis pas méfié :sweat: )

https://github.com/cloud-pi-native/console/pull/2192/changes#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2bR3