### PR TITLE
feat: fix the permission policy engine from AND to OR

### DIFF
--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project-access.decorator.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project-access.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common'
+
+export const PROJECT_ACCESS_KEY = 'project-access'
+
+export function RequireProjectAccess() {
+  return SetMetadata(PROJECT_ACCESS_KEY, true)
+}

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project-loader.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project-loader.service.ts
@@ -25,7 +25,7 @@ export class ProjectLoaderService {
   async load(request: RequestWithProjectParams, userId: string, requirements?: ProjectRequirements): Promise<ProjectContext> {
     let where: { id: string } | { slug: string }
     if (request.params?.projectId) {
-      where = { id: request.params.projectId }
+      where = isUuid(request.params.projectId) ? { id: request.params.projectId } : { slug: request.params.projectId }
     } else if (request.params?.projectSlug) {
       where = { slug: request.params.projectSlug }
     } else {
@@ -36,18 +36,21 @@ export class ProjectLoaderService {
       where,
       select: makeProjectSelect(requirements),
     })
-    if (!raw) throw new NotFoundException()
+    if (!raw) throw new NotFoundException('Projet introuvable')
 
     const project: ProjectContext = {
       id: raw.id,
       slug: raw.slug,
     }
 
-    if ('status' in raw && raw.status !== undefined) project.status = raw.status
-    if ('locked' in raw && raw.locked !== undefined) project.locked = raw.locked
-
-    if (requirements?.includePermissions && 'ownerId' in raw) {
-      project.projectPermissions = this.resolveProjectPermissions(raw as any, userId)
+    if (requirements?.includeStatus) {
+      project.status = raw.status
+    }
+    if (requirements?.includeLocked) {
+      project.locked = raw.locked
+    }
+    if (requirements?.includePermissions) {
+      project.projectPermissions = this.resolveProjectPermissions(raw, userId)
     }
 
     return project
@@ -90,4 +93,10 @@ function makeProjectSelect(requirements?: ProjectRequirements): Prisma.ProjectSe
         }
       : {}),
   } satisfies Prisma.ProjectSelect
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isUuid(value: string): boolean {
+  return UUID_RE.test(value)
 }

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.guard.spec.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.guard.spec.ts
@@ -5,6 +5,7 @@ import { UnauthorizedException } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { AuthService } from '../../auth/auth.service'
 import { ProjectLoaderService } from './project-loader.service'
 import { ProjectGuard } from './project.guard'
 import { ProjectPolicy } from './project.policy'
@@ -14,11 +15,13 @@ import { makeExecutionContext, makeProjectContext, makeProjectPolicy } from './p
 describe('projectGuard', () => {
   let module: TestingModule
   let guard: ProjectGuard
+  let authService: DeepMockProxy<AuthService>
   let projectService: DeepMockProxy<ProjectService>
   let projectPolicy: DeepMockProxy<ProjectPolicy>
   let loader: DeepMockProxy<ProjectLoaderService>
 
   beforeEach(async () => {
+    authService = mockDeep<AuthService>()
     projectService = mockDeep<ProjectService>()
     projectPolicy = mockDeep<ProjectPolicy>()
     loader = mockDeep<ProjectLoaderService>()
@@ -26,6 +29,7 @@ describe('projectGuard', () => {
     module = await Test.createTestingModule({
       providers: [
         ProjectGuard,
+        { provide: AuthService, useValue: authService },
         { provide: ProjectService, useValue: projectService },
         { provide: ProjectPolicy, useValue: projectPolicy },
         { provide: ProjectLoaderService, useValue: loader },
@@ -36,6 +40,8 @@ describe('projectGuard', () => {
   })
 
   it('throws 401 when userId is not set on the request', async () => {
+    projectPolicy.build.mockReturnValue(makeProjectPolicy())
+    authService.authenticate.mockRejectedValue(new UnauthorizedException())
     const ctx = makeExecutionContext({})
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException)
   })
@@ -44,6 +50,7 @@ describe('projectGuard', () => {
     const project: ProjectContext = makeProjectContext({})
     const policy = makeProjectPolicy({ projectPermissions: ['Manage'] })
     projectPolicy.build.mockReturnValue(policy)
+    authService.authenticate.mockResolvedValue({ userId: 'member1', adminPermissions: 0n })
     loader.load.mockResolvedValue(project)
     const request = { userId: 'member1', adminPermissions: 0n, params: { projectId: 'p1' } }
     const ctx = makeExecutionContext(request)

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.guard.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.guard.ts
@@ -1,9 +1,9 @@
 import type { CanActivate, ExecutionContext } from '@nestjs/common'
 import type { Project } from '@prisma/client'
 import type { FastifyRequest } from 'fastify'
-import type { ProjectRequirements } from './project-loader.service'
-import type { ProjectPolicyConfig } from './project.policy'
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common'
+import type { UserContext } from '../../auth/auth.service'
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { AuthService } from '../../auth/auth.service'
 import { ProjectLoaderService } from './project-loader.service'
 import { ProjectPolicy } from './project.policy'
 import { ProjectService } from './project.service'
@@ -23,6 +23,7 @@ export interface RequestWithProjectContext extends FastifyRequest {
 type RequestWithUserContext = FastifyRequest & {
   userId?: string
   adminPermissions?: bigint
+  userType?: string
 }
 
 interface ProjectParams {
@@ -32,39 +33,62 @@ interface ProjectParams {
 
 @Injectable()
 export class ProjectGuard implements CanActivate {
+  private readonly logger = new Logger(ProjectGuard.name)
+
   constructor(
+    @Inject(AuthService) private readonly authService: AuthService,
     @Inject(ProjectService) private readonly projectService: ProjectService,
-    @Inject(ProjectPolicy) private readonly projectPolicy: ProjectPolicy,
     @Inject(ProjectLoaderService) private readonly loader: ProjectLoaderService,
+    @Inject(ProjectPolicy) private readonly projectPolicy: ProjectPolicy,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const policy = this.projectPolicy.build(context)
-    const request = context.switchToHttp().getRequest<
-      RequestWithProjectContext & RequestWithUserContext & FastifyRequest<{ Params?: ProjectParams }>
-    >()
-    const userId = request.userId
-    if (typeof userId !== 'string') {
-      throw new UnauthorizedException('User ID not available')
-    }
-    const adminPermissions = request.adminPermissions
-    if (typeof adminPermissions !== 'bigint') {
-      throw new UnauthorizedException('Admin permissions not available')
-    }
+    const request = this.getRequest(context)
+    const user = await this.authenticate(request)
+    const project = await this.loadProject(request, user.userId)
 
-    const requirements = makeProjectRequirements(policy)
-    request.project = await this.loader.load(request, userId, requirements)
-
-    this.projectService.validate(policy, request.project, { userId, adminPermissions })
+    this.projectService.validate(policy, project, user)
 
     return true
   }
-}
 
-function makeProjectRequirements(policy: ProjectPolicyConfig): ProjectRequirements {
-  return {
-    includeStatus: policy.projectStatuses.length > 0,
-    includeLocked: policy.projectLocked !== undefined,
-    includePermissions: policy.projectPermissions.length > 0,
+  private getRequest(context: ExecutionContext): RequestWithProjectContext & RequestWithUserContext & FastifyRequest<{ Params?: ProjectParams }> {
+    return context.switchToHttp().getRequest<
+      RequestWithProjectContext & RequestWithUserContext & FastifyRequest<{ Params?: ProjectParams }>
+    >()
+  }
+
+  private async authenticate(
+    request: RequestWithProjectContext & RequestWithUserContext & FastifyRequest<{ Params?: ProjectParams }>,
+  ): Promise<UserContext> {
+    try {
+      const user = await this.authService.authenticate(request, {
+        includeAdminRoleIds: true,
+        includeUserType: true,
+      })
+
+      request.userId = user.userId
+      if (user.adminPermissions !== undefined) request.adminPermissions = user.adminPermissions
+      if (user.userType !== undefined) request.userType = user.userType
+
+      return user
+    } catch (error) {
+      this.logger.warn(`Project access auth rejected (requestId=${request.id}, error=${error instanceof Error ? error.message : String(error)})`)
+      throw error
+    }
+  }
+
+  private async loadProject(
+    request: RequestWithProjectContext & RequestWithUserContext & FastifyRequest<{ Params?: ProjectParams }>,
+    userId: string,
+  ): Promise<ProjectContext> {
+    const project = await this.loader.load(request, userId, {
+      includeStatus: true,
+      includeLocked: true,
+      includePermissions: true,
+    })
+    request.project = project
+    return project
   }
 }

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.module.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+import { AuthModule } from '../../auth/auth.module'
 import { DatabaseModule } from '../../database/database.module'
 import { ProjectLoaderService } from './project-loader.service'
 import { ProjectGuard } from './project.guard'
@@ -6,7 +7,10 @@ import { ProjectPolicy } from './project.policy'
 import { ProjectService } from './project.service'
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [
+    AuthModule,
+    DatabaseModule,
+  ],
   providers: [
     ProjectGuard,
     ProjectLoaderService,

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.policy.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.policy.ts
@@ -1,16 +1,22 @@
-import type { ProjectAuthorized } from '@cpn-console/shared'
+import type { AdminAuthorized, ProjectAuthorized } from '@cpn-console/shared'
 import type { ExecutionContext } from '@nestjs/common'
-import type { Project } from '@prisma/client'
+import type { Project, User } from '@prisma/client'
 import { Inject, Injectable } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
+import { ADMIN_PERMISSIONS_KEY } from '../user/user-admin-permission.decorator'
+import { USER_TYPES_KEY } from '../user/user-type.decorator'
+import { PROJECT_ACCESS_KEY } from './project-access.decorator'
 import { PROJECT_LOCKED_KEY } from './project-locked.decorator'
 import { PROJECT_PERMISSION_KEY } from './project-permission.decorator'
 import { PROJECT_STATUS_KEY } from './project-status.decorator'
 
 export interface ProjectPolicyConfig {
+  adminPermissions: (keyof typeof AdminAuthorized)[]
+  userTypes: User['type'][]
   projectPermissions: (keyof typeof ProjectAuthorized)[]
   projectStatuses: Project['status'][]
   projectLocked?: boolean
+  projectAccess: boolean
 }
 
 @Injectable()
@@ -20,9 +26,12 @@ export class ProjectPolicy {
   build(context: ExecutionContext): ProjectPolicyConfig {
     const targets = [context.getHandler(), context.getClass()]
     return {
+      adminPermissions: this.reflector.getAllAndOverride<(keyof typeof AdminAuthorized)[] | undefined>(ADMIN_PERMISSIONS_KEY, targets) ?? [],
+      userTypes: this.reflector.getAllAndOverride<User['type'][] | undefined>(USER_TYPES_KEY, targets) ?? [],
       projectPermissions: this.reflector.getAllAndOverride<(keyof typeof ProjectAuthorized)[] | undefined>(PROJECT_PERMISSION_KEY, targets) ?? [],
       projectStatuses: this.reflector.getAllAndOverride<Project['status'][] | undefined>(PROJECT_STATUS_KEY, targets) ?? [],
       projectLocked: this.reflector.getAllAndOverride<boolean | undefined>(PROJECT_LOCKED_KEY, targets),
+      projectAccess: this.reflector.getAllAndOverride<boolean | undefined>(PROJECT_ACCESS_KEY, targets) ?? false,
     }
   }
 }

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.service.ts
@@ -1,27 +1,54 @@
-import type { ProjectStatus } from '@prisma/client'
+import type { ProjectStatus, User } from '@prisma/client'
 import type { UserContext } from '../../auth/auth.service.js'
 import type { ProjectContext } from './project.guard'
 import type { ProjectPolicyConfig } from './project.policy'
-import { ProjectAuthorized } from '@cpn-console/shared'
-import { ForbiddenException, Injectable } from '@nestjs/common'
+import { AdminAuthorized, ProjectAuthorized } from '@cpn-console/shared'
+import { ForbiddenException, Injectable, Logger } from '@nestjs/common'
 
 @Injectable()
 export class ProjectService {
+  private readonly logger = new Logger(ProjectService.name)
+
   validate(policy: ProjectPolicyConfig, project: ProjectContext, user: UserContext): void {
+    this.validateUserType(policy, user.userType)
     this.validateProjectStatus(policy, project.status)
     this.validateProjectLock(policy, project.locked)
+    this.validateProjectAccess(policy, project, user)
     this.validateProjectPermissions(policy, project, user)
   }
 
   validateProjectStatus(policy: ProjectPolicyConfig, projectStatus: ProjectStatus | undefined): void {
     if (policy.projectStatuses.length > 0 && (!projectStatus || !policy.projectStatuses.includes(projectStatus))) {
-      throw new ForbiddenException()
+      this.logger.warn(`project auth denied: invalid project status (projectStatus=${projectStatus}, policy=${JSON.stringify(policy)})`)
+      throw new ForbiddenException('Statut de projet invalide')
     }
   }
 
   validateProjectLock(policy: ProjectPolicyConfig, projectLocked: boolean | undefined): void {
     if (policy.projectLocked !== undefined && projectLocked !== policy.projectLocked) {
-      throw new ForbiddenException()
+      this.logger.warn(`project auth denied: invalid lock status (projectLocked=${projectLocked}, policy=${JSON.stringify(policy)})`)
+      throw new ForbiddenException('État de verrouillage invalide')
+    }
+  }
+
+  validateUserType(policy: ProjectPolicyConfig, userType: string | undefined): void {
+    if (!policy.userTypes.length) return
+    if (typeof userType !== 'string' || !policy.userTypes.includes(userType as User['type'])) {
+      this.logger.warn(`project auth denied: invalid user type (userType=${userType}, policy=${JSON.stringify(policy)})`)
+      throw new ForbiddenException('Cannot find requestor in request context')
+    }
+  }
+
+  validateProjectAccess(policy: ProjectPolicyConfig, project: ProjectContext, user: UserContext): void {
+    if (!policy.projectAccess) return
+
+    const adminPermissions = user.adminPermissions ?? 0n
+    const hasAccess = AdminAuthorized.Manage(adminPermissions) || Boolean(project.projectPermissions)
+    if (!hasAccess) {
+      this.logger.warn(
+        `project auth denied: missing project access (projectId=${project.id}, projectSlug=${project.slug}, userId=${user.userId}, adminPermissions=${user.adminPermissions?.toString()}, projectPermissions=${project.projectPermissions?.toString()}, policy=${JSON.stringify(policy)})`,
+      )
+      throw new ForbiddenException('Permissions insuffisantes pour ce projet')
     }
   }
 
@@ -29,11 +56,17 @@ export class ProjectService {
     if (!policy.projectPermissions.length) return
 
     const hasPermission = policy.projectPermissions.every(
-      permName => ProjectAuthorized[permName]({ adminPermissions: user.adminPermissions, projectPermissions: project.projectPermissions }),
+      permName => ProjectAuthorized[permName]({
+        adminPermissions: user.adminPermissions,
+        projectPermissions: project.projectPermissions,
+      }),
     )
 
     if (!hasPermission) {
-      throw new ForbiddenException()
+      this.logger.warn(
+        `project auth denied: missing project permissions (projectId=${project.id}, projectSlug=${project.slug}, userId=${user.userId}, adminPermissions=${user.adminPermissions?.toString()}, projectPermissions=${project.projectPermissions?.toString()}, policy=${JSON.stringify(policy)})`,
+      )
+      throw new ForbiddenException('Permissions insuffisantes pour ce projet')
     }
   }
 }

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.testing.utils.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.testing.utils.ts
@@ -26,9 +26,12 @@ export function makeProjectContext(overrides: Partial<ProjectContext> = {}): Pro
 
 export function makeProjectPolicy(overrides: Partial<ProjectPolicyConfig> = {}): ProjectPolicyConfig {
   return {
+    adminPermissions: [],
+    userTypes: [],
     projectPermissions: [],
     projectStatuses: [],
     projectLocked: undefined,
+    projectAccess: false,
     ...overrides,
   }
 }

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user.guard.spec.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user.guard.spec.ts
@@ -55,7 +55,7 @@ describe('userGuard', () => {
     expect(result).toBe(true)
     expect(authService.authenticate).toHaveBeenCalledWith(
       expect.anything(),
-      { includeAdminRoleIds: false, includeUserType: false },
+      { includeAdminRoleIds: true, includeUserType: true },
     )
     expect(authService.authenticate.mock.calls[0]?.[0]?.headers).toEqual(httpRequest.headers)
     expect(request.userId).toBe('u1')
@@ -71,7 +71,7 @@ describe('userGuard', () => {
     await expect(guard.canActivate(ctx)).resolves.toBe(true)
     expect(authService.authenticate).toHaveBeenCalledWith(
       expect.anything(),
-      { includeAdminRoleIds: true, includeUserType: false },
+      { includeAdminRoleIds: true, includeUserType: true },
     )
     expect(authService.authenticate.mock.calls[0]?.[0]?.headers).toEqual(httpRequest.headers)
     expect(userService.validate).toHaveBeenCalled()
@@ -82,7 +82,7 @@ describe('userGuard', () => {
     const policy: UserPolicyConfig = { adminPermissions: ['ManageSystem'], userTypes: [] }
     userPolicy.build.mockReturnValue(policy)
     userService.validate.mockImplementation(() => { throw new ForbiddenException() })
-    const ctx = makeExecutionContext({ headers: { 'x-dso-token': 'tok' } })
+    const ctx = makeExecutionContext({ 'x-dso-token': 'tok' })
 
     await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException)
   })
@@ -97,7 +97,7 @@ describe('userGuard', () => {
     await expect(guard.canActivate(ctx)).resolves.toBe(true)
     expect(authService.authenticate).toHaveBeenCalledWith(
       expect.anything(),
-      { includeAdminRoleIds: false, includeUserType: true },
+      { includeAdminRoleIds: true, includeUserType: true },
     )
     expect(authService.authenticate.mock.calls[0]?.[0]?.headers).toEqual(httpRequest.headers)
     expect(userService.validate).toHaveBeenCalled()

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user.guard.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user.guard.ts
@@ -1,7 +1,6 @@
 import type { CanActivate, ExecutionContext } from '@nestjs/common'
 import type { FastifyRequest } from 'fastify'
-import type { UserPolicyConfig } from './user-policy.service'
-import { Inject, Injectable } from '@nestjs/common'
+import { Inject, Injectable, Logger, UnauthorizedException } from '@nestjs/common'
 import { AuthService } from '../../auth/auth.service'
 import { UserPolicy } from './user-policy.service'
 import { UserService } from './user.service'
@@ -14,6 +13,8 @@ type RequestWithAuthContext = FastifyRequest & {
 
 @Injectable()
 export class UserGuard implements CanActivate {
+  private readonly logger = new Logger(UserGuard.name)
+
   constructor(
     @Inject(AuthService) private readonly authService: AuthService,
     @Inject(UserService) private readonly userService: UserService,
@@ -22,24 +23,38 @@ export class UserGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const policy = this.userPolicy.build(context)
-    const request = context.switchToHttp().getRequest<RequestWithAuthContext>()
-    const requirements = makeRequirements(policy)
+    const request = this.getRequest(context)
+    const user = await this.authenticate(request)
 
-    const user = await this.authService.authenticate(request, requirements)
-
-    request.userId = user.userId
-    if (user.adminPermissions !== undefined) request.adminPermissions = user.adminPermissions
-    if (user.userType !== undefined) request.userType = user.userType
-
-    this.userService.validate(policy, user)
+    this.validate(policy, user)
+    this.logger.debug(`User auth granted (requestId=${request.id}, userId=${user.userId}, adminPermissions=${user.adminPermissions?.toString()}, userType=${user.userType})`)
 
     return true
   }
-}
 
-function makeRequirements(policy: UserPolicyConfig) {
-  return {
-    includeAdminRoleIds: policy.adminPermissions.length > 0,
-    includeUserType: policy.userTypes.length > 0,
+  private getRequest(context: ExecutionContext): RequestWithAuthContext {
+    return context.switchToHttp().getRequest<RequestWithAuthContext>()
+  }
+
+  private async authenticate(request: RequestWithAuthContext) {
+    try {
+      const user = await this.authService.authenticate(request, {
+        includeAdminRoleIds: true,
+        includeUserType: true,
+      })
+
+      request.userId = user.userId
+      if (user.adminPermissions !== undefined) request.adminPermissions = user.adminPermissions
+      if (user.userType !== undefined) request.userType = user.userType
+
+      return user
+    } catch (error) {
+      this.logger.warn(`User auth ${error instanceof UnauthorizedException ? 'rejected' : 'denied'} (requestId=${request.id}, error=${error instanceof Error ? error.message : String(error)})`)
+      throw error
+    }
+  }
+
+  private validate(policy: ReturnType<UserPolicy['build']>, user: Awaited<ReturnType<UserGuard['authenticate']>>) {
+    this.userService.validate(policy, user)
   }
 }

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user.service.ts
@@ -2,10 +2,12 @@ import type { User as PrismaUser } from '@prisma/client'
 import type { UserContext } from '../../auth/auth.service'
 import type { UserPolicyConfig } from './user-policy.service'
 import { AdminAuthorized } from '@cpn-console/shared'
-import { ForbiddenException, Injectable } from '@nestjs/common'
+import { ForbiddenException, Injectable, Logger } from '@nestjs/common'
 
 @Injectable()
 export class UserService {
+  private readonly logger = new Logger(UserService.name)
+
   validate(policy: UserPolicyConfig, user: UserContext): void {
     this.validateAdminPermissions(policy, user.adminPermissions)
     this.validateUserType(policy, user.userType)
@@ -19,13 +21,15 @@ export class UserService {
     )
 
     if (!hasPermission) {
-      throw new ForbiddenException()
+      this.logger.warn(`User auth denied: missing admin permissions (adminPermissions=${adminPermissions?.toString()}, policy=${JSON.stringify(policy)})`)
+      throw new ForbiddenException('Permissions administrateur insuffisantes')
     }
   }
 
   validateUserType(policy: UserPolicyConfig, userType: string | undefined): void {
     if (!policy.userTypes.length) return
     if (typeof userType !== 'string' || !policy.userTypes.includes(userType as PrismaUser['type'])) {
+      this.logger.warn(`User auth denied: invalid user type (userType=${userType}, policy=${JSON.stringify(policy)})`)
       throw new ForbiddenException('Cannot find requestor in request context')
     }
   }


### PR DESCRIPTION
Previously, the use of both UserGuard and ProjectGuard was required when defining permissions for admin and project permissions. However, the strict AND function was not useful in our case. This PR will change this to a strict OR. It was a design flaw that NestJS Guard is strictly AND.

Additionally we added a RequireProjectAccess which is used to check if the user is part of a project which is a permission by itself but ambiguous because it doesn't include the owner.

Change-Id: Ic3a749fbc22bd42380bab0006c71c7d66a6a6964

## Issues liées

Extrait de #2199 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
