### PR TITLE
feat(server-nestjs): capture per-plugin event handler results

### DIFF
--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -9,6 +9,7 @@ import { stringify } from 'yaml'
 import { GitlabClientService } from '../gitlab/gitlab-client.service'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { PluginHandler } from '../plugin/plugin-handler.decorator'
 import { VaultClientService } from '../vault/vault-client.service'
 import { ArgoCDDatastoreService } from './argocd-datastore.service'
 import {
@@ -37,6 +38,7 @@ export class ArgoCDService {
   }
 
   @OnEvent('project.upsert')
+  @PluginHandler('argocd')
   @StartActiveSpan()
   async handleUpsert(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
@@ -47,6 +49,7 @@ export class ArgoCDService {
   }
 
   @OnEvent('project.delete')
+  @PluginHandler('argocd')
   @StartActiveSpan()
   async handleDelete(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -9,6 +9,7 @@ import { trace } from '@opentelemetry/api'
 import { getAll } from '../../utils/iterable'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { PluginHandler } from '../plugin/plugin-handler.decorator'
 import { VaultClientService } from '../vault/vault-client.service'
 import { GitlabClientService } from './gitlab-client.service'
 import { GitlabDatastoreService } from './gitlab-datastore.service'
@@ -57,6 +58,7 @@ export class GitlabService {
   }
 
   @OnEvent('project.upsert')
+  @PluginHandler('gitlab')
   @StartActiveSpan()
   async handleUpsert(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
@@ -67,6 +69,7 @@ export class GitlabService {
   }
 
   @OnEvent('project.delete')
+  @PluginHandler('gitlab')
   @StartActiveSpan()
   async handleDelete(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
@@ -7,6 +7,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import z from 'zod'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { PluginHandler } from '../plugin/plugin-handler.decorator'
 import { KeycloakClientService } from './keycloak-client.service'
 import { KeycloakDatastoreService } from './keycloak-datastore.service'
 import { isMember, isNonEmptyGroupPath, isOwnedProjectGroup, normalizeGroupPath } from './keycloak.utils'
@@ -23,6 +24,7 @@ export class KeycloakService {
   }
 
   @OnEvent('project.upsert')
+  @PluginHandler('keycloak')
   @StartActiveSpan()
   async handleUpsert(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
@@ -33,6 +35,7 @@ export class KeycloakService {
   }
 
   @OnEvent('project.delete')
+  @PluginHandler('keycloak')
   @StartActiveSpan()
   async handleDelete(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.ts
@@ -9,6 +9,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { PluginHandler } from '../plugin/plugin-handler.decorator'
 import { VaultClientService } from '../vault/vault-client.service'
 import { VaultError } from '../vault/vault-http-client.service'
 import { NexusClientService } from './nexus-client.service'
@@ -59,6 +60,7 @@ export class NexusService {
   }
 
   @OnEvent('project.upsert')
+  @PluginHandler('nexus')
   @StartActiveSpan()
   async handleUpsert(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
@@ -70,6 +72,7 @@ export class NexusService {
   }
 
   @OnEvent('project.delete')
+  @PluginHandler('nexus')
   @StartActiveSpan()
   async handleDelete(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()

--- a/apps/server-nestjs/src/modules/plugin/plugin-handler.decorator.spec.ts
+++ b/apps/server-nestjs/src/modules/plugin/plugin-handler.decorator.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { PluginHandler } from './plugin-handler.decorator'
+
+class FakeService {
+  @PluginHandler('gitlab')
+  async succeeds() {
+    // no explicit return: decorator falls back to the default message
+  }
+
+  @PluginHandler('gitlab')
+  async succeedsWithMessage() {
+    return 'Everything synced'
+  }
+
+  @PluginHandler('gitlab')
+  async fails(): Promise<void> {
+    throw new Error('GitLab unreachable')
+  }
+
+  @PluginHandler('gitlab')
+  async failsWithNonError(): Promise<void> {
+    throw 'boom' // eslint-disable-line no-throw-literal
+  }
+
+  @PluginHandler('nexus')
+  async echoes(value: string) {
+    return value
+  }
+}
+
+describe('pluginHandler decorator', () => {
+  const service = new FakeService()
+
+  it('should wrap a successful handler into an OK result with the default message', async () => {
+    await expect(service.succeeds()).resolves.toEqual({
+      gitlab: {
+        status: 'OK',
+        message: 'Up to date',
+        executionTime: expect.any(Number),
+      },
+    })
+  })
+
+  it('should use the string returned by the handler as message', async () => {
+    await expect(service.succeedsWithMessage()).resolves.toEqual({
+      gitlab: expect.objectContaining({ status: 'OK', message: 'Everything synced' }),
+    })
+  })
+
+  it('should wrap a throwing handler into a KO result instead of rejecting', async () => {
+    await expect(service.fails()).resolves.toEqual({
+      gitlab: {
+        status: 'KO',
+        message: 'GitLab unreachable',
+        executionTime: expect.any(Number),
+        error: new Error('GitLab unreachable'),
+      },
+    })
+  })
+
+  it('should report a fallback message for non-Error throws', async () => {
+    await expect(service.failsWithNonError()).resolves.toEqual({
+      gitlab: expect.objectContaining({ status: 'KO', message: 'Erreur inconnue', error: 'boom' }),
+    })
+  })
+
+  it('should forward the handler arguments and report under the given plugin name', async () => {
+    await expect(service.echoes('custom message')).resolves.toEqual({
+      nexus: expect.objectContaining({ status: 'OK', message: 'custom message' }),
+    })
+  })
+})

--- a/apps/server-nestjs/src/modules/plugin/plugin-handler.decorator.ts
+++ b/apps/server-nestjs/src/modules/plugin/plugin-handler.decorator.ts
@@ -1,0 +1,62 @@
+import type { PluginName, PluginResults } from './plugin.utils'
+import { Logger } from '@nestjs/common'
+
+/**
+ * Wraps an `@OnEvent` handler so it always resolves with a `PluginResults` object
+ * instead of throwing: the handler's outcome (status, message, execution time and
+ * error, if any) is reported under the given plugin name so the emitter can merge
+ * and persist the results of every listener.
+ *
+ * The handler keeps its natural shape: do the work, throw on failure, optionally
+ * return a message string to override the default 'Up to date'. Any other return
+ * type is rejected at compile time.
+ *
+ * Place it between `@OnEvent` and `@StartActiveSpan`: decorators apply bottom-up,
+ * so the span must wrap the original method (to record the exception and set the
+ * ERROR status on failure) while this decorator wraps the span and converts the
+ * rethrown error into a KO result.
+ */
+export function PluginHandler(plugin: PluginName) {
+  return <Args extends unknown[], Message extends string | void>(
+    target: object,
+    propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<(...args: Args) => Promise<Message>>,
+  ): void => {
+    const original = descriptor.value
+    if (!original) return
+
+    const logger = new Logger(target.constructor.name)
+
+    const wrapped = async function (this: unknown, ...args: Args): Promise<PluginResults> {
+      const start = process.hrtime.bigint()
+      const elapsedMs = () => Number(process.hrtime.bigint() - start) / 1_000_000
+
+      try {
+        const message = await original.apply(this, args)
+        return {
+          [plugin]: {
+            status: 'OK',
+            message: typeof message === 'string' ? message : 'Up to date',
+            executionTime: elapsedMs(),
+          },
+        }
+      } catch (error: unknown) {
+        logger.error(`${plugin} handler ${String(propertyKey)} failed`, error)
+        return {
+          [plugin]: {
+            status: 'KO',
+            message: error instanceof Error ? error.message : 'Erreur inconnue',
+            executionTime: elapsedMs(),
+            error,
+          },
+        }
+      }
+    }
+
+    // Decorators cannot change a method's declared type, so the wrapper (which
+    // returns PluginResults instead of Message) is not assignable to the typed
+    // descriptor. Mutate through PropertyDescriptor, whose `value` is untyped.
+    const mutable: PropertyDescriptor = descriptor
+    mutable.value = wrapped
+  }
+}

--- a/apps/server-nestjs/src/modules/plugin/plugin.utils.spec.ts
+++ b/apps/server-nestjs/src/modules/plugin/plugin.utils.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { getFailedPlugins, mergePluginResults } from './plugin.utils'
+
+describe('mergePluginResults', () => {
+  it('should return empty object when given empty array', () => {
+    expect(mergePluginResults([])).toEqual({})
+  })
+
+  it('should return single result as-is', () => {
+    const result = [{ argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 } }]
+    expect(mergePluginResults(result)).toEqual(result[0])
+  })
+
+  it('should merge multiple results into one', () => {
+    const results = [
+      { argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 } },
+      { gitlab: { status: 'OK' as const, message: 'Synced', executionTime: 20 } },
+    ]
+    expect(mergePluginResults(results)).toEqual({
+      argocd: { status: 'OK', message: 'Up to date', executionTime: 10 },
+      gitlab: { status: 'OK', message: 'Synced', executionTime: 20 },
+    })
+  })
+
+  it('should have later entries overwrite earlier ones for the same plugin', () => {
+    const error = new Error('sync error')
+    const results = [
+      { argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 } },
+      { argocd: { status: 'KO' as const, message: 'Failed', executionTime: 20, error } },
+    ]
+    expect(mergePluginResults(results)).toEqual({
+      argocd: { status: 'KO', message: 'Failed', executionTime: 20, error },
+    })
+  })
+})
+
+describe('getFailedPlugins', () => {
+  it('should return empty array when all plugins are OK', () => {
+    const results = {
+      argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 },
+      gitlab: { status: 'OK' as const, message: 'Synced', executionTime: 20 },
+    }
+    expect(getFailedPlugins(results)).toEqual([])
+  })
+
+  it('should return names of KO plugins', () => {
+    const error = new Error('sync error')
+    const results = {
+      argocd: { status: 'KO' as const, message: 'Failed', executionTime: 10, error },
+      gitlab: { status: 'OK' as const, message: 'Synced', executionTime: 20 },
+    }
+    expect(getFailedPlugins(results)).toEqual(['argocd'])
+  })
+
+  it('should return all plugins when all fail', () => {
+    const error = new Error('error')
+    const results = {
+      argocd: { status: 'KO' as const, message: 'Failed', executionTime: 10, error },
+      gitlab: { status: 'KO' as const, message: 'Failed', executionTime: 20, error },
+    }
+    const failed = getFailedPlugins(results)
+    expect(failed).toHaveLength(2)
+    expect(failed).toContain('argocd')
+    expect(failed).toContain('gitlab')
+  })
+
+  it('should return empty array for empty result', () => {
+    expect(getFailedPlugins({})).toEqual([])
+  })
+})

--- a/apps/server-nestjs/src/modules/plugin/plugin.utils.ts
+++ b/apps/server-nestjs/src/modules/plugin/plugin.utils.ts
@@ -10,3 +10,41 @@ export function makeToUrlParams(overrides: Partial<ToUrlFnParamaters> = {}): ToU
     ...overrides,
   }
 }
+export type PluginName = 'argocd'
+  | 'gitlab'
+  | 'nexus'
+  | 'vault'
+  | 'keycloak'
+  | 'harbor'
+  | 'sonarqube'
+  | 'observability'
+
+export type PluginResult = {
+  status: 'OK'
+  message: string
+  executionTime: number
+} | {
+  status: 'KO'
+  message: string
+  executionTime: number
+  error: unknown
+}
+
+export type PluginResults = Partial<Record<PluginName, PluginResult>>
+
+export type RequiredPluginResult<T extends PluginName>
+  = { [K in T]: PluginResult } & PluginResults
+
+export function mergePluginResults(responses: PluginResults[]): PluginResults {
+  return responses.reduce((merged, currentResponse) => {
+    return { ...merged, ...currentResponse }
+  }, {} as PluginResults)
+}
+
+export function getFailedPlugins(response: PluginResults): PluginName[] {
+  const entries = Object.entries(response) as [PluginName, PluginResult][]
+
+  return entries
+    .filter(([_, result]) => result.status === 'KO')
+    .map(([pluginName]) => pluginName)
+}

--- a/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
@@ -160,7 +160,7 @@ describe('registryService', () => {
       })
     })
 
-    it('throws when Maintainer membership creation fails', async () => {
+    it('returns a KO result when Maintainer membership creation fails', async () => {
       const project = makeProjectWithDetails()
       registry.addGroupMember.mockImplementation(async (_projectName, body) => {
         if (body.member_group.group_name === `/${project.slug}/console/devops` && body.role_id === 4) {
@@ -169,7 +169,12 @@ describe('registryService', () => {
         return { status: 201, data: null }
       })
 
-      await expect(service.handleUpsert(project)).rejects.toThrow('Harbor create member failed')
+      await expect(service.handleUpsert(project)).resolves.toEqual({
+        harbor: expect.objectContaining({
+          status: 'KO',
+          message: expect.stringContaining('Harbor create member failed'),
+        }),
+      })
 
       expect(registry.addGroupMember).toHaveBeenCalledWith(project.slug, {
         role_id: 4,

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -15,6 +15,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { PluginHandler } from '../plugin/plugin-handler.decorator'
 import { VaultClientService } from '../vault/vault-client.service'
 import { VaultError } from '../vault/vault-http-client.service'
 import { projectRobotName, RegistryClientService, roAccess, roRobotName, rwAccess, rwRobotName } from './registry-client.service'
@@ -315,6 +316,7 @@ export class RegistryService {
   }
 
   @OnEvent('project.upsert')
+  @PluginHandler('harbor')
   @StartActiveSpan()
   async handleUpsert(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
@@ -329,6 +331,7 @@ export class RegistryService {
   }
 
   @OnEvent('project.delete')
+  @PluginHandler('harbor')
   @StartActiveSpan()
   async handleDelete(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
@@ -8,6 +8,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { PluginHandler } from '../plugin/plugin-handler.decorator'
 import { VaultClientService } from '../vault/vault-client.service'
 import { SonarqubeClientService } from './sonarqube-client.service'
 import { SonarqubeDatastoreService } from './sonarqube-datastore.service'
@@ -87,6 +88,7 @@ export class SonarqubeService implements OnModuleInit {
   }
 
   @OnEvent('project.upsert')
+  @PluginHandler('sonarqube')
   @StartActiveSpan()
   async handleUpsert(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
@@ -97,6 +99,7 @@ export class SonarqubeService implements OnModuleInit {
   }
 
   @OnEvent('project.delete')
+  @PluginHandler('sonarqube')
   @StartActiveSpan()
   async handleDelete(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()

--- a/apps/server-nestjs/src/modules/vault/vault.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.service.ts
@@ -4,6 +4,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { PluginHandler } from '../plugin/plugin-handler.decorator'
 import { VaultClientService } from './vault-client.service'
 import { VaultDatastoreService } from './vault-datastore.service'
 import { VaultError } from './vault-http-client.service'
@@ -49,6 +50,7 @@ export class VaultService {
   }
 
   @OnEvent('project.upsert')
+  @PluginHandler('vault')
   @StartActiveSpan()
   async handleUpsert(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
@@ -59,6 +61,7 @@ export class VaultService {
   }
 
   @OnEvent('project.delete')
+  @PluginHandler('vault')
   @StartActiveSpan()
   async handleDelete(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
@@ -72,6 +75,7 @@ export class VaultService {
   }
 
   @OnEvent('zone.upsert')
+  @PluginHandler('vault')
   @StartActiveSpan()
   async handleUpsertZone(zone: ZoneWithDetails) {
     const span = trace.getActiveSpan()
@@ -82,6 +86,7 @@ export class VaultService {
   }
 
   @OnEvent('zone.delete')
+  @PluginHandler('vault')
   @StartActiveSpan()
   async handleDeleteZone(zone: ZoneWithDetails) {
     const span = trace.getActiveSpan()


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

Chaque plugin d'intégration (ArgoCD, GitLab, Keycloak, Nexus, Harbor/registry, SonarQube, Vault) écoute les événements `project.*` / `zone.*` via des handlers `@OnEvent`. En cas d'échec, ces handlers lèvent une exception : l'émetteur n'a aucun moyen de connaître de façon uniforme le résultat de chaque listener (succès/échec, message, durée d'exécution), ni d'agréger l'état de l'ensemble des plugins.

## Quel est le nouveau comportement ?

Introduction d'un décorateur `@PluginHandler(plugin)` qui enveloppe les handlers `@OnEvent` pour qu'ils résolvent systématiquement un objet `PluginResults` au lieu de lever une exception :
- succès → `{ status: 'OK', message, executionTime }` (message par défaut « Up to date », surchargeable en retournant une chaîne depuis le handler) ;
- échec → `{ status: 'KO', message, executionTime, error }`, avec log de l'erreur.

Le décorateur se place entre `@OnEvent` et `@StartActiveSpan` afin que le span enveloppe la méthode d'origine (enregistrement de l'exception + statut ERROR) tandis que `@PluginHandler` convertit l'erreur en résultat KO.

Ajout dans `plugin.utils.ts` des types `PluginName`, `PluginResult(s)`, `RequiredPluginResult`, ainsi que des helpers `mergePluginResults` (fusion des résultats de tous les listeners) et `getFailedPlugins` (extraction des plugins en échec).

Application du décorateur aux handlers des plugins argocd, gitlab, keycloak, nexus, registry (harbor), sonarqube et vault. Couvert par des tests unitaires pour le décorateur (`plugin-handler.decorator.spec.ts`) et les utils (`plugin.utils.spec.ts`).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Travail de fondation destiné à permettre à l'émetteur d'agréger et de persister le résultat de chaque listener (base pour le futur suivi/logs par plugin).
