### PR TITLE
feat(server-nestjs): secure deployment API with project permission guards

### DIFF
--- a/apps/nginx-strangler/conf.d/routing.conf
+++ b/apps/nginx-strangler/conf.d/routing.conf
@@ -70,7 +70,7 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
-    location /api/v1/deployments {
+    location ~ ^/api/v1/projects/[^/]+/deployments(.*)$ {
         proxy_pass         http://server-nestjs;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
@@ -51,6 +51,62 @@ describe('argoCDService', () => {
     expect(service).toBeDefined()
   })
 
+  describe('handleUpsert', () => {
+    it('should return OK result when ensureProject succeeds', async () => {
+      const mockProject = makeProjectWithDetails({
+        slug: 'project-1',
+        name: 'Project 1',
+        environments: [],
+        repositories: [],
+        deployments: [],
+      })
+
+      const infraProject = makeProjectSchema({ id: 100, http_url_to_repo: 'https://gitlab.internal/infra' })
+      gitlab.getOrCreateInfraGroupRepo.mockResolvedValue(infraProject)
+      gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
+      gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
+      gitlab.listFiles.mockResolvedValue([])
+      gitlab.generateCreateOrUpdateAction.mockResolvedValue(null)
+      gitlab.maybeCreateCommit.mockResolvedValue(undefined)
+
+      const result = await service.handleUpsert(mockProject)
+
+      expect(result).toEqual({
+        argocd: expect.objectContaining({
+          status: 'OK',
+          message: 'Up to date',
+          executionTime: expect.any(Number),
+        }),
+      })
+    })
+
+    it('should return KO result when ensureProject throws', async () => {
+      const mockProject = makeProjectWithDetails({
+        slug: 'project-1',
+        name: 'Project 1',
+        environments: [
+          makeProjectEnvironment({ name: 'dev', cluster: { id: 'c1', label: 'cluster-1', zone: { slug: 'zone-1' } } }),
+        ],
+        repositories: [makeProjectRepository({ internalRepoName: 'infra-repo', isInfra: true })],
+        deployments: [],
+      })
+
+      const error = new Error('GitLab unreachable')
+      gitlab.getOrCreateInfraGroupRepo.mockRejectedValue(error)
+
+      const result = await service.handleUpsert(mockProject)
+
+      expect(result).toEqual({
+        argocd: expect.objectContaining({
+          status: 'KO',
+          message: 'GitLab unreachable',
+          executionTime: expect.any(Number),
+          error,
+        }),
+      })
+    })
+  })
+
   it('should sync project environments', async () => {
     const mockProject = makeProjectWithDetails({
       slug: 'project-1',

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -240,11 +240,6 @@ export class ArgoCDService {
 
     const valueFilePath = formatEnvironmentValuesFilePath(project, cluster, environment)
 
-    const repo = project.repositories.find(r => r.isInfra)
-    if (!repo) {
-      this.logger.warn(`Infrastructure repository not found for project ${project.slug} (projectId=${project.id})`)
-      return null
-    }
     const gitlabPublicProjectUrl = `${(await this.gitlab.getOrCreateProjectGroupPublicUrl())}/${project.slug}`
 
     const values = formatValues({

--- a/apps/server-nestjs/src/modules/deployment/deployment-datastore.service.spec.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment-datastore.service.spec.ts
@@ -74,6 +74,7 @@ describe('deploymentDatastoreService', () => {
             include: { repository: true },
           },
         },
+        orderBy: { createdAt: 'asc' },
       })
       expect(result).toEqual(deployments)
     })

--- a/apps/server-nestjs/src/modules/deployment/deployment-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment-datastore.service.ts
@@ -27,6 +27,7 @@ export class DeploymentDatastoreService {
           include: { repository: true },
         },
       },
+      orderBy: { createdAt: 'asc' },
     })
   }
 

--- a/apps/server-nestjs/src/modules/deployment/deployment.controller.spec.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.controller.spec.ts
@@ -1,9 +1,13 @@
 import type { CreateDeployment, UpdateDeployment } from '@cpn-console/shared'
 import type { TestingModule } from '@nestjs/testing'
+import type { FastifyRequest } from 'fastify'
 import type { DeepMockProxy } from 'vitest-mock-extended'
+import type { UserContext } from '../infrastructure/auth/auth-user.decorator'
+import type { ProjectContext } from '../infrastructure/permission/project/project.guard'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { ProjectGuard } from '../infrastructure/permission/project/project.guard'
 import { makeDeployment, makeDeploymentWithRelations } from './deployment-testing.utils'
 import { DeploymentController } from './deployment.controller'
 import { DeploymentService } from './deployment.service'
@@ -13,22 +17,17 @@ describe('deploymentController', () => {
   let controller: DeploymentController
   let service: DeepMockProxy<DeploymentService>
 
-  beforeEach(async () => {
-    service = mockDeep<DeploymentService>()
+  const projectId = '11111111-1111-1111-1111-111111111111'
+  const userId = 'user-uuid-1234'
+  const requestId = 'request-uuid-5678'
 
-    module = await Test.createTestingModule({
-      controllers: [DeploymentController],
-      providers: [
-        { provide: DeploymentService, useValue: service },
-      ],
-    }).compile()
-
-    controller = module.get<DeploymentController>(DeploymentController)
-  })
+  const project: ProjectContext = { id: projectId, slug: 'my-project' }
+  const user: UserContext = { userId }
+  const request = { id: requestId } as FastifyRequest
 
   const validCreateDeployment = {
     name: 'dev',
-    projectId: '11111111-1111-1111-1111-111111111111',
+    projectId,
     environmentId: '22222222-2222-2222-2222-222222222222',
     autosync: true,
     deploymentSources: [
@@ -55,12 +54,17 @@ describe('deploymentController', () => {
   } satisfies UpdateDeployment
 
   beforeEach(async () => {
+    service = mockDeep<DeploymentService>()
+
     module = await Test.createTestingModule({
       controllers: [DeploymentController],
       providers: [
         { provide: DeploymentService, useValue: service },
       ],
-    }).compile()
+    })
+      .overrideGuard(ProjectGuard)
+      .useValue({ canActivate: () => true })
+      .compile()
 
     controller = module.get<DeploymentController>(DeploymentController)
   })
@@ -71,12 +75,11 @@ describe('deploymentController', () => {
 
   describe('list', () => {
     it('should call deploymentService.listByProjectId with projectId', async () => {
-      const projectId = '11111111-1111-1111-1111-111111111111'
       const expectedResult = [makeDeploymentWithRelations({ projectId })]
 
       service.listByProjectId.mockResolvedValue(expectedResult)
 
-      const result = await controller.list(projectId)
+      const result = await controller.list(project)
 
       expect(service.listByProjectId).toHaveBeenCalledWith(projectId)
       expect(result).toEqual(expectedResult)
@@ -85,15 +88,17 @@ describe('deploymentController', () => {
 
   describe('create', () => {
     it('should validate body and call deploymentService.createDeployment', async () => {
-      const expectedResult = makeDeployment({ projectId: validCreateDeployment.projectId })
+      const expectedResult = makeDeployment()
 
       service.createDeployment.mockResolvedValue(expectedResult)
 
-      const result = await controller.create(validCreateDeployment)
+      const result = await controller.create(validCreateDeployment, project, user, request)
 
       expect(service.createDeployment).toHaveBeenCalledWith(
-        validCreateDeployment.projectId,
+        projectId,
         validCreateDeployment,
+        userId,
+        requestId,
       )
       expect(result).toEqual(expectedResult)
     })
@@ -106,11 +111,14 @@ describe('deploymentController', () => {
 
       service.updateDeployment.mockResolvedValue(expectedResult)
 
-      const result = await controller.update(deploymentId, validUpdateDeployment)
+      const result = await controller.update(deploymentId, validUpdateDeployment, project, user, request)
 
       expect(service.updateDeployment).toHaveBeenCalledWith(
+        projectId,
         deploymentId,
         validUpdateDeployment,
+        userId,
+        requestId,
       )
       expect(result).toEqual(expectedResult)
     })
@@ -122,9 +130,9 @@ describe('deploymentController', () => {
 
       service.deleteDeployment.mockResolvedValue(undefined)
 
-      const result = await controller.delete(deploymentId)
+      const result = await controller.delete(deploymentId, project, user, request)
 
-      expect(service.deleteDeployment).toHaveBeenCalledWith(deploymentId)
+      expect(service.deleteDeployment).toHaveBeenCalledWith(projectId, deploymentId, userId, requestId)
       expect(result).toBeUndefined()
     })
   })

--- a/apps/server-nestjs/src/modules/deployment/deployment.controller.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.controller.ts
@@ -1,40 +1,63 @@
 import type { CreateDeployment, UpdateDeployment } from '@cpn-console/shared'
+import type { FastifyRequest } from 'fastify'
+import type { UserContext } from '../infrastructure/auth/auth-user.decorator'
+import type { ProjectContext } from '../infrastructure/permission/project/project.guard'
 import { CreateDeploymentSchema, UpdateDeploymentSchema } from '@cpn-console/shared'
-import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Inject, Param, Post, Put, Query } from '@nestjs/common'
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Inject, Param, Post, Put, Req, UseGuards } from '@nestjs/common'
+import { AuthUser } from '../infrastructure/auth/auth-user.decorator'
+import { RequireProjectPermission } from '../infrastructure/permission/project/project-permission.decorator'
+import { Project } from '../infrastructure/permission/project/project.decorator'
+import { ProjectGuard } from '../infrastructure/permission/project/project.guard'
+import { RequireAdminPermission } from '../infrastructure/permission/user/user-admin-permission.decorator'
 import { ZodValidationPipe } from '../infrastructure/pipe/zod-validation.pipe'
 import { DeploymentService } from './deployment.service'
 
-// TODO add auth and project perms guard
-@Controller('api/v1/deployments')
+@Controller('api/v1/projects/:projectId/deployments')
+@UseGuards(ProjectGuard)
 export class DeploymentController {
   constructor(@Inject(DeploymentService) private readonly deploymentService: DeploymentService) {}
 
   @Get('')
-  list(@Query('projectId') projectId: string) {
-    return this.deploymentService.listByProjectId(projectId)
+  @RequireAdminPermission('ListProjects')
+  @RequireProjectPermission('ListDeployments')
+  list(@Project() project: ProjectContext) {
+    return this.deploymentService.listByProjectId(project.id)
   }
 
   @Post('')
+  @RequireProjectPermission('ManageDeployments')
   @HttpCode(HttpStatus.CREATED)
   create(
     @Body(new ZodValidationPipe(CreateDeploymentSchema)) data: CreateDeployment,
+    @Project() project: ProjectContext,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
   ) {
-    const projectId = data.projectId
-    return this.deploymentService.createDeployment(projectId, data)
+    return this.deploymentService.createDeployment(project.id, data, user.userId, request.id)
   }
 
-  @Put('/:deploymentId')
+  @Put(':deploymentId')
+  @RequireProjectPermission('ManageDeployments')
   @HttpCode(HttpStatus.OK)
   update(
     @Param('deploymentId') deploymentId: string, @Body(new ZodValidationPipe(UpdateDeploymentSchema))
     data: UpdateDeployment,
+    @Project() project: ProjectContext,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
   ) {
-    return this.deploymentService.updateDeployment(deploymentId, data)
+    return this.deploymentService.updateDeployment(project.id, deploymentId, data, user.userId, request.id)
   }
 
-  @Delete('/:deploymentId')
+  @Delete(':deploymentId')
+  @RequireProjectPermission('ManageDeployments')
   @HttpCode(HttpStatus.NO_CONTENT)
-  delete(@Param('deploymentId') deploymentId: string) {
-    return this.deploymentService.deleteDeployment(deploymentId)
+  delete(
+    @Param('deploymentId') deploymentId: string,
+    @Project() project: ProjectContext,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
+  ) {
+    return this.deploymentService.deleteDeployment(project.id, deploymentId, user.userId, request.id)
   }
 }

--- a/apps/server-nestjs/src/modules/deployment/deployment.service.spec.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.service.spec.ts
@@ -16,7 +16,11 @@ describe('deploymentService', () => {
   let appEvents: DeepMockProxy<AppEventsService>
 
   const projectId = '11111111-1111-1111-1111-111111111111'
+  const userId = 'user-uuid-1234'
+  const requestId = 'request-uuid-5678'
   const deploymentId = '22222222-2222-2222-2222-222222222222'
+
+  const okArgoCDResults = { argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 } }
 
   const validCreateDeployment = {
     name: 'mydeployment',
@@ -80,12 +84,13 @@ describe('deploymentService', () => {
   })
 
   describe('createDeployment', () => {
-    it('should create deployment and upsert project', async () => {
+    it('should create deployment and trigger a project reconciliation', async () => {
       const createdDeployment = makeDeployment({ id: deploymentId, projectId })
 
       datastore.createDeployment.mockResolvedValue(createdDeployment)
+      appEvents.emitProjectEvent.mockResolvedValue(okArgoCDResults)
 
-      const result = await service.createDeployment(projectId, validCreateDeployment)
+      const result = await service.createDeployment(projectId, validCreateDeployment, userId, requestId)
 
       expect(datastore.createDeployment).toHaveBeenCalledWith({
         name: validCreateDeployment.name,
@@ -105,13 +110,23 @@ describe('deploymentService', () => {
         },
       })
 
-      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, { action: 'Create Deployment' })
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, { action: 'Create Deployment', userId, requestId })
+      expect(result).toEqual(createdDeployment)
+    })
+
+    it('should return the deployment even when the reconciliation fails', async () => {
+      const createdDeployment = makeDeployment({ id: deploymentId, projectId })
+      datastore.createDeployment.mockResolvedValue(createdDeployment)
+      appEvents.emitProjectEvent.mockRejectedValue(new Error('sync error'))
+
+      const result = await service.createDeployment(projectId, validCreateDeployment, userId, requestId)
+
       expect(result).toEqual(createdDeployment)
     })
   })
 
   describe('updateDeployment', () => {
-    it('should update deployment and upsert project', async () => {
+    it('should update deployment and trigger a project reconciliation', async () => {
       const existingDeployment = makeDeploymentWithRelations({
         id: deploymentId,
         projectId,
@@ -125,8 +140,9 @@ describe('deploymentService', () => {
 
       datastore.getDeploymentById.mockResolvedValue(existingDeployment)
       datastore.updateDeployment.mockResolvedValue(updatedDeployment)
+      appEvents.emitProjectEvent.mockResolvedValue(okArgoCDResults)
 
-      const result = await service.updateDeployment(deploymentId, validUpdateDeployment)
+      const result = await service.updateDeployment(projectId, deploymentId, validUpdateDeployment, userId, requestId)
 
       expect(datastore.updateDeployment).toHaveBeenCalledWith(
         deploymentId,
@@ -141,7 +157,7 @@ describe('deploymentService', () => {
         }),
       )
 
-      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', validUpdateDeployment.projectId, { action: 'Update Deployment' })
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, { action: 'Update Deployment', userId, requestId })
       expect(result).toEqual(updatedDeployment)
     })
 
@@ -149,21 +165,47 @@ describe('deploymentService', () => {
       datastore.getDeploymentById.mockResolvedValue(null)
 
       await expect(
-        service.updateDeployment(deploymentId, validUpdateDeployment),
+        service.updateDeployment(projectId, deploymentId, validUpdateDeployment, userId, requestId),
       ).rejects.toThrow(`Deployment with id ${deploymentId} not found`)
 
       expect(datastore.updateDeployment).not.toHaveBeenCalled()
     })
+
+    it('should return the deployment even when the reconciliation fails', async () => {
+      const existingDeployment = makeDeploymentWithRelations({
+        id: deploymentId,
+        projectId,
+        deploymentSources: [
+          makeDeploymentSource({ id: '55555555-5555-5555-5555-555555555555', deploymentId }),
+        ],
+      })
+      const updatedDeployment = makeDeployment({ id: deploymentId, projectId })
+      datastore.getDeploymentById.mockResolvedValue(existingDeployment)
+      datastore.updateDeployment.mockResolvedValue(updatedDeployment)
+      appEvents.emitProjectEvent.mockRejectedValue(new Error('sync error'))
+
+      const result = await service.updateDeployment(projectId, deploymentId, validUpdateDeployment, userId, requestId)
+
+      expect(result).toEqual(updatedDeployment)
+    })
   })
 
   describe('deleteDeployment', () => {
-    it('should delete deployment and upsert project', async () => {
+    it('should delete deployment and trigger a project reconciliation', async () => {
       datastore.deleteDeployment.mockResolvedValue(makeDeployment({ id: deploymentId, projectId }))
+      appEvents.emitProjectEvent.mockResolvedValue(okArgoCDResults)
 
-      await service.deleteDeployment(deploymentId)
+      await service.deleteDeployment(projectId, deploymentId, userId, requestId)
 
       expect(datastore.deleteDeployment).toHaveBeenCalledWith(deploymentId)
-      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, { action: 'Delete Deployment' })
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, { action: 'Delete Deployment', userId, requestId })
+    })
+
+    it('should resolve even when the reconciliation fails', async () => {
+      datastore.deleteDeployment.mockResolvedValue(makeDeployment({ id: deploymentId, projectId }))
+      appEvents.emitProjectEvent.mockRejectedValue(new Error('sync error'))
+
+      await expect(service.deleteDeployment(projectId, deploymentId, userId, requestId)).resolves.toBeUndefined()
     })
   })
 

--- a/apps/server-nestjs/src/modules/deployment/deployment.service.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.service.ts
@@ -1,11 +1,13 @@
 import type { CreateDeployment, UpdateDeployment } from '@cpn-console/shared'
 import type { EventLogAction } from '../events/app-events.service'
-import { Inject, Injectable } from '@nestjs/common'
+import { Inject, Injectable, Logger } from '@nestjs/common'
 import { AppEventsService } from '../events/app-events.service'
 import { DeploymentDatastoreService } from './deployment-datastore.service'
 
 @Injectable()
 export class DeploymentService {
+  private readonly logger = new Logger(DeploymentService.name)
+
   constructor(
     @Inject(DeploymentDatastoreService) private readonly deploymentDatastoreService: DeploymentDatastoreService,
     @Inject(AppEventsService) private readonly appEvents: AppEventsService,
@@ -15,7 +17,7 @@ export class DeploymentService {
     return this.deploymentDatastoreService.getDeploymentsByProjectId(projectId)
   }
 
-  async createDeployment(projectId: string, deploymentToCreate: CreateDeployment) {
+  async createDeployment(projectId: string, deploymentToCreate: CreateDeployment, userId: string, requestId: string) {
     const deployment = await this.deploymentDatastoreService.createDeployment({
       name: deploymentToCreate.name,
       project: { connect: { id: projectId } },
@@ -34,11 +36,11 @@ export class DeploymentService {
       },
     })
 
-    await this.upsertProject(projectId, 'Create Deployment')
+    this.reconcileProject(projectId, 'Create Deployment', userId, requestId)
     return deployment
   }
 
-  async updateDeployment(deploymentId: string, deploymentToUpdate: UpdateDeployment) {
+  async updateDeployment(projectId: string, deploymentId: string, deploymentToUpdate: UpdateDeployment, userId: string, requestId: string) {
     const existing = await this.deploymentDatastoreService.getDeploymentById(deploymentId)
     if (!existing) throw new Error(`Deployment with id ${deploymentId} not found`)
 
@@ -79,21 +81,28 @@ export class DeploymentService {
         })),
       },
     })
-    await this.upsertProject(deploymentToUpdate.projectId, 'Update Deployment')
+    this.reconcileProject(projectId, 'Update Deployment', userId, requestId)
     return deployment
   }
 
-  async deleteDeployment(deploymentId: string) {
-    const deployment = await this.deploymentDatastoreService.deleteDeployment(deploymentId)
-    await this.upsertProject(deployment.projectId, 'Delete Deployment')
+  async deleteDeployment(projectId: string, deploymentId: string, userId: string, requestId: string) {
+    await this.deploymentDatastoreService.deleteDeployment(deploymentId)
+    this.reconcileProject(projectId, 'Delete Deployment', userId, requestId)
   }
 
   async deleteAllDeploymentsByProjectId(projectId: string) {
     await this.deploymentDatastoreService.deleteAllDeploymentsByProjectId(projectId)
-    await this.upsertProject(projectId, 'Delete all project deployments')
+    await this.appEvents.emitProjectEvent('project.upsert', projectId, { action: 'Delete all project deployments' })
   }
 
-  private async upsertProject(projectId: string, action: EventLogAction) {
-    await this.appEvents.emitProjectEvent('project.upsert', projectId, { action })
+  /**
+   * Triggers the project reconciliation without blocking the response: listener
+   * outcomes (including failures) are persisted in the admin log by AppEventsService.
+   */
+  private reconcileProject(projectId: string, action: EventLogAction, userId: string, requestId: string) {
+    this.appEvents.emitProjectEvent('project.upsert', projectId, { action, userId, requestId })
+      .catch((error: unknown) => {
+        this.logger.error(`project.upsert reconciliation failed (projectId=${projectId})`, error instanceof Error ? error.stack : String(error))
+      })
   }
 }

--- a/apps/server-nestjs/src/prisma/migrations/20260615095046_cascade_delete_deployment/migration.sql
+++ b/apps/server-nestjs/src/prisma/migrations/20260615095046_cascade_delete_deployment/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "Deployment" DROP CONSTRAINT "Deployment_environmentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "DeploymentSource" DROP CONSTRAINT "DeploymentSource_repositoryId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Deployment" ADD CONSTRAINT "Deployment_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DeploymentSource" ADD CONSTRAINT "DeploymentSource_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/server-nestjs/src/prisma/schema/project.prisma
+++ b/apps/server-nestjs/src/prisma/schema/project.prisma
@@ -7,7 +7,7 @@ model Deployment {
   updatedAt         DateTime           @updatedAt
   environmentId     String             @db.Uuid
   project           Project            @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  environment       Environment        @relation(fields: [environmentId], references: [id])
+  environment       Environment        @relation(fields: [environmentId], references: [id], onDelete: Cascade)
   deploymentSources DeploymentSource[]
 }
 
@@ -21,7 +21,7 @@ model DeploymentSource {
   targetRevision  String               @default("")
   path            String               @default("")
   helmValuesFiles String               @default("")
-  repository      Repository           @relation(fields: [repositoryId], references: [id])
+  repository      Repository           @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
   deployment      Deployment           @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
 }
 

--- a/apps/server/src/prisma/migrations/20260615095046_cascade_delete_deployment/migration.sql
+++ b/apps/server/src/prisma/migrations/20260615095046_cascade_delete_deployment/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "Deployment" DROP CONSTRAINT "Deployment_environmentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "DeploymentSource" DROP CONSTRAINT "DeploymentSource_repositoryId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Deployment" ADD CONSTRAINT "Deployment_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DeploymentSource" ADD CONSTRAINT "DeploymentSource_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/server/src/prisma/schema/project.prisma
+++ b/apps/server/src/prisma/schema/project.prisma
@@ -7,7 +7,7 @@ model Deployment {
   updatedAt         DateTime           @updatedAt
   environmentId     String             @db.Uuid
   project           Project            @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  environment       Environment        @relation(fields: [environmentId], references: [id])
+  environment       Environment        @relation(fields: [environmentId], references: [id], onDelete: Cascade)
   deploymentSources DeploymentSource[]
 }
 
@@ -21,7 +21,7 @@ model DeploymentSource {
   targetRevision  String               @default("")
   path            String               @default("")
   helmValuesFiles String               @default("")
-  repository      Repository           @relation(fields: [repositoryId], references: [id])
+  repository      Repository           @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
   deployment      Deployment           @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
 }
 

--- a/packages/shared/src/schemas/deployment.ts
+++ b/packages/shared/src/schemas/deployment.ts
@@ -1,13 +1,13 @@
 import type Zod from 'zod'
 import { z } from 'zod'
-import { longestEnvironmentName } from '../utils/const.js'
+import { longestDeploymentName } from '../utils/const.js'
 import { AtDatesToStringExtend } from './_utils.js'
 import { EnvironmentSchema } from './environment.js'
 import { RepoSchema } from './repository.js'
 
 const DeploymentSourceType = z.enum(['git', 'oci'])
 
-const DeploymentSourceSchema = z.object({
+export const DeploymentSourceSchema = z.object({
   id: z.string()
     .uuid(),
   deploymentId: z.string()
@@ -28,7 +28,7 @@ export const DeploymentSchema = z.object({
   name: z.string()
     .regex(/^[a-z0-9]+$/)
     .min(2)
-    .max(longestEnvironmentName),
+    .max(longestDeploymentName),
   projectId: z.string()
     .uuid(),
   environmentId: z.string()

--- a/packages/shared/src/utils/const.ts
+++ b/packages/shared/src/utils/const.ts
@@ -26,6 +26,7 @@ export const projectRoles = [
 export type ProjectRoles = typeof projectRoles[number]
 
 export const longestEnvironmentName = 11 as const
+export const longestDeploymentName = 11 as const
 
 export const allStatus = [
   'initializing',

--- a/packages/shared/src/utils/permissions.ts
+++ b/packages/shared/src/utils/permissions.ts
@@ -59,6 +59,8 @@ export const PROJECT_PERMS = { // project permissions
   LIST_REPOSITORIES: bit(9n),
   LIST_MEMBERS: bit(10n),
   LIST_ROLES: bit(11n),
+  MANAGE_DEPLOYMENTS: bit(12n),
+  LIST_DEPLOYMENTS: bit(13n),
 }
 
 // Be very careful and think to apply corresponding updates in database if you modify these values, You'll have to do binary updates in SQL, good luck !
@@ -142,6 +144,10 @@ export const ProjectAuthorized = {
 
   SeeSecrets: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
     || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.SEE_SECRETS | PROJECT_PERMS.MANAGE)),
+  ManageDeployments: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
+    || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.MANAGE_DEPLOYMENTS | PROJECT_PERMS.MANAGE)),
+  ListDeployments: (perms: ProjectAuthorizedParams) => AdminAuthorized.Manage(perms.adminPermissions)
+    || !!(toBigInt(perms.projectPermissions) & (PROJECT_PERMS.LIST_DEPLOYMENTS | PROJECT_PERMS.MANAGE)),
 } as const
 
 interface ScopePerm<T extends string> {
@@ -207,6 +213,20 @@ export const projectPermsDetails: PermDetails<ProjectPermsKeys> = [{
       key: 'LIST_REPOSITORIES',
       label: 'Voir les dépôts',
       hint: 'Permet de visualiser tous les dépôts et leurs configurations',
+    },
+  ],
+}, {
+  name: 'Déploiements',
+  perms: [
+    {
+      key: 'MANAGE_DEPLOYMENTS',
+      label: 'Gérer les déploiements',
+      hint: 'Permet de créer, éditer, supprimer des déploiements',
+    },
+    {
+      key: 'LIST_DEPLOYMENTS',
+      label: 'Voir les déploiements',
+      hint: 'Permet de visualiser tous les déploiements et leurs configurations',
     },
   ],
 }] as const


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

Les endpoints de déploiement sont exposés sous `/api/v1/deployments` avec le `projectId` passé en query/body, sans garde de permission (un TODO `add auth and project perms guard` était présent). N'importe quel utilisateur authentifié peut donc lister, créer, modifier ou supprimer des déploiements sans vérification des droits sur le projet.

## Quel est le nouveau comportement ?

Sécurisation de l'API de déploiement via les permissions projet :

- Déplacement des routes sous `/api/v1/projects/:projectId/deployments` et application du `ProjectGuard`.
- Ajout des permissions requises par endpoint : `ListDeployments` / `ManageDeployments` (`RequireProjectPermission`) et `RequireAdminPermission` sur la liste.
- Réutilisation des décorateurs existants `@Project()` et `@AuthUser()` (plus `request.id`) pour résoudre projet/utilisateur depuis la requête, sans nouveau décorateur dédié.
- Réconciliation en style GitOps : les mutations de déploiement émettent l'événement générique `project.upsert` (pas d'événement spécifique ArgoCD) de manière asynchrone ; la réponse HTTP n'attend pas la synchronisation et les échecs sont tracés dans le journal d'administration via `AppEventsService`.
- Ajout d'utilitaires de résultats de plugins (`PluginResults`, `mergePluginResults`, `getFailedPlugins`).
- Suppression en cascade des déploiements (migration Prisma + mise à jour du schéma).
- Renommage de la limite de nom en `longestDeploymentName` et export de `DeploymentSourceSchema`.
- Extension des services argocd/deployment et du datastore, ajout d'utilitaires de test et enrichissement des specs controller/service.

## Cette PR introduit-elle un breaking change ?

Oui. Les URLs des endpoints de déploiement changent : le `projectId` passe de query/body à un segment de path (`/api/v1/projects/:projectId/deployments`). Les clients appelant l'ancienne route `/api/v1/deployments` doivent être mis à jour.

## Autres informations
