### PR TITLE
fix(server-nestjs): satisfy Prisma payload types in deployment spec mocks

### DIFF
--- a/apps/server-nestjs/src/modules/deployment/deployment-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment-testing.utils.ts
@@ -1,0 +1,85 @@
+import type { Deployment, DeploymentSource, Environment, Prisma, Repository } from '@prisma/client'
+import { faker } from '@faker-js/faker'
+
+export function makeDeployment(overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    id: faker.string.uuid(),
+    projectId: faker.string.uuid(),
+    name: faker.string.alphanumeric(8).toLowerCase(),
+    autosync: true,
+    environmentId: faker.string.uuid(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  }
+}
+
+export function makeEnvironment(overrides: Partial<Environment> = {}): Environment {
+  return {
+    id: faker.string.uuid(),
+    name: faker.string.alphanumeric(8).toLowerCase(),
+    projectId: faker.string.uuid(),
+    memory: 2,
+    cpu: 1,
+    gpu: 0,
+    autosync: true,
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    clusterId: faker.string.uuid(),
+    stageId: faker.string.uuid(),
+    ...overrides,
+  }
+}
+
+export function makeRepository(overrides: Partial<Repository> = {}): Repository {
+  return {
+    id: faker.string.uuid(),
+    projectId: faker.string.uuid(),
+    internalRepoName: faker.string.alphanumeric(8).toLowerCase(),
+    externalRepoUrl: '',
+    externalUserName: '',
+    isInfra: false,
+    isPrivate: false,
+    deployRevision: '',
+    deployPath: '',
+    helmValuesFiles: '',
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  }
+}
+
+type DeploymentSourceWithRepository = DeploymentSource & { repository: Repository }
+
+export function makeDeploymentSource(overrides: Partial<DeploymentSourceWithRepository> = {}): DeploymentSourceWithRepository {
+  const repositoryId = overrides.repositoryId ?? faker.string.uuid()
+  return {
+    id: faker.string.uuid(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    deploymentId: faker.string.uuid(),
+    repositoryId,
+    type: 'git',
+    targetRevision: 'main',
+    path: '/app',
+    helmValuesFiles: '',
+    repository: makeRepository({ id: repositoryId }),
+    ...overrides,
+  }
+}
+
+export type DeploymentWithRelations = Prisma.DeploymentGetPayload<{
+  include: {
+    environment: true
+    deploymentSources: { include: { repository: true } }
+  }
+}>
+
+export function makeDeploymentWithRelations(overrides: Partial<DeploymentWithRelations> = {}): DeploymentWithRelations {
+  const base = makeDeployment(overrides)
+  return {
+    ...base,
+    environment: overrides.environment ?? makeEnvironment({ id: base.environmentId, projectId: base.projectId }),
+    deploymentSources: overrides.deploymentSources ?? [makeDeploymentSource({ deploymentId: base.id })],
+  }
+}

--- a/apps/server-nestjs/src/modules/deployment/deployment.controller.spec.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.controller.spec.ts
@@ -4,6 +4,7 @@ import type { DeepMockProxy } from 'vitest-mock-extended'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { makeDeployment, makeDeploymentWithRelations } from './deployment-testing.utils'
 import { DeploymentController } from './deployment.controller'
 import { DeploymentService } from './deployment.service'
 
@@ -71,7 +72,7 @@ describe('deploymentController', () => {
   describe('list', () => {
     it('should call deploymentService.listByProjectId with projectId', async () => {
       const projectId = '11111111-1111-1111-1111-111111111111'
-      const expectedResult = [{ id: 'deployment-1' }]
+      const expectedResult = [makeDeploymentWithRelations({ projectId })]
 
       service.listByProjectId.mockResolvedValue(expectedResult)
 
@@ -84,7 +85,7 @@ describe('deploymentController', () => {
 
   describe('create', () => {
     it('should validate body and call deploymentService.createDeployment', async () => {
-      const expectedResult = { id: 'new-deployment-id' }
+      const expectedResult = makeDeployment({ projectId: validCreateDeployment.projectId })
 
       service.createDeployment.mockResolvedValue(expectedResult)
 
@@ -101,7 +102,7 @@ describe('deploymentController', () => {
   describe('update', () => {
     it('should validate body and call deploymentService.updateDeployment', async () => {
       const deploymentId = '55555555-5555-5555-5555-555555555555'
-      const expectedResult = { id: deploymentId }
+      const expectedResult = makeDeployment({ id: deploymentId })
 
       service.updateDeployment.mockResolvedValue(expectedResult)
 

--- a/apps/server-nestjs/src/modules/deployment/deployment.service.spec.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.service.spec.ts
@@ -5,8 +5,10 @@ import { EventEmitter2 } from '@nestjs/event-emitter'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { makeProjectWithDetails } from '../project/project-testing.utils'
 import { ProjectService } from '../project/project.service'
 import { DeploymentDatastoreService } from './deployment-datastore.service'
+import { makeDeployment, makeDeploymentSource, makeDeploymentWithRelations } from './deployment-testing.utils'
 import { DeploymentService } from './deployment.service'
 
 describe('deploymentService', () => {
@@ -19,10 +21,7 @@ describe('deploymentService', () => {
   const projectId = '11111111-1111-1111-1111-111111111111'
   const deploymentId = '22222222-2222-2222-2222-222222222222'
 
-  const mockProject = {
-    id: projectId,
-    name: 'Test Project',
-  }
+  const mockProject = makeProjectWithDetails({ id: projectId })
 
   const validCreateDeployment = {
     name: 'mydeployment',
@@ -77,7 +76,7 @@ describe('deploymentService', () => {
 
   describe('listByProjectId', () => {
     it('should return deployments by projectId', async () => {
-      const deployments = [{ id: deploymentId }]
+      const deployments = [makeDeploymentWithRelations({ id: deploymentId, projectId })]
       datastore.getDeploymentsByProjectId.mockResolvedValue(deployments)
 
       const result = await service.listByProjectId(projectId)
@@ -89,7 +88,7 @@ describe('deploymentService', () => {
 
   describe('createDeployment', () => {
     it('should create deployment and upsert project', async () => {
-      const createdDeployment = { id: deploymentId }
+      const createdDeployment = makeDeployment({ id: deploymentId, projectId })
 
       datastore.createDeployment.mockResolvedValue(createdDeployment)
       projectService.get.mockResolvedValue(mockProject)
@@ -123,15 +122,16 @@ describe('deploymentService', () => {
 
   describe('updateDeployment', () => {
     it('should update deployment and upsert project', async () => {
-      const existingDeployment = {
+      const existingDeployment = makeDeploymentWithRelations({
         id: deploymentId,
+        projectId,
         deploymentSources: [
-          { id: '55555555-5555-5555-5555-555555555555' },
-          { id: '66666666-6666-6666-6666-666666666666' },
+          makeDeploymentSource({ id: '55555555-5555-5555-5555-555555555555', deploymentId }),
+          makeDeploymentSource({ id: '66666666-6666-6666-6666-666666666666', deploymentId }),
         ],
-      }
+      })
 
-      const updatedDeployment = { id: deploymentId }
+      const updatedDeployment = makeDeployment({ id: deploymentId, projectId })
 
       datastore.getDeploymentById.mockResolvedValue(existingDeployment)
       datastore.updateDeployment.mockResolvedValue(updatedDeployment)
@@ -171,10 +171,7 @@ describe('deploymentService', () => {
 
   describe('deleteDeployment', () => {
     it('should delete deployment and upsert project', async () => {
-      datastore.deleteDeployment.mockResolvedValue({
-        id: deploymentId,
-        projectId,
-      })
+      datastore.deleteDeployment.mockResolvedValue(makeDeployment({ id: deploymentId, projectId }))
       projectService.get.mockResolvedValue(mockProject)
       events.emitAsync.mockResolvedValue([])
 
@@ -188,7 +185,7 @@ describe('deploymentService', () => {
 
   describe('deleteAllDeploymentsByProjectId', () => {
     it('should delete all deployments and upsert project', async () => {
-      datastore.deleteAllDeploymentsByProjectId.mockResolvedValue(undefined)
+      datastore.deleteAllDeploymentsByProjectId.mockResolvedValue({ count: 1 })
       projectService.get.mockResolvedValue(mockProject)
       events.emitAsync.mockResolvedValue([])
 


### PR DESCRIPTION
## Issues liées

Issues numéro: N/A

---------

## Quel est le comportement actuel ?

La compilation TypeScript (`tsc --noEmit`) échoue sur `deployment.service.spec.ts` et `deployment.controller.spec.ts` : les mocks des retours du datastore et de `ProjectService.get` utilisent des objets partiels (ex. `{ id: deploymentId }`) qui ne satisfont plus les types de retour Prisma complets (payloads `Deployment` avec `environment` et `deploymentSources.repository` inclus). Le mock de `deleteAllDeploymentsByProjectId` renvoie `undefined` au lieu d'un `BatchPayload`.

## Quel est le nouveau comportement ?

- Ajout de `deployment-testing.utils.ts` avec des factories basées sur faker (`makeDeployment`, `makeEnvironment`, `makeRepository`, `makeDeploymentSource`, `makeDeploymentWithRelations`) conformes aux modèles Prisma, sur le modèle des autres `*-testing.utils.ts` du projet (repris de la #2288).
- Les mocks des deux fichiers de spec utilisent désormais ces factories (et `makeProjectWithDetails` pour le projet), ce qui rend la compilation TypeScript propre sur le module deployment.
- Le mock de `deleteAllDeploymentsByProjectId` renvoie `{ count: 1 }` (type `BatchPayload`).

Aucun changement de code de production : uniquement des fichiers de test. Les 18 tests du module deployment passent.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Les factories sont reprises de la PR #2288 (`feat/secure-deployment-api`) afin de faciliter la convergence des deux branches. Une erreur TS préexistante et non liée subsiste dans `auth.service.spec.ts` (cast `FastifyRequest`), hors périmètre de cette PR.
