### PR TITLE
feat(server-nestjs): capture plugin handler outcomes as structured results

### DIFF
--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -1,4 +1,5 @@
 import type { CommitAction, CondensedProjectSchema, ProjectSchema, SimpleProjectSchema } from '@gitbeaker/core'
+import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { ProjectWithDetails } from './argocd-datastore.service'
 import { createHmac } from 'node:crypto'
 import { generateNamespaceName, inClusterLabel } from '@cpn-console/shared'
@@ -9,6 +10,7 @@ import { stringify } from 'yaml'
 import { GitlabClientService } from '../gitlab/gitlab-client.service'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { capturePluginResult } from '../plugin/plugin.utils'
 import { VaultClientService } from '../vault/vault-client.service'
 import { ArgoCDDatastoreService } from './argocd-datastore.service'
 import {
@@ -37,8 +39,12 @@ export class ArgoCDService {
   }
 
   @OnEvent('project.upsert')
+  async handleUpsert(project: ProjectWithDetails): Promise<RequiredPluginResult<'argocd'>> {
+    return capturePluginResult('argocd', () => this.syncProject(project))
+  }
+
   @StartActiveSpan()
-  async handleUpsert(project: ProjectWithDetails) {
+  private async syncProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -47,8 +53,12 @@ export class ArgoCDService {
   }
 
   @OnEvent('project.delete')
+  async handleDelete(project: ProjectWithDetails): Promise<RequiredPluginResult<'argocd'>> {
+    return capturePluginResult('argocd', () => this.cleanupProject(project))
+  }
+
   @StartActiveSpan()
-  async handleDelete(project: ProjectWithDetails) {
+  private async cleanupProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project delete event for ${project.slug}`)

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -1,4 +1,5 @@
 import type { CondensedGroupSchema, MemberSchema, ProjectSchema } from '@gitbeaker/core'
+import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { VaultSecret } from '../vault/vault-client.service'
 import type { ProjectWithDetails } from './gitlab-datastore.service'
 import { specificallyEnabled } from '@cpn-console/hooks'
@@ -9,6 +10,7 @@ import { trace } from '@opentelemetry/api'
 import { getAll } from '../../utils/iterable'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { capturePluginResult } from '../plugin/plugin.utils'
 import { VaultClientService } from '../vault/vault-client.service'
 import { GitlabClientService } from './gitlab-client.service'
 import { GitlabDatastoreService } from './gitlab-datastore.service'
@@ -57,8 +59,12 @@ export class GitlabService {
   }
 
   @OnEvent('project.upsert')
+  async handleUpsert(project: ProjectWithDetails): Promise<RequiredPluginResult<'gitlab'>> {
+    return capturePluginResult('gitlab', () => this.syncProject(project))
+  }
+
   @StartActiveSpan()
-  async handleUpsert(project: ProjectWithDetails) {
+  private async syncProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -67,8 +73,12 @@ export class GitlabService {
   }
 
   @OnEvent('project.delete')
+  async handleDelete(project: ProjectWithDetails): Promise<RequiredPluginResult<'gitlab'>> {
+    return capturePluginResult('gitlab', () => this.cleanupProject(project))
+  }
+
   @StartActiveSpan()
-  async handleDelete(project: ProjectWithDetails) {
+  private async cleanupProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project delete event for ${project.slug}`)

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
@@ -1,4 +1,5 @@
 import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation'
+import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { AdminRoleWithDetails, ProjectWithDetails, UserWithAdminRoles } from './keycloak-datastore.service'
 import type { GroupRepresentationWith } from './keycloak.utils'
 import { getPermsByUserRoles, isExternalRoleType, ProjectAuthorized, resourceListToDict } from '@cpn-console/shared'
@@ -7,6 +8,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import z from 'zod'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { capturePluginResult } from '../plugin/plugin.utils'
 import { KeycloakClientService } from './keycloak-client.service'
 import { KeycloakDatastoreService } from './keycloak-datastore.service'
 import { isMember, isNonEmptyGroupPath, isOwnedProjectGroup, normalizeGroupPath } from './keycloak.utils'
@@ -23,8 +25,12 @@ export class KeycloakService {
   }
 
   @OnEvent('project.upsert')
+  async handleUpsert(project: ProjectWithDetails): Promise<RequiredPluginResult<'keycloak'>> {
+    return capturePluginResult('keycloak', () => this.syncProject(project))
+  }
+
   @StartActiveSpan()
-  async handleUpsert(project: ProjectWithDetails) {
+  private async syncProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -33,8 +39,12 @@ export class KeycloakService {
   }
 
   @OnEvent('project.delete')
+  async handleDelete(project: ProjectWithDetails): Promise<RequiredPluginResult<'keycloak'>> {
+    return capturePluginResult('keycloak', () => this.cleanupProject(project))
+  }
+
   @StartActiveSpan()
-  async handleDelete(project: ProjectWithDetails) {
+  private async cleanupProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project delete event for ${project.slug}`)

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.ts
@@ -1,3 +1,4 @@
+import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { NexusPrivilege } from './nexus-client.service'
 import type { ProjectWithDetails } from './nexus-datastore.service'
 import type {
@@ -9,6 +10,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { capturePluginResult } from '../plugin/plugin.utils'
 import { VaultClientService } from '../vault/vault-client.service'
 import { VaultError } from '../vault/vault-http-client.service'
 import { NexusClientService } from './nexus-client.service'
@@ -59,8 +61,12 @@ export class NexusService {
   }
 
   @OnEvent('project.upsert')
+  async handleUpsert(project: ProjectWithDetails): Promise<RequiredPluginResult<'nexus'>> {
+    return capturePluginResult('nexus', () => this.syncProject(project))
+  }
+
   @StartActiveSpan()
-  async handleUpsert(project: ProjectWithDetails) {
+  private async syncProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling project upsert for ${project.slug}`)
@@ -70,8 +76,12 @@ export class NexusService {
   }
 
   @OnEvent('project.delete')
+  async handleDelete(project: ProjectWithDetails): Promise<RequiredPluginResult<'nexus'>> {
+    return capturePluginResult('nexus', () => this.cleanupProject(project))
+  }
+
   @StartActiveSpan()
-  async handleDelete(project: ProjectWithDetails) {
+  private async cleanupProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling project delete for ${project.slug}`)

--- a/apps/server-nestjs/src/modules/plugin/plugin.utils.spec.ts
+++ b/apps/server-nestjs/src/modules/plugin/plugin.utils.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { capturePluginResult, getFailedPlugins, mergePluginResults } from './plugin.utils'
+
+describe('capturePluginResult', () => {
+  it('should resolve a successful task into an OK result with the default message, keyed under the plugin name', async () => {
+    await expect(capturePluginResult('gitlab', async () => {})).resolves.toEqual({
+      gitlab: {
+        status: 'OK',
+        message: 'Up to date',
+        executionTime: expect.any(Number),
+      },
+    })
+  })
+
+  it('should use the string returned by the task as message', async () => {
+    await expect(capturePluginResult('gitlab', async () => 'Everything synced')).resolves.toEqual({
+      gitlab: expect.objectContaining({ status: 'OK', message: 'Everything synced' }),
+    })
+  })
+
+  it('should resolve a throwing task into a KO result instead of rejecting', async () => {
+    const task = async () => {
+      throw new Error('GitLab unreachable')
+    }
+    await expect(capturePluginResult('gitlab', task)).resolves.toEqual({
+      gitlab: {
+        status: 'KO',
+        message: 'GitLab unreachable',
+        executionTime: expect.any(Number),
+        error: new Error('GitLab unreachable'),
+      },
+    })
+  })
+
+  it('should report a fallback message for non-Error throws', async () => {
+    const task = async () => {
+      throw 'boom' // eslint-disable-line no-throw-literal
+    }
+    await expect(capturePluginResult('gitlab', task)).resolves.toEqual({
+      gitlab: expect.objectContaining({ status: 'KO', message: 'Erreur inconnue', error: 'boom' }),
+    })
+  })
+
+  it('should report under the given plugin name', async () => {
+    await expect(capturePluginResult('nexus', async () => 'custom message')).resolves.toEqual({
+      nexus: expect.objectContaining({ status: 'OK', message: 'custom message' }),
+    })
+  })
+})
+
+describe('mergePluginResults', () => {
+  it('should return empty object when given empty array', () => {
+    expect(mergePluginResults([])).toEqual({})
+  })
+
+  it('should return single result as-is', () => {
+    const result = [{ argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 } }]
+    expect(mergePluginResults(result)).toEqual(result[0])
+  })
+
+  it('should merge multiple results into one', () => {
+    const results = [
+      { argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 } },
+      { gitlab: { status: 'OK' as const, message: 'Synced', executionTime: 20 } },
+    ]
+    expect(mergePluginResults(results)).toEqual({
+      argocd: { status: 'OK', message: 'Up to date', executionTime: 10 },
+      gitlab: { status: 'OK', message: 'Synced', executionTime: 20 },
+    })
+  })
+
+  it('should have later entries overwrite earlier ones for the same plugin', () => {
+    const error = new Error('sync error')
+    const results = [
+      { argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 } },
+      { argocd: { status: 'KO' as const, message: 'Failed', executionTime: 20, error } },
+    ]
+    expect(mergePluginResults(results)).toEqual({
+      argocd: { status: 'KO', message: 'Failed', executionTime: 20, error },
+    })
+  })
+})
+
+describe('getFailedPlugins', () => {
+  it('should return empty array when all plugins are OK', () => {
+    const results = {
+      argocd: { status: 'OK' as const, message: 'Up to date', executionTime: 10 },
+      gitlab: { status: 'OK' as const, message: 'Synced', executionTime: 20 },
+    }
+    expect(getFailedPlugins(results)).toEqual([])
+  })
+
+  it('should return names of KO plugins', () => {
+    const error = new Error('sync error')
+    const results = {
+      argocd: { status: 'KO' as const, message: 'Failed', executionTime: 10, error },
+      gitlab: { status: 'OK' as const, message: 'Synced', executionTime: 20 },
+    }
+    expect(getFailedPlugins(results)).toEqual(['argocd'])
+  })
+
+  it('should return all plugins when all fail', () => {
+    const error = new Error('error')
+    const results = {
+      argocd: { status: 'KO' as const, message: 'Failed', executionTime: 10, error },
+      gitlab: { status: 'KO' as const, message: 'Failed', executionTime: 20, error },
+    }
+    const failed = getFailedPlugins(results)
+    expect(failed).toHaveLength(2)
+    expect(failed).toContain('argocd')
+    expect(failed).toContain('gitlab')
+  })
+
+  it('should return empty array for empty result', () => {
+    expect(getFailedPlugins({})).toEqual([])
+  })
+})

--- a/apps/server-nestjs/src/modules/plugin/plugin.utils.ts
+++ b/apps/server-nestjs/src/modules/plugin/plugin.utils.ts
@@ -1,4 +1,5 @@
 import type { ToUrlFnParamaters } from '@cpn-console/hooks'
+import { Logger } from '@nestjs/common'
 
 export function makeToUrlParams(overrides: Partial<ToUrlFnParamaters> = {}): ToUrlFnParamaters {
   return {
@@ -9,4 +10,98 @@ export function makeToUrlParams(overrides: Partial<ToUrlFnParamaters> = {}): ToU
     project: { id: '', slug: 'dulei', name: '' },
     ...overrides,
   }
+}
+export type PluginName = 'argocd'
+  | 'gitlab'
+  | 'nexus'
+  | 'vault'
+  | 'keycloak'
+  | 'harbor'
+  | 'sonarqube'
+  | 'observability'
+
+export type PluginResult = {
+  status: 'OK'
+  message: string
+  executionTime: number
+} | {
+  status: 'KO'
+  message: string
+  executionTime: number
+  error: unknown
+}
+
+export type PluginResults = Partial<Record<PluginName, PluginResult>>
+
+export type RequiredPluginResult<T extends PluginName>
+  = { [K in T]: PluginResult } & PluginResults
+
+const logger = new Logger('PluginResult')
+
+/**
+ * Runs a plugin task and always resolves with the task's outcome (status,
+ * message, execution time and error, if any) keyed under the given plugin
+ * name, instead of throwing, so the event emitter can merge and persist the
+ * results of every listener.
+ *
+ * The task keeps its natural shape: do the work, throw on failure, optionally
+ * return a message string to override the default 'Up to date'.
+ *
+ * The `@OnEvent` handler stays a thin, honestly-typed wrapper, while the
+ * traced work method keeps `@StartActiveSpan` so the span still records the
+ * exception on failure:
+ *
+ * ```ts
+ * @OnEvent('project.upsert')
+ * async handleUpsert(project: ProjectWithDetails): Promise<RequiredPluginResult<'argocd'>> {
+ *   return capturePluginResult('argocd', () => this.syncProject(project))
+ * }
+ *
+ * @StartActiveSpan()
+ * private async syncProject(project: ProjectWithDetails) { ... }
+ * ```
+ */
+export async function capturePluginResult<P extends PluginName>(
+  plugin: P,
+  task: () => Promise<string | void>,
+): Promise<RequiredPluginResult<P>> {
+  const start = process.hrtime.bigint()
+  const elapsedMs = () => Number(process.hrtime.bigint() - start) / 1_000_000
+
+  try {
+    const message = await task()
+    return keyedBy(plugin, {
+      status: 'OK',
+      message: typeof message === 'string' ? message : 'Up to date',
+      executionTime: elapsedMs(),
+    })
+  } catch (error: unknown) {
+    logger.error(`${plugin} handler failed`, error)
+    return keyedBy(plugin, {
+      status: 'KO',
+      message: error instanceof Error ? error.message : 'Erreur inconnue',
+      executionTime: elapsedMs(),
+      error,
+    })
+  }
+}
+
+// TypeScript widens a computed property with a generic key to an index
+// signature instead of Record<P, ...>, so the assertion is confined here.
+function keyedBy<P extends PluginName>(plugin: P, result: PluginResult): RequiredPluginResult<P> {
+  return { [plugin]: result } as RequiredPluginResult<P>
+}
+
+export function mergePluginResults(responses: PluginResults[]): PluginResults {
+  return responses.reduce((merged, currentResponse) => {
+    return { ...merged, ...currentResponse }
+  }, {} as PluginResults)
+}
+
+export function getFailedPlugins(response: PluginResults): PluginName[] {
+  const entries = Object.entries(response) as [PluginName, PluginResult][]
+
+  return entries
+    .filter(([_, result]) => result.status === 'KO')
+    .map(([pluginName]) => pluginName)
 }

--- a/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
@@ -160,7 +160,7 @@ describe('registryService', () => {
       })
     })
 
-    it('throws when Maintainer membership creation fails', async () => {
+    it('returns a KO result when Maintainer membership creation fails', async () => {
       const project = makeProjectWithDetails()
       registry.addGroupMember.mockImplementation(async (_projectName, body) => {
         if (body.member_group.group_name === `/${project.slug}/console/devops` && body.role_id === 4) {
@@ -169,7 +169,12 @@ describe('registryService', () => {
         return { status: 201, data: null }
       })
 
-      await expect(service.handleUpsert(project)).rejects.toThrow('Harbor create member failed')
+      await expect(service.handleUpsert(project)).resolves.toEqual({
+        harbor: expect.objectContaining({
+          status: 'KO',
+          message: expect.stringContaining('Harbor create member failed'),
+        }),
+      })
 
       expect(registry.addGroupMember).toHaveBeenCalledWith(project.slug, {
         role_id: 4,

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -1,3 +1,4 @@
+import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { VaultSecret } from '../vault/vault-client.service'
 import type {
   HarborAccess,
@@ -15,6 +16,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { capturePluginResult } from '../plugin/plugin.utils'
 import { VaultClientService } from '../vault/vault-client.service'
 import { VaultError } from '../vault/vault-http-client.service'
 import { projectRobotName, RegistryClientService, roAccess, roRobotName, rwAccess, rwRobotName } from './registry-client.service'
@@ -315,8 +317,12 @@ export class RegistryService {
   }
 
   @OnEvent('project.upsert')
+  async handleUpsert(project: ProjectWithDetails): Promise<RequiredPluginResult<'harbor'>> {
+    return capturePluginResult('harbor', () => this.syncProject(project))
+  }
+
   @StartActiveSpan()
-  async handleUpsert(project: ProjectWithDetails) {
+  private async syncProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling project upsert for ${project.slug}`)
@@ -329,8 +335,12 @@ export class RegistryService {
   }
 
   @OnEvent('project.delete')
+  async handleDelete(project: ProjectWithDetails): Promise<RequiredPluginResult<'harbor'>> {
+    return capturePluginResult('harbor', () => this.cleanupProject(project))
+  }
+
   @StartActiveSpan()
-  async handleDelete(project: ProjectWithDetails) {
+  private async cleanupProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling project delete for ${project.slug}`)

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
@@ -1,4 +1,5 @@
 import type { OnModuleInit } from '@nestjs/common'
+import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { SonarqubeUserSecret } from '../vault/vault-client.service'
 import type { SonarqubeProjectResult, SonarqubeUser } from './sonarqube-client.service'
 import type { ProjectWithDetails } from './sonarqube-datastore.service'
@@ -8,6 +9,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { capturePluginResult } from '../plugin/plugin.utils'
 import { VaultClientService } from '../vault/vault-client.service'
 import { SonarqubeClientService } from './sonarqube-client.service'
 import { SonarqubeDatastoreService } from './sonarqube-datastore.service'
@@ -87,8 +89,12 @@ export class SonarqubeService implements OnModuleInit {
   }
 
   @OnEvent('project.upsert')
+  async handleUpsert(project: ProjectWithDetails): Promise<RequiredPluginResult<'sonarqube'>> {
+    return capturePluginResult('sonarqube', () => this.syncProject(project))
+  }
+
   @StartActiveSpan()
-  async handleUpsert(project: ProjectWithDetails) {
+  private async syncProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -97,8 +103,12 @@ export class SonarqubeService implements OnModuleInit {
   }
 
   @OnEvent('project.delete')
+  async handleDelete(project: ProjectWithDetails): Promise<RequiredPluginResult<'sonarqube'>> {
+    return capturePluginResult('sonarqube', () => this.cleanupProject(project))
+  }
+
   @StartActiveSpan()
-  async handleDelete(project: ProjectWithDetails) {
+  private async cleanupProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project delete event for ${project.slug}`)

--- a/apps/server-nestjs/src/modules/vault/vault.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.service.ts
@@ -1,9 +1,11 @@
+import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { ProjectWithDetails, ZoneWithDetails } from './vault-datastore.service'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
+import { capturePluginResult } from '../plugin/plugin.utils'
 import { VaultClientService } from './vault-client.service'
 import { VaultDatastoreService } from './vault-datastore.service'
 import { VaultError } from './vault-http-client.service'
@@ -49,8 +51,12 @@ export class VaultService {
   }
 
   @OnEvent('project.upsert')
+  async handleUpsert(project: ProjectWithDetails): Promise<RequiredPluginResult<'vault'>> {
+    return capturePluginResult('vault', () => this.syncProject(project))
+  }
+
   @StartActiveSpan()
-  async handleUpsert(project: ProjectWithDetails) {
+  private async syncProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -59,8 +65,12 @@ export class VaultService {
   }
 
   @OnEvent('project.delete')
+  async handleDelete(project: ProjectWithDetails): Promise<RequiredPluginResult<'vault'>> {
+    return capturePluginResult('vault', () => this.cleanupProject(project))
+  }
+
   @StartActiveSpan()
-  async handleDelete(project: ProjectWithDetails) {
+  private async cleanupProject(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project delete event for ${project.slug}`)
@@ -72,8 +82,12 @@ export class VaultService {
   }
 
   @OnEvent('zone.upsert')
+  async handleUpsertZone(zone: ZoneWithDetails): Promise<RequiredPluginResult<'vault'>> {
+    return capturePluginResult('vault', () => this.syncZone(zone))
+  }
+
   @StartActiveSpan()
-  async handleUpsertZone(zone: ZoneWithDetails) {
+  private async syncZone(zone: ZoneWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('zone.slug', zone.slug)
     this.logger.log(`Handling a zone upsert event for ${zone.slug}`)
@@ -82,8 +96,12 @@ export class VaultService {
   }
 
   @OnEvent('zone.delete')
+  async handleDeleteZone(zone: ZoneWithDetails): Promise<RequiredPluginResult<'vault'>> {
+    return capturePluginResult('vault', () => this.cleanupZone(zone))
+  }
+
   @StartActiveSpan()
-  async handleDeleteZone(zone: ZoneWithDetails) {
+  private async cleanupZone(zone: ZoneWithDetails) {
     const span = trace.getActiveSpan()
     span?.setAttribute('zone.slug', zone.slug)
     this.logger.log(`Handling a zone delete event for ${zone.slug}`)


### PR DESCRIPTION

## Issues liées

Issues numéro: N/A

---------

## Quel est le comportement actuel ?

Les handlers `@OnEvent` des plugins (ArgoCD, GitLab, Keycloak, Nexus, Registry, SonarQube, Vault) exécutent leur travail sans retourner de résultat exploitable : en cas d'échec, l'exception se propage sans structure commune, et l'émetteur d'événements n'a aucun moyen de savoir quel plugin a réussi ou échoué, ni en combien de temps.

## Quel est le nouveau comportement ?

Introduction d'un utilitaire `capturePluginResult` dans `plugin.utils.ts` qui exécute la tâche d'un plugin et résout toujours avec un `PluginResult` structuré (`status: 'OK' | 'KO'`, `message`, `executionTime`, et `error` en cas d'échec) au lieu de laisser l'exception se propager.

- Chaque handler `@OnEvent` devient un wrapper léger typé `RequiredPluginResult<'<plugin>'>` qui clé son résultat sous le nom du plugin ; la méthode de travail privée conserve `@StartActiveSpan` pour que la span continue d'enregistrer l'exception.
- Ajout de `mergePluginResults` pour fusionner les résultats de tous les listeners et de `getFailedPlugins` pour identifier les plugins en échec.
- Application du pattern aux services ArgoCD, GitLab, Keycloak, Nexus, Registry, SonarQube et Vault.
- Tests unitaires ajoutés (`plugin.utils.spec.ts`).

## Cette PR introduit-elle un breaking change ?

Non. La signature des handlers change (ils retournent désormais un `PluginResult` au lieu de `void`), mais ils sont invoqués via l'event emitter et le comportement fonctionnel des plugins reste identique.

## Autres informations

Les échecs des handlers sont désormais journalisés via un `Logger('PluginResult')` dédié. Cette structure ouvre la voie à la persistance des résultats de chaque listener par l'émetteur d'événements.

