### PR TITLE
fix(server-nestjs/vault): build ArgoCD Vault values from AppRole creds and config

### DIFF
--- a/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
@@ -1,8 +1,8 @@
-import type { TestingModule } from '@nestjs/testing'
-import type { Mocked } from 'vitest'
+import type { DeepMockProxy } from 'vitest-mock-extended'
 import { generateNamespaceName } from '@cpn-console/shared'
 import { Test } from '@nestjs/testing'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
 import { stringify } from 'yaml'
 import { GitlabClientService } from '../gitlab/gitlab-client.service'
 import { makeCommitAction, makeProjectSchema, makeRepositoryTreeSchema } from '../gitlab/gitlab-testing.utils'
@@ -12,60 +12,39 @@ import { ArgoCDDatastoreService } from './argocd-datastore.service'
 import { makeProjectDeployment, makeProjectDeploymentSource, makeProjectEnvironment, makeProjectRepository, makeProjectWithDetails } from './argocd-testing.utils'
 import { ArgoCDService } from './argocd.service'
 
-function createArgoCDControllerServiceTestingModule() {
-  return Test.createTestingModule({
-    providers: [
-      ArgoCDService,
-      {
-        provide: ArgoCDDatastoreService,
-        useValue: {
-          getAllProjects: vi.fn(),
-        } satisfies Partial<ArgoCDDatastoreService>,
-      },
-      {
-        provide: ConfigurationService,
-        useValue: {
-          argoNamespace: 'argocd',
-          argocdUrl: 'https://argocd.internal',
-          argocdExtraRepositories: 'repo3',
-          dsoEnvChartVersion: 'dso-env-1.6.0',
-          dsoNsChartVersion: 'dso-ns-1.1.5',
-        } satisfies Partial<ConfigurationService>,
-      },
-      {
-        provide: GitlabClientService,
-        useValue: {
-          getOrCreateInfraGroupRepo: vi.fn(),
-          getOrCreateProjectGroupPublicUrl: vi.fn(),
-          getOrCreateInfraGroupRepoPublicUrl: vi.fn(),
-          generateCreateOrUpdateAction: vi.fn(),
-          maybeCreateCommit: vi.fn(),
-          listFiles: vi.fn(),
-        } satisfies Partial<GitlabClientService>,
-      },
-      {
-        provide: VaultClientService,
-        useValue: {
-          readProjectValues: vi.fn(),
-        } satisfies Partial<VaultClientService>,
-      },
-    ],
-  })
-}
-
 describe('argoCDService', () => {
   let service: ArgoCDService
-  let datastore: Mocked<ArgoCDDatastoreService>
-  let gitlab: Mocked<GitlabClientService>
-  let vault: Mocked<VaultClientService>
+  let datastore: DeepMockProxy<ArgoCDDatastoreService>
+  let gitlab: DeepMockProxy<GitlabClientService>
+  let vault: DeepMockProxy<VaultClientService>
 
   beforeEach(async () => {
-    vi.clearAllMocks()
-    const module: TestingModule = await createArgoCDControllerServiceTestingModule().compile()
+    datastore = mockDeep<ArgoCDDatastoreService>()
+    gitlab = mockDeep<GitlabClientService>()
+    vault = mockDeep<VaultClientService>()
+    const config = mockDeep<ConfigurationService>({
+      argoNamespace: 'argocd',
+      argocdUrl: 'https://argocd.internal',
+      argocdExtraRepositories: 'repo3',
+      dsoEnvChartVersion: 'dso-env-1.6.0',
+      dsoNsChartVersion: 'dso-ns-1.1.5',
+      projectRootDir: 'forge',
+      vaultUrl: 'https://vault.internal',
+      vaultKvName: 'kv',
+      deployVaultConnectionInNamespaces: false,
+    })
+
+    const module = await Test.createTestingModule({
+      providers: [
+        ArgoCDService,
+        { provide: ArgoCDDatastoreService, useValue: datastore },
+        { provide: ConfigurationService, useValue: config },
+        { provide: GitlabClientService, useValue: gitlab },
+        { provide: VaultClientService, useValue: vault },
+      ],
+    }).compile()
+
     service = module.get(ArgoCDService)
-    datastore = module.get(ArgoCDDatastoreService)
-    gitlab = module.get(GitlabClientService)
-    vault = module.get(VaultClientService)
   })
 
   it('should be defined', () => {
@@ -91,7 +70,8 @@ describe('argoCDService', () => {
     gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
     gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
     gitlab.listFiles.mockResolvedValue([])
-    vault.readProjectValues.mockResolvedValue({ secret: 'value' })
+    vault.getAuthApproleRoleRoleId.mockResolvedValue('role-id')
+    vault.createAuthApproleRoleSecretId.mockResolvedValue('secret-id')
     gitlab.generateCreateOrUpdateAction.mockImplementation(async (_repoId, _ref, filePath: string, content: string) => {
       return makeCommitAction({ filePath, content })
     })
@@ -153,7 +133,13 @@ describe('argoCDService', () => {
                 name: 'cluster-1',
               },
               autosync: true,
-              vault: { secret: 'value' },
+              vault: {
+                projectsRootDir: 'forge',
+                url: '',
+                coreKvName: 'kv',
+                roleId: 'role-id',
+                secretId: 'secret-id',
+              },
               repositories: [
                 {
                   id: mockProject.repositories[0].id,
@@ -222,7 +208,13 @@ describe('argoCDService', () => {
                 name: 'cluster-1',
               },
               autosync: true,
-              vault: { secret: 'value' },
+              vault: {
+                projectsRootDir: 'forge',
+                url: '',
+                coreKvName: 'kv',
+                roleId: 'role-id',
+                secretId: 'secret-id',
+              },
               repositories: [
                 {
                   id: mockProject.repositories[0].id,
@@ -277,7 +269,8 @@ describe('argoCDService', () => {
         { name: 'values.yaml', path: 'Project 1/cluster-1/prod/values.yaml' },
       ),
     ])
-    vault.readProjectValues.mockResolvedValue({ secret: 'value' })
+    vault.getAuthApproleRoleRoleId.mockResolvedValue('role-id')
+    vault.createAuthApproleRoleSecretId.mockResolvedValue('secret-id')
     gitlab.generateCreateOrUpdateAction.mockImplementation(async (_repoId, _ref, filePath: string, content: string) => {
       return makeCommitAction({ filePath, content })
     })
@@ -320,7 +313,8 @@ describe('argoCDService', () => {
     gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
     gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
     gitlab.listFiles.mockResolvedValue([])
-    vault.readProjectValues.mockResolvedValue({ secret: 'value' })
+    vault.getAuthApproleRoleRoleId.mockResolvedValue('role-id')
+    vault.createAuthApproleRoleSecretId.mockResolvedValue('secret-id')
 
     gitlab.generateCreateOrUpdateAction.mockResolvedValue(null)
 
@@ -364,7 +358,8 @@ describe('argoCDService', () => {
     gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
     gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
     gitlab.listFiles.mockResolvedValue([])
-    vault.readProjectValues.mockResolvedValue({ secret: 'value' })
+    vault.getAuthApproleRoleRoleId.mockResolvedValue('role-id')
+    vault.createAuthApproleRoleSecretId.mockResolvedValue('secret-id')
     gitlab.generateCreateOrUpdateAction.mockImplementation(async (_repoId, _ref, filePath: string, content: string) => {
       return makeCommitAction({ filePath, content })
     })
@@ -426,7 +421,13 @@ describe('argoCDService', () => {
                 name: 'cluster-1',
               },
               autosync: true,
-              vault: { secret: 'value' },
+              vault: {
+                projectsRootDir: 'forge',
+                url: '',
+                coreKvName: 'kv',
+                roleId: 'role-id',
+                secretId: 'secret-id',
+              },
               repositories: [
                 {
                   name: 'infra-repo',

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -220,7 +220,7 @@ export class ArgoCDService {
       'environment.id': environment.id,
       'environment.name': environment.name,
     })
-    const vaultValues = await this.vault.readProjectValues(project.id) ?? {}
+    const vaultValues = await this.generateVaultValues(project.slug)
     const cluster = environment.cluster
     if (!cluster) {
       this.logger.warn(`Cluster not found for environment ${environment.id} in project ${project.slug}`)
@@ -297,7 +297,7 @@ export class ArgoCDService {
       'environment.id': environment.id,
       'environment.name': environment.name,
     })
-    const vaultValues = await this.vault.readProjectValues(project.id) ?? {}
+    const vaultValues = await this.generateVaultValues(project.slug)
     const cluster = environment.cluster
     if (!cluster) {
       this.logger.warn(`Cluster not found for environment ${environment.id} in project ${project.slug}`)
@@ -330,6 +330,25 @@ export class ArgoCDService {
       valueFilePath,
       stringify(values),
     )
+  }
+
+  private async generateVaultValues(projectSlug: string): Promise<Record<string, any>> {
+    this.logger.verbose(`Generating Vault project values for projectSlug=${projectSlug}`)
+    const roleId = await this.vault.getAuthApproleRoleRoleId(projectSlug).catch(() => {
+      this.logger.warn(`Couldn't find app role (project=${projectSlug})`)
+      return undefined
+    })
+    const secretId = await this.vault.createAuthApproleRoleSecretId(projectSlug).catch(() => {
+      this.logger.warn(`Couldn't find secret (project=${projectSlug})`)
+      return undefined
+    })
+    return {
+      projectsRootDir: this.config.projectRootDir,
+      url: this.config.deployVaultConnectionInNamespaces ? this.config.vaultUrl : '',
+      coreKvName: this.config.vaultKvName,
+      roleId: roleId ?? 'none',
+      secretId: secretId ?? 'none',
+    }
   }
 }
 

--- a/apps/server-nestjs/src/modules/infrastructure/configuration/configuration.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/configuration/configuration.service.ts
@@ -81,6 +81,7 @@ export class ConfigurationService {
   vaultInternalUrl = process.env.VAULT_INTERNAL_URL
 
   vaultKvName = process.env.VAULT_KV_NAME ?? 'forge-dso'
+  deployVaultConnectionInNamespaces = process.env.VAULT__DEPLOY_VAULT_CONNECTION_IN_NS === 'true'
 
   // registry (harbor)
   harborUrl = process.env.HARBOR_URL

--- a/apps/server-nestjs/src/modules/vault/vault-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/vault/vault-client.service.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { VaultClientService } from './vault-client.service'
 import { VaultError, VaultHttpClientService } from './vault-http-client.service'
@@ -24,20 +25,21 @@ const server = setupServer(
   }),
 )
 
-function createVaultServiceTestingModule() {
+function createVaultServiceTestingModule(config: Partial<ConfigurationService> = {}) {
   return Test.createTestingModule({
     providers: [
       VaultClientService,
       VaultHttpClientService,
       {
         provide: ConfigurationService,
-        useValue: {
+        useValue: mockDeep<ConfigurationService>({
           vaultToken: 'token',
           vaultUrl,
           vaultInternalUrl: vaultUrl,
           vaultKvName: 'kv',
           getInternalOrPublicVaultUrl: () => vaultUrl,
-        } satisfies Partial<ConfigurationService>,
+          ...config,
+        }),
       },
     ],
   })
@@ -53,24 +55,6 @@ describe('vault', () => {
   })
   afterEach(() => server.resetHandlers())
   afterAll(() => server.close())
-
-  describe('getProjectValues', () => {
-    it('should get project values', async () => {
-      const result = await service.readProjectValues('project-id')
-      expect(result).toEqual({ secret: 'value' })
-    })
-
-    it('should return empty object if undefined', async () => {
-      server.use(
-        http.get(`${vaultUrl}/v1/kv/data/:path`, () => {
-          return HttpResponse.json({}, { status: HttpStatus.NOT_FOUND })
-        }),
-      )
-
-      const result = await service.readProjectValues('project-id')
-      expect(result).toEqual(undefined)
-    })
-  })
 
   describe('read', () => {
     it('should read secret', async () => {

--- a/apps/server-nestjs/src/modules/vault/vault-client.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault-client.service.ts
@@ -3,7 +3,7 @@ import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { VaultError, VaultHttpClientService } from './vault-http-client.service'
-import { generateGitlabMirrorCredPath, generateProjectPath, generateSonarqubeCredPath, generateTechReadOnlyCredPath } from './vault.utils'
+import { generateGitlabMirrorCredPath, generateSonarqubeCredPath, generateTechReadOnlyCredPath } from './vault.utils'
 
 export interface VaultSysPoliciesAclUpsertRequest {
   policy: string
@@ -159,18 +159,6 @@ export class VaultClientService {
     const span = trace.getActiveSpan()
     span?.setAttribute('vault.kv.path', path)
     return await this.deleteKvMetadata(this.config.vaultKvName, path)
-  }
-
-  @StartActiveSpan()
-  async readProjectValues(projectId: string): Promise<Record<string, any> | undefined> {
-    const path = generateProjectPath(this.config.projectRootDir, projectId)
-    this.logger.debug(`Reading Vault project values (projectId=${projectId}, path=${path})`)
-    this.logger.verbose(`Reading Vault project values for projectId=${projectId}`)
-    const secret = await this.read<Record<string, any>>(path).catch((error) => {
-      if (error instanceof VaultError && error.kind === 'NotFound') return null
-      throw error
-    })
-    return secret?.data
   }
 
   @StartActiveSpan()


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

Dans le nouveau serveur (server-nestjs), `ArgoCDService` récupérait les valeurs Vault du projet via `VaultClientService.readProjectValues()`, qui se contentait de lire les secrets bruts stockés dans le KV du projet (`kv/data/<projectRootDir>/<projectId>`) et retournait leur contenu (ou `undefined` si le chemin n'existait pas). Ces valeurs brutes ne contenaient pas les informations de connexion Vault (URL, KV, credentials AppRole) attendues par les consommateurs, contrairement au serveur legacy (`plugins/vault/src/vault-project-api.ts`, méthode `Project.getValues`).

## Quel est le nouveau comportement ?

La méthode `VaultClientService.readProjectValues()` (lecture des secrets bruts) est supprimée. `ArgoCDService` construit désormais lui-même la configuration Vault du projet via une nouvelle méthode privée `generateVaultValues(projectSlug)`, qui reproduit le comportement du serveur legacy et retourne :

- `projectsRootDir` : répertoire racine des projets (`config.projectRootDir`)
- `url` : URL Vault exposée uniquement si `deployVaultConnectionInNamespaces` est activé (`config.vaultUrl`), sinon chaîne vide
- `coreKvName` : nom du KV core (`config.vaultKvName`)
- `roleId` / `secretId` : credentials AppRole récupérés via `getAuthApproleRoleRoleId` / `createAuthApproleRoleSecretId`, avec repli sur `'none'` si le rôle n'existe pas

Les deux points d'appel dans `ArgoCDService` utilisent désormais `generateVaultValues(project.slug)` au lieu de `readProjectValues(project.id)`. Cela aligne le nouveau serveur sur le comportement du legacy (`VaultProjectApi.Project.getValues` / `getCredentials` et `defaultAppRoleCredentials`). Les tests ont été mis à jour pour couvrir les deux cas : projet avec et sans credentials AppRole.

## Cette PR introduit-elle un breaking change ?

Non. Le changement aligne le nouveau serveur sur le contrat déjà en place dans le serveur legacy.

## Autres informations

Fichier de référence pour le comportement legacy : `plugins/vault/src/vault-project-api.ts`.
