### PR TITLE
fix(nestjs/gitlab): build project group public URLs with URL constructor to avoid double slashes

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -187,12 +187,12 @@ export class GitlabClientService {
 
   async getOrCreateProjectGroupPublicUrl(): Promise<string> {
     const projectGroup = await this.getOrCreateProjectGroup()
-    return `${this.config.gitlabUrl}/${projectGroup.full_path}`
+    return new URL(projectGroup.full_path, this.config.gitlabUrl).toString()
   }
 
   async getOrCreateInfraGroupRepoPublicUrl(repoName: string): Promise<string> {
     const projectGroup = await this.getOrCreateProjectGroup()
-    return `${this.config.gitlabUrl}/${projectGroup.full_path}/${INFRA_GROUP_PATH}/${repoName}.git`
+    return new URL(`${projectGroup.full_path}/${INFRA_GROUP_PATH}/${repoName}.git`, this.config.gitlabUrl).toString()
   }
 
   async getOrCreateProjectGroupInternalRepoUrl(subGroupPath: string, repoName: string): Promise<string> {


### PR DESCRIPTION

## Issues liées

Issues numéro:

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Les URLs publiques des groupes de projet et des dépôts d'infrastructure GitLab sont construites par concaténation de chaînes. Lorsque `gitlabUrl` contient une barre oblique finale ou un segment de chemin, cela produit des URLs mal formées (doubles barres obliques, segments perdus).

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
`getOrCreateProjectGroupPublicUrl` et `getOrCreateInfraGroupRepoPublicUrl` utilisent désormais le constructeur `URL` pour assembler les chemins, garantissant une jonction correcte quelle que soit la forme de `gitlabUrl`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Aucune.
