### PR TITLE
feat(client): add deployment management UI

### DIFF
--- a/apps/client/src/components/DeleteForm.vue
+++ b/apps/client/src/components/DeleteForm.vue
@@ -1,0 +1,73 @@
+<script lang="ts" setup>
+const props = withDefaults(defineProps<{
+  disabled?: boolean
+  deleteValidationInput?: string
+  isLoading?: boolean
+}>(), {
+  disabled: false,
+  deleteValidationInput: 'DELETE',
+  isLoading: false,
+})
+
+defineEmits<{
+  delete: []
+}>()
+
+const isDeleting = ref(false)
+const deleteConfirmValue = ref('')
+</script>
+
+<template>
+  <div
+    class="danger-zone"
+  >
+    <div class="danger-zone-btns">
+      <DsfrButton
+        v-show="!isDeleting"
+        label="Supprimer"
+        danger
+        :disabled="props.disabled"
+        icon="ri:delete-bin-7-line"
+        @click="isDeleting = true"
+      />
+      <DsfrAlert
+        class="<md:mt-2"
+        description="La suppression est irréversible."
+        type="warning"
+        small
+      />
+    </div>
+    <div
+      v-if="isDeleting"
+      class="fr-mt-4w"
+    >
+      <DsfrInput
+        v-model="deleteConfirmValue"
+        :label="`Veuillez taper '${deleteValidationInput}' pour confirmer la suppression de l'environnement`"
+        label-visible
+        :placeholder="deleteValidationInput"
+        class="fr-mb-2w"
+      />
+      <div
+        class="flex justify-between"
+      >
+        <div class="flex">
+          <DsfrButton
+            label="Supprimer définitivement"
+            :disabled="deleteConfirmValue !== deleteValidationInput || props.isLoading"
+            title="Supprimer définitivement"
+            danger
+            icon="ri:delete-bin-7-line"
+            @click="$emit('delete')"
+          />
+          <DsfrButton v-if="props.isLoading" :icon="{ name: 'ri:refresh-line', animation: 'spin' }" icon-only disabled />
+        </div>
+        <DsfrButton
+          label="Annuler"
+          primary
+          @click="isDeleting = false"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/client/src/components/DeploymentCard.vue
+++ b/apps/client/src/components/DeploymentCard.vue
@@ -1,0 +1,46 @@
+<script lang="ts" setup>
+import type { Deployment, Stage } from '@cpn-console/shared'
+
+defineProps<{ deployment: Deployment & { stage?: Stage } }>()
+</script>
+
+<template>
+  <div class="fr-card fr-enlarge-link cursor-pointer w-1/5 min-w-xs">
+    <div class="fr-card__body">
+      <div class="fr-card__content fr-px-4v fr-pb-4v fr-pt-5v">
+        <p class="font-bold">
+          {{ deployment.name }}
+        </p>
+        <DsfrBadge
+          class="fr-mb-0"
+          :label="`${deployment.environment.name}${deployment.stage?.name ? ` • ${deployment.stage.name}` : ''}`"
+          no-icon
+          small
+          type="info"
+        />
+        <p class="fr-text--sm fr-text-mention--grey uppercase font-bold fr-my-4v">
+          {{ deployment.deploymentSources.length }}
+          <template v-if="deployment.deploymentSources.length > 1">
+            dépôts
+          </template>
+          <template v-else>
+            dépôt
+          </template>
+        </p>
+        <div class="flex flex-wrap items-start gap-2 mb-4">
+          <div
+            v-for="source in deployment.deploymentSources"
+            :key="source.id"
+            class="px-2 py-1 shadow fr-background-alt--grey flex items-center gap-2 fr-text--sm mb-0"
+          >
+            <v-icon name="mdi:git" class="flex-shrink-0" />
+            {{ source.repository.internalRepoName }}
+            <span class="text-xs fr-m-0 fr-text-mention--grey font-mono leading-none">
+              {{ source.targetRevision || 'HEAD' }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/client/src/components/DeploymentModal.vue
+++ b/apps/client/src/components/DeploymentModal.vue
@@ -1,0 +1,182 @@
+<script lang="ts" setup>
+import type { Cluster, Deployment, Environment, Stage, UpdateDeployment, Zone } from '@cpn-console/shared'
+import type { DsfrRadioButtonProps } from '@gouvminint/vue-dsfr'
+import type { Project } from '@/utils/project-utils.js'
+import { CreateDeploymentSchema, DeploymentSchema, longestDeploymentName } from '@cpn-console/shared'
+import { useSnackbarStore } from '@/stores/snackbar.js'
+import { scrollToFirstError } from '@/utils/func.js'
+
+const props = withDefaults(defineProps<{
+  opened: boolean
+  environments: (Environment & { cluster?: Cluster, zone?: Zone, stage?: Stage })[]
+  repoOptions: { text: string, value: string }[]
+  deployment?: Deployment
+  project: Project
+  disabled?: boolean
+}>(), { opened: false, disabled: false })
+
+const emit = defineEmits<{ close: [] }>()
+
+const snackbarStore = useSnackbarStore()
+
+const { opened } = toRefs(props)
+
+const options: ComputedRef<Omit<DsfrRadioButtonProps, 'modelValue'>[]> = computed(
+  () => props.environments.map(env => ({
+    hint: env.stage?.name,
+    label: env.name,
+    value: env.id,
+    class: 'fr-p-0',
+  })),
+)
+
+const deployment = ref<Partial<UpdateDeployment & { id: string }>>(
+  props.deployment ? { ...props.deployment } : { projectId: props.project.id, autosync: true },
+)
+
+watch(() => props.deployment, (newValue) => {
+  deployment.value = newValue ? { ...newValue } : { projectId: props.project.id, autosync: true }
+}, { deep: true })
+
+const deploymentSourcesModel = computed({
+  get: () => deployment.value?.deploymentSources ?? [],
+  set: (value: UpdateDeployment['deploymentSources']) =>
+    deployment.value = { ...deployment.value, deploymentSources: value },
+})
+
+const isLoading = ref(false)
+const isDeleting = ref(false)
+const isDirty = ref(false)
+
+const formContainer = ref<HTMLDivElement | null>(null)
+
+const isNew = computed(() => !deployment.value.id)
+
+const nameErrorMessage = computed(() => {
+  if (!deployment.value.name && !isDirty.value) return undefined
+  if (DeploymentSchema.pick({ name: true }).safeParse({ name: deployment.value.name }).success) return undefined
+  return `Le nom du déploiement est requis et ne doit pas contenir d'espace, doit être unique pour le projet et le cluster sélectionnés, être en minuscules et faire plus de 2 et moins de ${longestDeploymentName} caractères.`
+})
+
+const environmentErrorMessage = computed(() => {
+  if (!deployment.value.environmentId && !isDirty.value) return undefined
+  if (DeploymentSchema.pick({ environmentId: true }).safeParse({ environmentId: deployment.value.environmentId }).success) return undefined
+  return `L'environnement est requis`
+})
+
+function upsertDeployment() {
+  if (isLoading.value) return
+
+  const body = CreateDeploymentSchema.safeParse(deployment.value)
+  if (!body.success) {
+    isDirty.value = true
+    scrollToFirstError(formContainer)
+    return
+  }
+
+  isLoading.value = true
+  if (deployment.value.id) {
+    props.project.Deployments.update(deployment.value.id, body.data)
+      .then(() => {
+        closeModal()
+        snackbarStore.setMessage('Déploiement enregistré, opérations en cours en arrière-plan...')
+      })
+      .catch(error => snackbarStore.setMessage(error, 'error'))
+      .finally(() => isLoading.value = false)
+  } else {
+    props.project.Deployments.create(body.data)
+      .then(() => {
+        closeModal()
+        snackbarStore.setMessage('Déploiement enregistré, opérations en cours en arrière-plan...')
+      })
+      .catch(error => snackbarStore.setMessage(error, 'error'))
+      .finally(() => isLoading.value = false)
+  }
+}
+
+function deleteDeployment() {
+  if (isDeleting.value || !deployment.value.id) return
+
+  isDeleting.value = true
+  props.project.Deployments.delete(deployment.value.id)
+    .then(() => {
+      closeModal()
+      snackbarStore.setMessage('Suppression du déploiement enregistrée, opérations en cours en arrière-plan...')
+    })
+    .catch(error => snackbarStore.setMessage(error, 'error'))
+    .finally(() => isDeleting.value = false)
+}
+
+function closeModal() {
+  isDirty.value = false
+  deployment.value = { projectId: props.project.id, autosync: true }
+  emit('close')
+}
+</script>
+
+<template>
+  <DsfrModal title="" :opened is-alert @close="closeModal">
+    <div ref="formContainer" class="w-full">
+      <h4>
+        <template v-if="deployment.id">
+          Modifier le déploiement
+        </template>
+        <template v-else>
+          Ajouter un déploiement au projet
+        </template>
+      </h4>
+
+      <div class="w-full">
+        <DsfrInputGroup
+          v-model="deployment.name"
+          label="Nom du déploiement"
+          class="fr-mb-2v"
+          label-visible
+          :required="true"
+          :error-message="nameErrorMessage"
+          placeholder="deploy0"
+          :disabled="props.disabled"
+          :hint="`Ne doit pas contenir d'espace ni de trait d'union, doit être unique pour le projet et le cluster sélectionnés, être en minuscules et faire plus de 2 et moins de ${longestDeploymentName} caractères.`"
+        />
+      </div>
+
+      <h6 class="fr-mb-0">
+        Environnement cible
+      </h6>
+      <p class="fr-text--sm fr-text-mention--grey fr-mb-0">
+        Un déploiement est lié à exactement 1 environnement
+      </p>
+      <DsfrRadioButtonSet
+        v-model="deployment.environmentId"
+        :options="options"
+        :rich="true"
+        :required="true"
+        :disabled="props.disabled"
+        :error-message="environmentErrorMessage"
+      />
+
+      <h6 class="fr-mb-0">
+        Dépôts à inclure
+      </h6>
+      <DeploymentRepoSelect v-model="deploymentSourcesModel" :is-dirty :repo-options="repoOptions" :disabled="props.disabled" />
+    </div>
+    <div class="w-full flex justify-end gap-4">
+      <DsfrButton
+        v-if="!props.disabled"
+        label="Enregistrer"
+        primary
+        size="md"
+        :icon="isLoading ? { name: 'ri:refresh-line', animation: 'spin' } : undefined"
+        :icon-right="isLoading"
+        @click="upsertDeployment"
+      />
+      <DsfrButton
+        label="Annuler"
+        secondary
+        size="md"
+        @click="closeModal"
+      />
+    </div>
+    <DeleteForm v-if="!isNew && !props.disabled" :is-loading="isDeleting" @delete="deleteDeployment" />
+  </DsfrModal>
+</template>

--- a/apps/client/src/components/DeploymentRepoOption.vue
+++ b/apps/client/src/components/DeploymentRepoOption.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import type { UpdateDeployment } from '@cpn-console/shared'
+import { DeploymentSourceSchema } from '@cpn-console/shared'
+
+withDefaults(defineProps<{
+  cantDelete: boolean
+  options: { text: string, value: string }[]
+  disabled?: boolean
+  isDirty?: boolean
+}>(), {
+  options: () => [],
+  cantDelete: false,
+  disabled: false,
+  isDirty: false,
+})
+defineEmits<{ delete: [] }>()
+
+const model = defineModel<Partial<UpdateDeployment['deploymentSources'][0]>>(
+  {
+    default: {
+      id: undefined,
+      type: 'git',
+      repositoryId: undefined,
+      targetRevision: undefined,
+      path: undefined,
+      helmValuesFiles: undefined,
+    },
+  },
+)
+</script>
+
+<template>
+  <div class="w-full">
+    <div v-if="!($props.cantDelete || $props.disabled)" class="flex w-full justify-end">
+      <DsfrButton icon-only icon="ri:delete-bin-7-line" secondary @click="$emit('delete')" />
+    </div>
+    <DsfrSelect v-model="model.repositoryId" label="Dépôt" :options="$props.options" required :disabled="$props.disabled" :error-message="$props.isDirty && !DeploymentSourceSchema.pick({ repositoryId: true }).safeParse({ repositoryId: model.repositoryId }).success ? 'Le dépôt est requis' : undefined" />
+    <DsfrInputGroup
+      v-model="model.targetRevision"
+      class="mb-2"
+      placeholder="HEAD"
+      label="Nom de la révision à déployer (branche, tag, commit)"
+      label-visible
+      :disabled="$props.disabled"
+    />
+    <DsfrInputGroup
+      v-model="model.path"
+      class="mb-2"
+      placeholder="."
+      label="Chemin du répertoire à déployer"
+      label-visible
+      :disabled="$props.disabled"
+    />
+    <DsfrInputGroup
+      v-model="model.helmValuesFiles"
+      class="mb-2"
+      is-textarea
+      label="Fichiers values (Helm)"
+      label-visible
+      hint="Un fichier par ligne, chemin relatif par rapport au répertoire à déployer. L'ordre des fichiers est déterminant pour la surcharge des valeurs communes. Champ optionnel."
+      placeholder="values/extra.yaml
+values-<env>/custom.yaml"
+      :disabled="$props.disabled"
+    />
+  </div>
+</template>
+
+<style lang="css" scoped>
+.fr-select-group,
+.fr-input-group {
+  margin-bottom: .75rem;
+}
+</style>

--- a/apps/client/src/components/DeploymentRepoSelect.vue
+++ b/apps/client/src/components/DeploymentRepoSelect.vue
@@ -1,0 +1,65 @@
+<script lang="ts" setup>
+import type { UpdateDeployment } from '@cpn-console/shared'
+
+withDefaults(defineProps<{
+  repoOptions: { text: string, value: string }[]
+  disabled?: boolean
+  isDirty?: boolean
+}>(), { disabled: false, isDirty: false })
+
+const depots = defineModel<Partial<UpdateDeployment['deploymentSources'][0]>[]>({ default: [] })
+
+if (depots.value.length === 0) {
+  addDepot()
+}
+
+function addDepot() {
+  depots.value = [
+    ...depots.value,
+    {
+      id: undefined,
+      type: 'git',
+      repositoryId: undefined,
+      targetRevision: undefined,
+      path: undefined,
+      helmValuesFiles: undefined,
+    },
+  ]
+}
+
+function removeDepot(index: number) {
+  depots.value = depots.value.filter((_, i) => i !== index)
+}
+
+function updateDepot(index: number, value: Partial<UpdateDeployment['deploymentSources'][0]>) {
+  depots.value[index] = value
+}
+</script>
+
+<template>
+  <div class="p-2">
+    <div class="w-full flex flex-col gap-2">
+      <DeploymentRepoOption
+        v-for="(depot, index) in depots"
+        :key="depot.id ?? `new-${index}`"
+        :model-value="depot"
+        :options="$props.repoOptions"
+        class="w-full py-2 px-4 border border-solid border-gray-300"
+        :cant-delete="index === 0"
+        :disabled="$props.disabled"
+        :is-dirty="$props.isDirty"
+        @update:model-value="(value :Partial<UpdateDeployment['deploymentSources'][0]>) => updateDepot(index, value)"
+        @delete="removeDepot(index)"
+      />
+    </div>
+    <div v-if="!$props.disabled" class="w-full flex mt-4">
+      <DsfrButton
+        type="button"
+        label="Ajouter un dépôt"
+        icon="ri:add-line"
+        secondary
+        @click="addDepot"
+      />
+    </div>
+  </div>
+</template>

--- a/apps/client/src/components/DeploymentResources.vue
+++ b/apps/client/src/components/DeploymentResources.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import type { Cluster, Deployment, Environment, Repo, Stage, Zone } from '@cpn-console/shared'
+import type { Project } from '@/utils/project-utils.js'
+import { ProjectAuthorized } from '@cpn-console/shared'
+import { useSnackbarStore } from '@/stores/snackbar.js'
+
+const props = defineProps<{
+  environments: (Environment & { cluster?: Cluster, zone?: Zone, stage?: Stage })[]
+  repositories: (Repo & { source: string })[]
+  project: Project
+  asProfile: 'user' | 'admin'
+}>()
+
+const snackbarStore = useSnackbarStore()
+
+const deployments = ref<Deployment[]>([])
+const repoOptions = computed(() => props.repositories.map(repo => ({
+  text: repo.internalRepoName,
+  value: repo.id,
+})))
+
+const deploymentsWithStage = computed(() => deployments.value.map((deployment) => {
+  const stage = props.environments.find(env => env.id === deployment.environmentId)?.stage
+  return {
+    ...deployment,
+    stage,
+  }
+}))
+
+const canManageDeploy = computed(() => !props.project.locked && props.asProfile === 'user' && ProjectAuthorized.ManageDeployments({ projectPermissions: props.project.myPerms }))
+
+const isModalOpen = ref(false)
+const selectedDeployment = ref<Deployment>()
+
+function openModal(deployment?: Deployment) {
+  if (!deployment && (props.environments.length === 0 || props.repositories.length === 0)) {
+    snackbarStore.setMessage('Pour créer un déploiement, vous devez d\'abord créer un environnement et un dépôt.', 'error')
+    return
+  }
+  selectedDeployment.value = deployment
+  isModalOpen.value = true
+}
+
+function closeModal() {
+  loadDeployments()
+  isModalOpen.value = false
+}
+
+async function loadDeployments() {
+  deployments.value = await props.project.Deployments.list()
+}
+
+onMounted(loadDeployments)
+
+watch([() => props.environments, () => props.repositories], () => {
+  loadDeployments()
+})
+</script>
+
+<template>
+  <div class="w-full">
+    <div class="w-full flex justify-between items-start">
+      <div>
+        <h4 class="fr-mb-0">
+          Déploiements
+        </h4>
+        <p>Associez un environnement à un ou plusieurs dépôts pour configurer un déploiment.</p>
+      </div>
+      <DsfrButton
+        v-if="canManageDeploy"
+        label="Ajouter un nouveau déploiement"
+        tertiary
+        title="Ajouter un déploiement"
+        icon="ri:add-line"
+        @click="() => openModal()"
+      />
+    </div>
+    <div class="w-full flex items-stretch gap-4 flex-wrap">
+      <DeploymentCard
+        v-for="deployment in deploymentsWithStage"
+        :key="deployment.id"
+        :deployment="deployment"
+        @click="() => openModal(deployment)"
+      />
+    </div>
+  </div>
+  <DeploymentModal
+    v-model:opened="isModalOpen"
+    :environments="props.environments"
+    :repo-options="repoOptions"
+    :project="props.project"
+    :deployment="selectedDeployment"
+    :disabled="!canManageDeploy"
+    @close="closeModal"
+  />
+</template>

--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CleanedCluster, Cluster, CreateEnvironmentBody, Environment, Repo, UpdateEnvironmentBody, Zone } from '@cpn-console/shared'
+import type { CleanedCluster, Cluster, CreateEnvironmentBody, Environment, Repo, Stage, UpdateEnvironmentBody, Zone } from '@cpn-console/shared'
 import type { Project } from '@/utils/project-utils.js'
 import { logger } from '@cpn-console/logger/browser'
 import { AdminAuthorized, ProjectAuthorized, projectIsLockedInfo } from '@cpn-console/shared'
@@ -25,8 +25,8 @@ const snackbarStore = useSnackbarStore()
 const stageStore = useStageStore()
 const userStore = useUserStore()
 
-const environments = ref<(Environment & { cluster?: Cluster, zone?: Zone })[]>()
-const repositories = ref<(Repo & { source: Source })[]>()
+const environments = ref<(Environment & { cluster?: Cluster, zone?: Zone, stage?: Stage })[]>([])
+const repositories = ref<(Repo & { source: Source })[]>([])
 const projectUsage = ref<({
   hprod: { cpu: number, gpu: number, memory: number }
   prod: { cpu: number, gpu: number, memory: number }
@@ -62,6 +62,7 @@ const projectClusters = computed(() => ([
 
 const canManageEnvs = computed(() => !props.project.locked && props.asProfile === 'user' && ProjectAuthorized.ManageEnvironments({ projectPermissions: props.project.myPerms }))
 const canManageRepos = computed(() => !props.project.locked && props.asProfile === 'user' && ProjectAuthorized.ManageRepositories({ projectPermissions: props.project.myPerms }))
+const canListDeploy = computed(() => ProjectAuthorized.ListDeployments({ projectPermissions: props.project.myPerms }))
 
 watch(selectedRepo, async () => {
   branchName.value = defaultBranchName
@@ -135,10 +136,12 @@ async function reload() {
     .then(envs => envs.map((environment: Environment) => {
       const cluster = clusterStore.clusters.find(cluster => cluster.id === environment.clusterId)
       const zone = zoneStore.zones.find(zone => zone.id === cluster?.zoneId)
+      const stage = stageStore.stages.find(stage => stage.id === environment.stageId)
       return {
         ...environment,
         cluster,
         zone,
+        stage,
       }
     }))
   repositories.value = await props.project.Repositories.list()
@@ -201,6 +204,7 @@ async function copyToClipboard(text: string) {
 </script>
 
 <template>
+  <DeploymentResources v-if="canListDeploy" :as-profile="props.asProfile" :environments :repositories :project />
   <div
     class="grow"
   >

--- a/apps/client/src/main.css
+++ b/apps/client/src/main.css
@@ -42,6 +42,7 @@ body,
 .fr-fieldset {
   margin: 1rem 0 0;
   align-items: flex-start;
+  min-width: 0;
 }
 
 .fr-checkbox-group {
@@ -70,6 +71,10 @@ body,
 
 .fr-alert {
   background-color: var(--background-alt-grey);
+}
+
+.fr-alert pre {
+  white-space: normal;
 }
 
 .log-panel, .log-btn {

--- a/apps/client/src/utils/func.ts
+++ b/apps/client/src/utils/func.ts
@@ -1,3 +1,4 @@
+import type { Ref } from 'vue'
 import { useSnackbarStore } from '@/stores/snackbar.js'
 
 const LOCALE = navigator.language.slice(0, 2)
@@ -84,4 +85,19 @@ export function localeParseFloat(s: string): number {
   const delocalizedInput = s.replaceAll(THOUSANDS_SEPARATOR, '').replaceAll(DECIMAL_SEPARATOR, '.')
   // Now it can be parsed
   return Number.parseFloat(delocalizedInput)
+}
+
+export async function scrollToFirstError(container: Ref<HTMLDivElement | null>) {
+  await nextTick()
+
+  if (!container.value) return
+
+  const firstErrorElement = container.value.querySelector('.fr-error-text, .fr-input-group--error')
+
+  if (firstErrorElement) {
+    firstErrorElement.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    })
+  }
 }

--- a/apps/client/src/utils/project-utils.ts
+++ b/apps/client/src/utils/project-utils.ts
@@ -1,6 +1,8 @@
 import type {
+  CreateDeploymentBody,
   CreateEnvironmentBody,
   CreateRepositoryBody,
+  Deployment,
   Environment,
   GetLogsQuery,
   PermissionTarget,
@@ -13,6 +15,7 @@ import type {
   Repo,
   RepositoryParams,
   Role,
+  UpdateDeploymentBody,
   UpdateEnvironmentBody,
   UpdateRepositoryBody,
   User,
@@ -35,6 +38,7 @@ import { getRandomId } from './func.js'
 
 export type ProjectOperations = 'create'
   | 'delete'
+  | 'deploymentManagement'
   | 'envManagement'
   | 'repoManagement'
   | 'teamManagement'
@@ -80,6 +84,7 @@ export class Project implements ProjectV2 {
   myPerms: bigint
   repositories: Ref<Repo[]>
   environments: Ref<Environment[]>
+  deployments: Ref<Deployment[]>
   services: ProjectService[] = []
   lastSuccessProvisionningVersion: string | null
   needReplay: Ref<boolean>
@@ -112,6 +117,7 @@ export class Project implements ProjectV2 {
     this.environments = ref([])
     this.repositories = ref([])
     this.needReplay = ref(false)
+    this.deployments = ref([])
   }
 
   private removeOperation(operationName: ProjectOperations) {
@@ -226,6 +232,43 @@ export class Project implements ProjectV2 {
     getCandidateUsers: async (letters: string) => {
       return apiClient.Users.getMatchingUsers({ query: { letters, notInProjectId: this.id } })
         .then((response: any) => extractData(response, 200))
+    },
+  }
+
+  Deployments = {
+    list: async () => {
+      this.deployments.value = await apiClient.Deployments.listDeployments({ params: { projectId: this.id } })
+        .then((response: any) => extractData(response, 200))
+      return this.deployments.value
+    },
+    create: async (deploymentData: Omit<CreateDeploymentBody, 'projectId'>) => {
+      const callback = this.addOperation('deploymentManagement')
+      try {
+        await apiClient.Deployments.createDeployment({
+          params: { projectId: this.id },
+          body: { ...deploymentData, projectId: this.id },
+        })
+          .then((response: any) => extractData(response, 201))
+      } finally { callback() }
+    },
+    update: async (id: Deployment['id'], deployment: UpdateDeploymentBody) => {
+      const callback = this.addOperation('deploymentManagement')
+      try {
+        await apiClient.Deployments.updateDeployment({
+          params: { projectId: this.id, deploymentId: id },
+          body: deployment,
+        })
+          .then((response: any) => extractData(response, 200))
+      } finally { callback() }
+    },
+    delete: async (deploymentId: Deployment['id']) => {
+      const callback = this.addOperation('deploymentManagement')
+      try {
+        await apiClient.Deployments.deleteDeployment({
+          params: { projectId: this.id, deploymentId },
+        })
+          .then((response: any) => extractData(response, 204))
+      } finally { callback() }
     },
   }
 

--- a/packages/shared/src/api-client.ts
+++ b/packages/shared/src/api-client.ts
@@ -11,6 +11,7 @@ export async function getContract() {
     AdminRoles: (await import('./contracts/index.js')).adminRoleContract,
     Clusters: (await import('./contracts/index.js')).clusterContract,
     ServiceChains: (await import('./contracts/index.js')).serviceChainContract,
+    Deployments: (await import('./contracts/index.js')).deploymentContract,
     Environments: (await import('./contracts/index.js')).environmentContract,
     Logs: (await import('./contracts/index.js')).logContract,
     PersonalAccessTokens: (await import('./contracts/index.js'))

--- a/packages/shared/src/contracts/deployment.ts
+++ b/packages/shared/src/contracts/deployment.ts
@@ -1,0 +1,90 @@
+import type { ClientInferRequest } from '@ts-rest/core'
+import { z } from 'zod'
+import { apiPrefix, contractInstance } from '../api-client.js'
+import {
+  CreateDeploymentSchema,
+  DeploymentSchema,
+  UpdateDeploymentSchema,
+} from '../schemas/index.js'
+import { baseHeaders, ErrorSchema } from './_utils.js'
+
+export const deploymentContract = contractInstance.router({
+  createDeployment: {
+    method: 'POST',
+    path: '',
+    contentType: 'application/json',
+    summary: 'Create deployment',
+    description: 'Create new deployment.',
+    body: CreateDeploymentSchema,
+    responses: {
+      201: DeploymentSchema,
+      400: ErrorSchema,
+      401: ErrorSchema,
+      500: ErrorSchema,
+    },
+  },
+
+  listDeployments: {
+    method: 'GET',
+    path: '',
+    summary: 'Get deployments',
+    description: 'Retrieved project deployments.',
+    responses: {
+      200: DeploymentSchema.array(),
+      400: ErrorSchema,
+      401: ErrorSchema,
+      403: ErrorSchema,
+      404: ErrorSchema,
+      500: ErrorSchema,
+    },
+  },
+
+  updateDeployment: {
+    method: 'PUT',
+    path: `/:deploymentId`,
+    summary: 'Update deployment',
+    description: 'Update a deployment by its ID.',
+    pathParams: z.object({
+      deploymentId: z.string()
+        .uuid(),
+    }),
+    body: UpdateDeploymentSchema,
+    responses: {
+      200: DeploymentSchema,
+      400: ErrorSchema,
+      401: ErrorSchema,
+      403: ErrorSchema,
+      404: ErrorSchema,
+      500: ErrorSchema,
+    },
+  },
+
+  deleteDeployment: {
+    method: 'DELETE',
+    path: `/:deploymentId`,
+    summary: 'Delete deployment',
+    description: 'Delete a deployment by its ID.',
+    body: null,
+    pathParams: z.object({
+      deploymentId: z.string()
+        .uuid(),
+    }),
+    responses: {
+      204: null,
+      400: ErrorSchema,
+      401: ErrorSchema,
+      403: ErrorSchema,
+      404: ErrorSchema,
+      500: ErrorSchema,
+    },
+  },
+}, {
+  baseHeaders,
+  pathPrefix: `${apiPrefix}/projects/:projectId/deployments`,
+  pathParams: z.object({
+    projectId: z.string().uuid(),
+  }),
+})
+
+export type CreateDeploymentBody = ClientInferRequest<typeof deploymentContract.createDeployment>['body']
+export type UpdateDeploymentBody = ClientInferRequest<typeof deploymentContract.updateDeployment>['body']

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -1,6 +1,7 @@
 export * from './admin-role.js'
 export * from './admin-token.js'
 export * from './cluster.js'
+export * from './deployment.js'
 export * from './environment.js'
 export * from './log.js'
 export * from './personal-access-token.js'

--- a/playwright/e2e-tests/deployment.spec.ts
+++ b/playwright/e2e-tests/deployment.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+import { clientURL, signInCloudPiNative, testUser } from 'config/console'
+import { createDeployment } from 'helpers/deployment'
+import { createEnvironment } from 'helpers/environment'
+import { createProject, deleteProject } from 'helpers/project'
+import { createRepository } from 'helpers/repository'
+
+test.describe('Déploiement', { tag: '@e2e' }, () => {
+  let projectName: string
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(clientURL)
+    await signInCloudPiNative({ page, credentials: testUser })
+    const { name } = await createProject({ page })
+    projectName = name
+  })
+
+  // Not working on CI (need to mock plugins....)
+  test.skip('should not be able to create a deployment without an environment or a repository', async ({ page }) => {
+    await page.getByRole('button', { name: 'Ajouter un nouveau déploiement' }).click()
+    await expect(page.getByText('Pour créer un déploiement, vous devez d\'abord créer un environnement et un dépôt.')).toBeVisible()
+  })
+
+  // Not working on CI (need to mock plugins....)
+  test.skip('should create a deployment', async ({ page }) => {
+    const envName = await createEnvironment({
+      page,
+      zone: 'publique',
+      customStageName: 'dev',
+      customClusterName: 'public1',
+      cpuInput: '2',
+      gpuInput: '0',
+    })
+    const repoName = await createRepository({ page })
+
+    const deploymentName = await createDeployment({ page, envName, repoName, customStageName: 'dev' })
+    await expect(page.getByText(deploymentName)).toBeVisible()
+  })
+
+  test.afterEach(async ({ page }) => {
+    if (!projectName) return
+    await deleteProject({ page, projectName })
+  })
+})

--- a/playwright/helpers/deployment.ts
+++ b/playwright/helpers/deployment.ts
@@ -1,0 +1,44 @@
+import type { Page } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+export async function createDeployment({
+  page,
+  deploymentName,
+  envName,
+  repoName,
+  customStageName,
+}: {
+  page: Page
+  deploymentName?: string
+  envName: string
+  repoName: string
+  customStageName: string
+}): Promise<string> {
+  deploymentName = deploymentName ?? faker.string.alpha(10).toLocaleLowerCase()
+  await openDeploymentCreateForm(page)
+  await fillDeploymentName(page, deploymentName)
+  await selectDeploymentEnvironment(page, envName, customStageName)
+  await selectDeploymentRepository(page, repoName)
+  await submitDeploymentForm(page)
+  return deploymentName
+}
+
+async function openDeploymentCreateForm(page: Page) {
+  await page.getByRole('button', { name: 'Ajouter un nouveau déploiement' }).click()
+}
+
+async function fillDeploymentName(page: Page, deploymentName: string) {
+  await page.getByRole('textbox', { name: 'Nom du déploiement * Ne doit' }).fill(deploymentName)
+}
+
+async function selectDeploymentEnvironment(page: Page, envName: string, customStageName: string) {
+  await page.getByText(`${envName} ${customStageName}`).click()
+}
+
+async function selectDeploymentRepository(page: Page, repoName: string) {
+  await page.getByLabel('Dépôt *').selectOption({ label: repoName })
+}
+
+async function submitDeploymentForm(page: Page) {
+  await page.getByRole('button', { name: 'Enregistrer' }).click()
+}


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

Il n'existe aucun moyen de gérer les déploiements d'un projet depuis l'interface. Les utilisateurs peuvent créer des environnements et des dépôts, mais ne peuvent pas déployer un dépôt sur un environnement.

## Quel est le nouveau comportement ?

Ajout de la gestion des déploiements côté front-end (création, liste, mise à jour et suppression) :

- Nouveaux composants de déploiement : `DeploymentCard`, `DeploymentModal`, `DeploymentResources`, `DeploymentRepoSelect`, `DeploymentRepoOption`, ainsi qu'un composant réutilisable `DeleteForm`.
- Ajout des opérations `Deployments` (list/create/update/delete) à la classe `Project` et intégration de `deploymentManagement` dans les `ProjectOperations`.
- Ajout du contrat ts-rest `deployment` et export des types `CreateDeploymentBody` / `UpdateDeploymentBody` depuis le package partagé.

<img width="1724" height="762" alt="Screenshot 2026-05-14 at 00 02 37" src="https://github.com/user-attachments/assets/02778b73-5163-4f26-aa22-4016666b1a28" />


## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Deux tests e2e sont marqués `skip` car ils nécessitent le mock des plugins pour fonctionner sur la CI.
