### PR TITLE
feat(server-nestjs): introduce AppEventsService for project events

### DIFF
--- a/apps/server-nestjs/src/modules/deployment/deployment.module.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common'
+import { AppEventsModule } from '../events/app-events.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
-import { ProjectModule } from '../project/project.module'
 import { DeploymentDatastoreService } from './deployment-datastore.service'
 import { DeploymentController } from './deployment.controller'
 import { DeploymentService } from './deployment.service'
 
 @Module({
-  imports: [InfrastructureModule, ProjectModule],
+  imports: [AppEventsModule, InfrastructureModule],
   controllers: [DeploymentController],
   providers: [
     DeploymentDatastoreService,

--- a/apps/server-nestjs/src/modules/deployment/deployment.service.spec.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.service.spec.ts
@@ -1,12 +1,10 @@
 import type { CreateDeployment, UpdateDeployment } from '@cpn-console/shared'
 import type { TestingModule } from '@nestjs/testing'
 import type { DeepMockProxy } from 'vitest-mock-extended'
-import { EventEmitter2 } from '@nestjs/event-emitter'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
-import { makeProjectWithDetails } from '../project/project-testing.utils'
-import { ProjectService } from '../project/project.service'
+import { AppEventsService } from '../events/app-events.service'
 import { DeploymentDatastoreService } from './deployment-datastore.service'
 import { makeDeployment, makeDeploymentSource, makeDeploymentWithRelations } from './deployment-testing.utils'
 import { DeploymentService } from './deployment.service'
@@ -15,13 +13,10 @@ describe('deploymentService', () => {
   let module: TestingModule
   let service: DeploymentService
   let datastore: DeepMockProxy<DeploymentDatastoreService>
-  let projectService: DeepMockProxy<ProjectService>
-  let events: DeepMockProxy<EventEmitter2>
+  let appEvents: DeepMockProxy<AppEventsService>
 
   const projectId = '11111111-1111-1111-1111-111111111111'
   const deploymentId = '22222222-2222-2222-2222-222222222222'
-
-  const mockProject = makeProjectWithDetails({ id: projectId })
 
   const validCreateDeployment = {
     name: 'mydeployment',
@@ -55,15 +50,13 @@ describe('deploymentService', () => {
 
   beforeEach(async () => {
     datastore = mockDeep<DeploymentDatastoreService>()
-    projectService = mockDeep<ProjectService>()
-    events = mockDeep<EventEmitter2>()
+    appEvents = mockDeep<AppEventsService>()
 
     module = await Test.createTestingModule({
       providers: [
         DeploymentService,
         { provide: DeploymentDatastoreService, useValue: datastore },
-        { provide: ProjectService, useValue: projectService },
-        { provide: EventEmitter2, useValue: events },
+        { provide: AppEventsService, useValue: appEvents },
       ],
     }).compile()
 
@@ -91,8 +84,6 @@ describe('deploymentService', () => {
       const createdDeployment = makeDeployment({ id: deploymentId, projectId })
 
       datastore.createDeployment.mockResolvedValue(createdDeployment)
-      projectService.get.mockResolvedValue(mockProject)
-      events.emitAsync.mockResolvedValue([])
 
       const result = await service.createDeployment(projectId, validCreateDeployment)
 
@@ -114,8 +105,7 @@ describe('deploymentService', () => {
         },
       })
 
-      expect(projectService.get).toHaveBeenCalledWith(projectId)
-      expect(events.emitAsync).toHaveBeenCalledWith('project.upsert', mockProject)
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, { action: 'Create Deployment' })
       expect(result).toEqual(createdDeployment)
     })
   })
@@ -135,8 +125,6 @@ describe('deploymentService', () => {
 
       datastore.getDeploymentById.mockResolvedValue(existingDeployment)
       datastore.updateDeployment.mockResolvedValue(updatedDeployment)
-      projectService.get.mockResolvedValue(mockProject)
-      events.emitAsync.mockResolvedValue([])
 
       const result = await service.updateDeployment(deploymentId, validUpdateDeployment)
 
@@ -153,8 +141,7 @@ describe('deploymentService', () => {
         }),
       )
 
-      expect(projectService.get).toHaveBeenCalledWith(validUpdateDeployment.projectId)
-      expect(events.emitAsync).toHaveBeenCalledWith('project.upsert', mockProject)
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', validUpdateDeployment.projectId, { action: 'Update Deployment' })
       expect(result).toEqual(updatedDeployment)
     })
 
@@ -172,28 +159,22 @@ describe('deploymentService', () => {
   describe('deleteDeployment', () => {
     it('should delete deployment and upsert project', async () => {
       datastore.deleteDeployment.mockResolvedValue(makeDeployment({ id: deploymentId, projectId }))
-      projectService.get.mockResolvedValue(mockProject)
-      events.emitAsync.mockResolvedValue([])
 
       await service.deleteDeployment(deploymentId)
 
       expect(datastore.deleteDeployment).toHaveBeenCalledWith(deploymentId)
-      expect(projectService.get).toHaveBeenCalledWith(projectId)
-      expect(events.emitAsync).toHaveBeenCalledWith('project.upsert', mockProject)
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, { action: 'Delete Deployment' })
     })
   })
 
   describe('deleteAllDeploymentsByProjectId', () => {
     it('should delete all deployments and upsert project', async () => {
       datastore.deleteAllDeploymentsByProjectId.mockResolvedValue({ count: 1 })
-      projectService.get.mockResolvedValue(mockProject)
-      events.emitAsync.mockResolvedValue([])
 
       await service.deleteAllDeploymentsByProjectId(projectId)
 
       expect(datastore.deleteAllDeploymentsByProjectId).toHaveBeenCalledWith(projectId)
-      expect(projectService.get).toHaveBeenCalledWith(projectId)
-      expect(events.emitAsync).toHaveBeenCalledWith('project.upsert', mockProject)
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, { action: 'Delete all project deployments' })
     })
   })
 })

--- a/apps/server-nestjs/src/modules/deployment/deployment.service.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.service.ts
@@ -1,15 +1,14 @@
 import type { CreateDeployment, UpdateDeployment } from '@cpn-console/shared'
+import type { EventLogAction } from '../events/app-events.service'
 import { Inject, Injectable } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
-import { ProjectService } from '../project/project.service'
+import { AppEventsService } from '../events/app-events.service'
 import { DeploymentDatastoreService } from './deployment-datastore.service'
 
 @Injectable()
 export class DeploymentService {
   constructor(
     @Inject(DeploymentDatastoreService) private readonly deploymentDatastoreService: DeploymentDatastoreService,
-    @Inject(ProjectService) private readonly projectService: ProjectService,
-    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
+    @Inject(AppEventsService) private readonly appEvents: AppEventsService,
   ) {}
 
   async listByProjectId(projectId: string) {
@@ -35,8 +34,7 @@ export class DeploymentService {
       },
     })
 
-    await this.upsertProject(projectId)
-    // TODO handle result and add logs
+    await this.upsertProject(projectId, 'Create Deployment')
     return deployment
   }
 
@@ -81,26 +79,21 @@ export class DeploymentService {
         })),
       },
     })
-    await this.upsertProject(deploymentToUpdate.projectId)
-    // TODO handle result and add logs
+    await this.upsertProject(deploymentToUpdate.projectId, 'Update Deployment')
     return deployment
   }
 
   async deleteDeployment(deploymentId: string) {
     const deployment = await this.deploymentDatastoreService.deleteDeployment(deploymentId)
-    await this.upsertProject(deployment.projectId)
-    // TODO handle result and add logs
+    await this.upsertProject(deployment.projectId, 'Delete Deployment')
   }
 
   async deleteAllDeploymentsByProjectId(projectId: string) {
     await this.deploymentDatastoreService.deleteAllDeploymentsByProjectId(projectId)
-    await this.upsertProject(projectId)
-    // TODO handle result and add logs
+    await this.upsertProject(projectId, 'Delete all project deployments')
   }
 
-  private async upsertProject(projectId: string) {
-    const projectWithDetails = await this.projectService.get(projectId)
-
-    await this.eventEmitter.emitAsync('project.upsert', projectWithDetails)
+  private async upsertProject(projectId: string, action: EventLogAction) {
+    await this.appEvents.emitProjectEvent('project.upsert', projectId, { action })
   }
 }

--- a/apps/server-nestjs/src/modules/events/app-events.module.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { InfrastructureModule } from '../infrastructure/infrastructure.module'
+import { LogModule } from '../log/log.module'
+import { AppEventsService } from './app-events.service'
+
+@Module({
+  imports: [InfrastructureModule, LogModule],
+  providers: [AppEventsService],
+  exports: [AppEventsService],
+})
+export class AppEventsModule {}

--- a/apps/server-nestjs/src/modules/events/app-events.service.spec.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.service.spec.ts
@@ -1,0 +1,134 @@
+import type { EventEmitter2 as EventEmitter2Type } from '@nestjs/event-emitter'
+import type { TestingModule } from '@nestjs/testing'
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { Test } from '@nestjs/testing'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { LogService } from '../log/log.service'
+import { projectSelect } from '../project/project-queries.utils'
+import { makeProject } from '../project/project-testing.utils'
+import { AppEventsService } from './app-events.service'
+
+describe('appEventsService', () => {
+  let module: TestingModule
+  let service: AppEventsService
+  let prisma: DeepMockProxy<PrismaService>
+  let eventEmitter: DeepMockProxy<EventEmitter2Type>
+  let logs: DeepMockProxy<LogService>
+
+  beforeEach(async () => {
+    prisma = mockDeep<PrismaService>()
+    eventEmitter = mockDeep<EventEmitter2>({ emitAsync: vi.fn().mockResolvedValue([]) })
+    logs = mockDeep<LogService>()
+
+    module = await Test.createTestingModule({
+      providers: [
+        AppEventsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: EventEmitter2, useValue: eventEmitter },
+        { provide: LogService, useValue: logs },
+      ],
+    }).compile()
+
+    service = module.get(AppEventsService)
+  })
+
+  afterEach(async () => {
+    await module?.close()
+  })
+
+  it('loads the project by id, emits and logs the merged listener results', async () => {
+    const project = makeProject()
+    prisma.project.findUnique.mockResolvedValue(project)
+    eventEmitter.emitAsync.mockResolvedValue([
+      undefined, // listener not yet migrated to capturePluginResult
+      { gitlab: { status: 'OK', message: 'Up to date', executionTime: 10 } },
+      { argocd: { status: 'KO', message: 'Sync failed', executionTime: 20, error: new Error('Sync failed') } },
+    ])
+
+    const results = await service.emitProjectEvent('project.upsert', project.id, {
+      action: 'Create Project',
+      userId: 'user-id',
+      requestId: 'request-id',
+    })
+
+    expect(prisma.project.findUnique).toHaveBeenCalledWith({
+      where: { id: project.id },
+      select: projectSelect,
+    })
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith('project.upsert', project)
+    expect(results).toEqual({
+      gitlab: expect.objectContaining({ status: 'OK' }),
+      argocd: expect.objectContaining({ status: 'KO' }),
+    })
+    expect(logs.addLog).toHaveBeenCalledWith({
+      action: 'Create Project',
+      userId: 'user-id',
+      requestId: 'request-id',
+      projectId: project.id,
+      data: {
+        args: project,
+        failed: ['argocd'],
+        results: {
+          gitlab: {
+            status: { result: 'OK', message: 'Up to date' },
+            executionTime: { main: 10 },
+          },
+          argocd: {
+            status: { result: 'KO', message: 'Sync failed' },
+            executionTime: { main: 20 },
+            error: expect.stringContaining('"message":"Sync failed"'),
+          },
+        },
+        totalExecutionTime: expect.any(Number),
+        messageResume: 'Errors:\nargocd: Sync failed;',
+      },
+    })
+  })
+
+  it('uses a provided project snapshot without fetching it again', async () => {
+    const project = makeProject()
+
+    await service.emitProjectEvent('project.delete', project, { action: 'Delete all project resources' })
+
+    expect(prisma.project.findUnique).not.toHaveBeenCalled()
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith('project.delete', project)
+  })
+
+  it('defaults the log userId and requestId to null', async () => {
+    const project = makeProject()
+
+    await service.emitProjectEvent('project.upsert', project, { action: 'Update Project' })
+
+    expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'Update Project',
+      userId: null,
+      requestId: null,
+    }))
+  })
+
+  it('skips emitting and logging when the project cannot be found', async () => {
+    prisma.project.findUnique.mockResolvedValue(null)
+
+    const results = await service.emitProjectEvent('project.upsert', 'missing-id', { action: 'Update Project' })
+
+    expect(results).toEqual({})
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled()
+    expect(logs.addLog).not.toHaveBeenCalled()
+  })
+
+  it('emits and logs project member events with their payload as args', async () => {
+    const payload = { projectId: 'project-id', userId: 'user-id' }
+
+    await service.emitProjectMemberEvent('projectMember.upsert', payload, { action: 'Add Project Member' })
+
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith('projectMember.upsert', payload)
+    expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'Add Project Member',
+      projectId: 'project-id',
+      data: expect.objectContaining({ args: payload }),
+    }))
+  })
+})

--- a/apps/server-nestjs/src/modules/events/app-events.service.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.service.ts
@@ -1,0 +1,105 @@
+import type { PluginResults } from '../plugin/plugin.utils'
+import type { ProjectWithDetails } from '../project/project-queries.utils'
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { LogService } from '../log/log.service'
+import { mergePluginResults } from '../plugin/plugin.utils'
+import { getProject } from '../project/project-queries.utils'
+import { formatEventLogData, isPluginResults } from './app-events.utils'
+
+export type ProjectEventName = 'project.upsert' | 'project.delete'
+export type ProjectMemberEventName = 'projectMember.upsert' | 'projectMember.delete'
+
+export interface ProjectMemberEventPayload {
+  projectId: string
+  userId: string
+}
+
+/** Admin-log action labels (legacy hooks wording). */
+export type EventLogAction
+  = | 'Create Project' | 'Update Project' | 'Delete all project resources'
+    | 'Replay hooks for Project' | 'Upsert Project Role'
+    | 'Create Deployment' | 'Update Deployment' | 'Delete Deployment'
+    | 'Delete all project deployments'
+    | 'Add Project Member' | 'Update Project Member' | 'Remove Project Member'
+
+export interface EventContext {
+  /** Action label persisted in the admin log. */
+  action: EventLogAction
+  userId?: string | null
+  requestId?: string | null
+}
+
+/**
+ * Single entry point to emit domain events: emits through EventEmitter2, merges the
+ * `PluginResults` returned by every `capturePluginResult` listener and persists one admin
+ * log per event. Emitters only provide an id and the log context.
+ */
+@Injectable()
+export class AppEventsService {
+  private readonly logger = new Logger(AppEventsService.name)
+
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
+    @Inject(LogService) private readonly logs: LogService,
+  ) {}
+
+  /**
+   * Emits a project event and logs the merged listener results.
+   *
+   * Pass a project id in the general case: the project is loaded here, after the
+   * emitting transaction commits, so every listener sees the same committed state.
+   * Pass an already-loaded snapshot when the row no longer reflects what listeners
+   * must act on (e.g. archiving renames the slug before emitting `project.delete`).
+   */
+  async emitProjectEvent(
+    event: ProjectEventName,
+    projectOrId: string | ProjectWithDetails,
+    context: EventContext,
+  ): Promise<PluginResults> {
+    const project = typeof projectOrId === 'string'
+      ? await getProject(this.prisma, projectOrId)
+      : projectOrId
+
+    if (!project) {
+      this.logger.warn(`${event} skipped: project not found (projectId=${String(projectOrId)})`)
+      return {}
+    }
+
+    return this.emitAndLog(event, project, project.id, context)
+  }
+
+  async emitProjectMemberEvent(
+    event: ProjectMemberEventName,
+    payload: ProjectMemberEventPayload,
+    context: EventContext,
+  ): Promise<PluginResults> {
+    return this.emitAndLog(event, payload, payload.projectId, context)
+  }
+
+  private async emitAndLog(
+    event: string,
+    payload: unknown,
+    projectId: string,
+    context: EventContext,
+  ): Promise<PluginResults> {
+    const start = process.hrtime.bigint()
+    const responses = await this.eventEmitter.emitAsync(event, payload)
+    const totalExecutionTime = Number(process.hrtime.bigint() - start) / 1_000_000
+
+    const results = mergePluginResults(responses.filter(isPluginResults))
+    this.logger.log(`${event} completed (projectId=${projectId}, services=${Object.keys(results).join(',') || 'none'})`)
+
+    await this.logs.addLog({
+      action: context.action,
+      data: formatEventLogData(payload, results, totalExecutionTime),
+      userId: context.userId ?? null,
+      requestId: context.requestId ?? null,
+      projectId,
+    })
+
+    return results
+  }
+}

--- a/apps/server-nestjs/src/modules/events/app-events.utils.spec.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.utils.spec.ts
@@ -1,0 +1,81 @@
+import type { PluginResults } from '../plugin/plugin.utils'
+import { describe, expect, it } from 'vitest'
+import { formatEventLogData, isPluginResults, serializeError } from './app-events.utils'
+
+describe('isPluginResults', () => {
+  it('should accept an object produced by a capturePluginResult handler', () => {
+    expect(isPluginResults({ gitlab: { status: 'OK', message: 'Up to date', executionTime: 10 } })).toBe(true)
+    expect(isPluginResults({ argocd: { status: 'KO', message: 'boom', executionTime: 10, error: new Error('boom') } })).toBe(true)
+  })
+
+  it('should reject non-result responses', () => {
+    expect(isPluginResults(undefined)).toBe(false)
+    expect(isPluginResults(null)).toBe(false)
+    expect(isPluginResults('ok')).toBe(false)
+    expect(isPluginResults({})).toBe(false)
+    expect(isPluginResults({ gitlab: { foo: 'bar' } })).toBe(false)
+    expect(isPluginResults({ gitlab: { status: 'MAYBE' } })).toBe(false)
+  })
+})
+
+describe('serializeError', () => {
+  it('should serialize an Error with name, message and stack', () => {
+    const parsed = JSON.parse(serializeError(new Error('boom')))
+    expect(parsed).toEqual({ name: 'Error', message: 'boom', stack: expect.any(String) })
+  })
+
+  it('should serialize non-Error values', () => {
+    expect(serializeError({ code: 42 })).toBe('{"code":42}')
+    expect(serializeError('boom')).toBe('"boom"')
+  })
+})
+
+describe('formatEventLogData', () => {
+  const args = { id: 'project-1', slug: 'project-1' }
+
+  it('should format results in the LogSchema shape', () => {
+    const results: PluginResults = {
+      gitlab: { status: 'OK', message: 'Up to date', executionTime: 12.4 },
+      argocd: { status: 'KO', message: 'Sync failed', executionTime: 100.9, error: new Error('Sync failed') },
+    }
+
+    expect(formatEventLogData(args, results, 120.6)).toEqual({
+      args,
+      failed: ['argocd'],
+      results: {
+        gitlab: {
+          status: { result: 'OK', message: 'Up to date' },
+          executionTime: { main: 12 },
+        },
+        argocd: {
+          status: { result: 'KO', message: 'Sync failed' },
+          executionTime: { main: 101 },
+          error: expect.stringContaining('"message":"Sync failed"'),
+        },
+      },
+      totalExecutionTime: 121,
+      messageResume: 'Errors:\nargocd: Sync failed;',
+    })
+  })
+
+  it('should produce an empty failed list and a success resume when everything is OK', () => {
+    const results: PluginResults = {
+      gitlab: { status: 'OK', message: 'Up to date', executionTime: 10 },
+    }
+
+    expect(formatEventLogData(args, results, 10)).toEqual(expect.objectContaining({
+      failed: [],
+      messageResume: 'Success',
+    }))
+  })
+
+  it('should handle events without any listener', () => {
+    expect(formatEventLogData(args, {}, 1)).toEqual({
+      args,
+      failed: [],
+      results: {},
+      totalExecutionTime: 1,
+      messageResume: 'Success',
+    })
+  })
+})

--- a/apps/server-nestjs/src/modules/events/app-events.utils.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.utils.ts
@@ -1,0 +1,71 @@
+import type { LogData } from '../log/log.service'
+import type { PluginName, PluginResult, PluginResults } from '../plugin/plugin.utils'
+import { getFailedPlugins } from '../plugin/plugin.utils'
+
+/** Per-service result as persisted in the admin logs (legacy hooks format, parsed by LogSchema). */
+export interface LoggablePluginResult {
+  status: {
+    result: 'OK' | 'KO'
+    message?: string
+  }
+  executionTime: {
+    main: number
+  }
+  error?: string
+}
+
+function isPluginResult(value: unknown): value is PluginResult {
+  return typeof value === 'object'
+    && value !== null
+    && 'status' in value
+    && ((value as PluginResult).status === 'OK' || (value as PluginResult).status === 'KO')
+}
+
+/** Narrows an `emitAsync` response to a `PluginResults` object produced by `capturePluginResult` handlers. */
+export function isPluginResults(response: unknown): response is PluginResults {
+  if (typeof response !== 'object' || response === null) return false
+  const values = Object.values(response)
+  return values.length > 0 && values.every(isPluginResult)
+}
+
+export function serializeError(error: unknown): string {
+  if (error instanceof Error) {
+    return JSON.stringify({ name: error.name, message: error.message, stack: error.stack })
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+function toLoggableResult(result: PluginResult): LoggablePluginResult {
+  return {
+    status: {
+      result: result.status,
+      ...(result.message ? { message: result.message } : {}),
+    },
+    executionTime: { main: Math.round(result.executionTime) },
+    ...(result.status === 'KO' ? { error: serializeError(result.error) } : {}),
+  }
+}
+
+function buildMessageResume(results: PluginResults, failed: PluginName[]): string {
+  if (!failed.length) return 'Success'
+  const errorLines = failed.map(service => `${service}: ${results[service]?.message};`).join('\n')
+  return `Errors:\n${errorLines}`
+}
+
+/** Builds the log `data` payload for an event: the emitted args plus every listener's result. */
+export function formatEventLogData(args: unknown, results: PluginResults, totalExecutionTime: number): LogData {
+  const failed = getFailedPlugins(results)
+  const entries = Object.entries(results) as [PluginName, PluginResult][]
+
+  return {
+    args,
+    failed,
+    results: Object.fromEntries(entries.map(([service, result]) => [service, toLoggableResult(result)])),
+    totalExecutionTime: Math.round(totalExecutionTime),
+    messageResume: buildMessageResume(results, failed),
+  }
+}

--- a/apps/server-nestjs/src/modules/log/log.service.ts
+++ b/apps/server-nestjs/src/modules/log/log.service.ts
@@ -5,9 +5,26 @@ import { Inject, Injectable } from '@nestjs/common'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { countLogs, listLogs } from './log-queries.utils'
 
+/**
+ * Shape of the `data` JSON column, aligned with the LogSchema contract in
+ * `@cpn-console/shared` so the console can parse and display every entry.
+ */
+export interface LogData {
+  /** Payload the action/event was invoked with (e.g. the full project). */
+  args?: unknown
+  /** Names of the services that reported a KO result. */
+  failed?: boolean | string[]
+  /** Per-service outcome, keyed by service name. */
+  results?: Record<string, unknown>
+  totalExecutionTime?: number
+  messageResume?: string
+  /** Extra keys are persisted as-is, except the sensitive ones stripped by addLog. */
+  [key: string]: unknown
+}
+
 interface AddLogArgs {
   action: string
-  data: Prisma.InputJsonValue
+  data: LogData
   userId?: string | null
   requestId?: string | null
   projectId?: string | null
@@ -50,7 +67,7 @@ export class LogService {
         userId,
         requestId,
         projectId,
-        data: exclude<Prisma.InputJsonValue>(data, ['cluster', 'user', 'newCreds', 'apis', 'config']),
+        data: exclude(data, ['cluster', 'user', 'newCreds', 'apis', 'config']) as Prisma.InputJsonValue,
       },
     })
   }

--- a/apps/server-nestjs/src/modules/project-hooks/project-hooks.module.ts
+++ b/apps/server-nestjs/src/modules/project-hooks/project-hooks.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common'
+import { AppEventsModule } from '../events/app-events.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
-import { LogModule } from '../log/log.module'
 import { ProjectHooksController } from './project-hooks.controller'
 import { ProjectHooksService } from './project-hooks.service'
 
 @Module({
-  imports: [InfrastructureModule, LogModule],
+  imports: [AppEventsModule, InfrastructureModule],
   controllers: [ProjectHooksController],
   providers: [ProjectHooksService],
   exports: [ProjectHooksService],

--- a/apps/server-nestjs/src/modules/project-hooks/project-hooks.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-hooks/project-hooks.service.spec.ts
@@ -1,13 +1,11 @@
-import type { EventEmitter2 as EventEmitter2Type } from '@nestjs/event-emitter'
 import type { TestingModule } from '@nestjs/testing'
 import type { DeepMockProxy } from 'vitest-mock-extended'
 import { ForbiddenException } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
 import { Test } from '@nestjs/testing'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { AppEventsService } from '../events/app-events.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
-import { LogService } from '../log/log.service'
 import { projectSelect } from '../project/project-queries.utils'
 import { makeProject } from '../project/project-testing.utils'
 import { ProjectHooksService } from './project-hooks.service'
@@ -16,20 +14,17 @@ describe('projectHooksService', () => {
   let module: TestingModule
   let service: ProjectHooksService
   let prisma: DeepMockProxy<PrismaService>
-  let eventEmitter: DeepMockProxy<EventEmitter2Type>
-  let logs: DeepMockProxy<LogService>
+  let appEvents: DeepMockProxy<AppEventsService>
 
   beforeEach(async () => {
     prisma = mockDeep<PrismaService>()
-    eventEmitter = mockDeep<EventEmitter2>({ emitAsync: vi.fn().mockResolvedValue([]) })
-    logs = mockDeep<LogService>()
+    appEvents = mockDeep<AppEventsService>()
 
     module = await Test.createTestingModule({
       providers: [
         ProjectHooksService,
         { provide: PrismaService, useValue: prisma },
-        { provide: EventEmitter2, useValue: eventEmitter },
-        { provide: LogService, useValue: logs },
+        { provide: AppEventsService, useValue: appEvents },
       ],
     }).compile()
 
@@ -51,7 +46,7 @@ describe('projectHooksService', () => {
       data: { locked: true },
       select: projectSelect,
     })
-    expect(eventEmitter.emitAsync).toHaveBeenCalledWith('project.upsert', project)
+    expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', project, { action: 'Update Project' })
   })
 
   it('replayHooks loads the project and emits project.upsert', async () => {
@@ -67,13 +62,11 @@ describe('projectHooksService', () => {
       where: { id: 'project-id', status: { not: 'archived' } },
       select: projectSelect,
     })
-    expect(eventEmitter.emitAsync).toHaveBeenCalledWith('project.upsert', project)
-    expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({
+    expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', project, {
       action: 'Replay hooks for Project',
-      requestId,
       userId,
-      projectId: project.id,
-    }))
+      requestId,
+    })
   })
 
   it('replayHooks rejects locked projects', async () => {
@@ -82,7 +75,6 @@ describe('projectHooksService', () => {
 
     await expect(service.replay('project-id', 'user-id', 'request-id')).rejects.toThrow(ForbiddenException)
 
-    expect(eventEmitter.emitAsync).not.toHaveBeenCalled()
-    expect(logs.addLog).not.toHaveBeenCalled()
+    expect(appEvents.emitProjectEvent).not.toHaveBeenCalled()
   })
 })

--- a/apps/server-nestjs/src/modules/project-hooks/project-hooks.service.ts
+++ b/apps/server-nestjs/src/modules/project-hooks/project-hooks.service.ts
@@ -1,9 +1,7 @@
-import type { ProjectWithDetails } from '../project/project-queries.utils'
 import { ForbiddenException, Inject, Injectable, Logger } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
+import { AppEventsService } from '../events/app-events.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
-import { LogService } from '../log/log.service'
 import { getProjectNotArchived, projectSelect } from '../project/project-queries.utils'
 
 @Injectable()
@@ -12,29 +10,8 @@ export class ProjectHooksService {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
-    @Inject(LogService) private readonly logs: LogService,
+    @Inject(AppEventsService) private readonly appEvents: AppEventsService,
   ) {}
-
-  private async logProjectAction(
-    action: string,
-    project: ProjectWithDetails,
-    messageResume: string,
-    userId: string | undefined,
-    requestId: string | undefined,
-  ): Promise<void> {
-    await this.logs.addLog({
-      action,
-      data: {
-        args: { projectId: project.id },
-        messageResume,
-        results: { projectId: project.id, slug: project.slug },
-      },
-      userId,
-      requestId,
-      projectId: project.id,
-    })
-  }
 
   async updateProjectLocked(projectId: string, locked: boolean): Promise<void> {
     const project = await this.prisma.project.update({
@@ -42,7 +19,7 @@ export class ProjectHooksService {
       data: { locked },
       select: projectSelect,
     })
-    await this.eventEmitter.emitAsync('project.upsert', project)
+    await this.appEvents.emitProjectEvent('project.upsert', project, { action: 'Update Project' })
   }
 
   async replay(projectId: string, requestorUserId?: string, requestId?: string): Promise<void> {
@@ -59,14 +36,11 @@ export class ProjectHooksService {
       throw new ForbiddenException('Veuillez déverrouiller le projet pour rejouer les webhooks')
     }
     span?.setAttribute('project.slug', project.slug)
-    await this.eventEmitter.emitAsync('project.upsert', project)
-    await this.logProjectAction(
-      'Replay hooks for Project',
-      project,
-      `Hooks du projet rejoués: ${project.slug}`,
-      requestorUserId,
+    await this.appEvents.emitProjectEvent('project.upsert', project, {
+      action: 'Replay hooks for Project',
+      userId: requestorUserId,
       requestId,
-    )
+    })
     this.logger.log(`project.replayHooks completed (projectId=${projectId})`)
   }
 }

--- a/apps/server-nestjs/src/modules/project-members/project-members.module.ts
+++ b/apps/server-nestjs/src/modules/project-members/project-members.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+import { AppEventsModule } from '../events/app-events.module'
 import { AuthModule } from '../infrastructure/auth/auth.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
 import { KeycloakModule } from '../keycloak/keycloak.module'
@@ -6,7 +7,7 @@ import { ProjectMembersController } from './project-members.controller'
 import { ProjectMembersService } from './project-members.service'
 
 @Module({
-  imports: [InfrastructureModule, AuthModule, KeycloakModule],
+  imports: [AppEventsModule, InfrastructureModule, AuthModule, KeycloakModule],
   controllers: [ProjectMembersController],
   providers: [ProjectMembersService],
 })

--- a/apps/server-nestjs/src/modules/project-members/project-members.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-members/project-members.service.spec.ts
@@ -3,10 +3,10 @@ import type { Prisma } from '@prisma/client'
 import type { DeepMockProxy } from 'vitest-mock-extended'
 import { faker } from '@faker-js/faker'
 import { NotFoundException } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { AppEventsService } from '../events/app-events.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { KeycloakClientService } from '../keycloak/keycloak-client.service'
 import {
@@ -21,19 +21,19 @@ describe('projectMembersService', () => {
   let module: TestingModule
   let service: ProjectMembersService
   let prisma: DeepMockProxy<PrismaService>
-  let events: DeepMockProxy<EventEmitter2>
+  let appEvents: DeepMockProxy<AppEventsService>
   let keycloak: DeepMockProxy<KeycloakClientService>
 
   beforeEach(async () => {
     prisma = mockDeep<PrismaService>()
-    events = mockDeep<EventEmitter2>()
+    appEvents = mockDeep<AppEventsService>()
     keycloak = mockDeep<KeycloakClientService>()
 
     module = await Test.createTestingModule({
       providers: [
         ProjectMembersService,
         { provide: PrismaService, useValue: prisma },
-        { provide: EventEmitter2, useValue: events },
+        { provide: AppEventsService, useValue: appEvents },
         { provide: KeycloakClientService, useValue: keycloak },
       ],
     }).compile()
@@ -91,10 +91,10 @@ describe('projectMembersService', () => {
         create: { projectId, userId: newUserId, roleIds: [] },
         update: {},
       })
-      expect(events.emitAsync).toHaveBeenCalledWith('projectMember.upsert', {
+      expect(appEvents.emitProjectMemberEvent).toHaveBeenCalledWith('projectMember.upsert', {
         projectId,
         userId: newUserId,
-      })
+      }, { action: 'Add Project Member' })
       expect(result).toBeDefined()
     })
 
@@ -230,15 +230,15 @@ describe('projectMembersService', () => {
       await service.patch(projectId, members)
 
       expect(tx.projectMembers.upsert).toHaveBeenCalledTimes(2)
-      expect(events.emitAsync).toHaveBeenCalledTimes(2)
-      expect(events.emitAsync).toHaveBeenCalledWith('projectMember.upsert', {
+      expect(appEvents.emitProjectMemberEvent).toHaveBeenCalledTimes(2)
+      expect(appEvents.emitProjectMemberEvent).toHaveBeenCalledWith('projectMember.upsert', {
         projectId,
         userId: members[0].userId,
-      })
-      expect(events.emitAsync).toHaveBeenCalledWith('projectMember.upsert', {
+      }, { action: 'Update Project Member' })
+      expect(appEvents.emitProjectMemberEvent).toHaveBeenCalledWith('projectMember.upsert', {
         projectId,
         userId: members[1].userId,
-      })
+      }, { action: 'Update Project Member' })
     })
   })
 
@@ -258,10 +258,10 @@ describe('projectMembersService', () => {
       expect(tx.projectMembers.delete).toHaveBeenCalledWith({
         where: { projectId_userId: { projectId, userId } },
       })
-      expect(events.emitAsync).toHaveBeenCalledWith('projectMember.delete', {
+      expect(appEvents.emitProjectMemberEvent).toHaveBeenCalledWith('projectMember.delete', {
         projectId,
         userId,
-      })
+      }, { action: 'Remove Project Member' })
       expect(result).toBeDefined()
     })
   })

--- a/apps/server-nestjs/src/modules/project-members/project-members.service.ts
+++ b/apps/server-nestjs/src/modules/project-members/project-members.service.ts
@@ -1,7 +1,7 @@
 import type { AddMemberInput, PatchMemberInput } from './project-members-queries.utils'
 import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
+import { AppEventsService } from '../events/app-events.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { KeycloakClientService } from '../keycloak/keycloak-client.service'
@@ -13,7 +13,7 @@ export class ProjectMembersService {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
+    @Inject(AppEventsService) private readonly appEvents: AppEventsService,
     @Inject(KeycloakClientService) private readonly keycloak: KeycloakClientService,
   ) {}
 
@@ -59,7 +59,7 @@ export class ProjectMembersService {
         const members = await listProjectMembersWithUser(tx, projectId)
         return { userId: userDb.id, members }
       })
-      await this.eventEmitter.emitAsync('projectMember.upsert', { projectId, userId: result.userId })
+      await this.appEvents.emitProjectMemberEvent('projectMember.upsert', { projectId, userId: result.userId }, { action: 'Add Project Member' })
       span?.setAttribute('project.member.userId', result.userId)
       span?.setAttribute('project.members.count', result.members.length)
       this.logger.log(`projectMembers.addMember completed (projectId=${projectId}, userId=${result.userId}, memberCount=${result.members.length})`)
@@ -124,7 +124,7 @@ export class ProjectMembersService {
         return listProjectMembersWithUser(tx, projectId)
       })
       await Promise.all(
-        body.map(member => this.eventEmitter.emitAsync('projectMember.upsert', { projectId, userId: member.userId })),
+        body.map(member => this.appEvents.emitProjectMemberEvent('projectMember.upsert', { projectId, userId: member.userId }, { action: 'Update Project Member' })),
       )
       span?.setAttribute('project.members.count', members.length)
       this.logger.log(`projectMembers.patchMembers completed (projectId=${projectId}, memberCount=${members.length})`)
@@ -149,7 +149,7 @@ export class ProjectMembersService {
         await deleteProjectMember(tx, projectId, userId)
         return listProjectMembersWithUser(tx, projectId)
       })
-      await this.eventEmitter.emitAsync('projectMember.delete', { projectId, userId })
+      await this.appEvents.emitProjectMemberEvent('projectMember.delete', { projectId, userId }, { action: 'Remove Project Member' })
       span?.setAttribute('project.members.count', members.length)
       this.logger.log(`projectMembers.removeMember completed (projectId=${projectId}, userId=${userId}, memberCount=${members.length})`)
       return members

--- a/apps/server-nestjs/src/modules/project-roles/project-roles.module.ts
+++ b/apps/server-nestjs/src/modules/project-roles/project-roles.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
+import { AppEventsModule } from '../events/app-events.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
 import { ProjectRolesController } from './project-roles.controller'
 import { ProjectRolesService } from './project-roles.service'
 
 @Module({
-  imports: [InfrastructureModule],
+  imports: [AppEventsModule, InfrastructureModule],
   controllers: [ProjectRolesController],
   providers: [ProjectRolesService],
   exports: [ProjectRolesService],

--- a/apps/server-nestjs/src/modules/project-roles/project-roles.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-roles/project-roles.service.spec.ts
@@ -3,10 +3,10 @@ import type { Prisma } from '@prisma/client'
 import type { DeepMockProxy } from 'vitest-mock-extended'
 import { faker } from '@faker-js/faker'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { AppEventsService } from '../events/app-events.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { makeProject, makeProjectMembers, makeProjectRole, makeProjectRoleWithProject } from './project-roles-testing.utils'
 import { ProjectRolesService } from './project-roles.service'
@@ -15,17 +15,17 @@ describe('projectRolesService', () => {
   let module: TestingModule
   let service: ProjectRolesService
   let prisma: DeepMockProxy<PrismaService>
-  let events: DeepMockProxy<EventEmitter2>
+  let appEvents: DeepMockProxy<AppEventsService>
 
   beforeEach(async () => {
     prisma = mockDeep<PrismaService>()
-    events = mockDeep<EventEmitter2>()
+    appEvents = mockDeep<AppEventsService>()
 
     module = await Test.createTestingModule({
       providers: [
         ProjectRolesService,
         { provide: PrismaService, useValue: prisma },
-        { provide: EventEmitter2, useValue: events },
+        { provide: AppEventsService, useValue: appEvents },
       ],
     }).compile()
 
@@ -70,7 +70,7 @@ describe('projectRolesService', () => {
         projectId,
       }),
     }))
-    expect(events.emitAsync).toHaveBeenCalledWith('project.upsert', expect.anything())
+    expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', expect.anything(), { action: 'Upsert Project Role' })
   })
 
   it('rejects system role creation', async () => {
@@ -162,7 +162,7 @@ describe('projectRolesService', () => {
     await service.delete(roleId)
 
     expect(tx.projectMembers.update).toHaveBeenCalledTimes(2)
-    expect(events.emitAsync).toHaveBeenCalledWith('project.upsert', expect.anything())
+    expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', expect.anything(), { action: 'Upsert Project Role' })
   })
 
   it('rejects system role deletion', async () => {

--- a/apps/server-nestjs/src/modules/project-roles/project-roles.service.ts
+++ b/apps/server-nestjs/src/modules/project-roles/project-roles.service.ts
@@ -5,9 +5,9 @@ import type {
 } from './project-roles.utils'
 import { isSystemRoleType } from '@cpn-console/shared'
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
+import { AppEventsService } from '../events/app-events.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
-import { getProjectBySlug, getProjectForUpsert, getProjectRoleForDelete, projectRoleWithProjectSelect } from './project-roles-queries.utils'
+import { getProjectBySlug, getProjectRoleForDelete, projectRoleWithProjectSelect } from './project-roles-queries.utils'
 import {
   buildUpdatedProjectRoles,
   toProjectRoleResponse,
@@ -18,7 +18,7 @@ import {
 export class ProjectRolesService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
+    @Inject(AppEventsService) private readonly appEvents: AppEventsService,
   ) {}
 
   async list(projectId: Project['id']) {
@@ -125,9 +125,6 @@ export class ProjectRolesService {
   }
 
   private async emitProjectUpsert(projectId: string): Promise<void> {
-    const project = await getProjectForUpsert(this.prisma, projectId)
-    if (project) {
-      await this.eventEmitter.emitAsync('project.upsert', project)
-    }
+    await this.appEvents.emitProjectEvent('project.upsert', projectId, { action: 'Upsert Project Role' })
   }
 }

--- a/apps/server-nestjs/src/modules/project/project.module.ts
+++ b/apps/server-nestjs/src/modules/project/project.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common'
+import { AppEventsModule } from '../events/app-events.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
 import { LogModule } from '../log/log.module'
 import { ProjectController } from './project.controller'
 import { ProjectService } from './project.service'
 
 @Module({
-  imports: [InfrastructureModule, LogModule],
+  imports: [AppEventsModule, InfrastructureModule, LogModule],
   controllers: [ProjectController],
   providers: [ProjectService],
   exports: [ProjectService],

--- a/apps/server-nestjs/src/modules/project/project.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project/project.service.spec.ts
@@ -8,10 +8,10 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { AppEventsService } from '../events/app-events.service'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { LogService } from '../log/log.service'
@@ -32,13 +32,13 @@ describe('projectService', () => {
   let module: TestingModule
   let service: ProjectService
   let prisma: DeepMockProxy<PrismaService>
-  let events: DeepMockProxy<EventEmitter2>
+  let appEvents: DeepMockProxy<AppEventsService>
   let config: DeepMockProxy<ConfigurationService>
   let logs: DeepMockProxy<LogService>
 
   beforeEach(async () => {
     prisma = mockDeep<PrismaService>()
-    events = mockDeep<EventEmitter2>()
+    appEvents = mockDeep<AppEventsService>()
     config = mockDeep<ConfigurationService>({ appVersion: 'dev' })
     logs = mockDeep<LogService>()
 
@@ -46,7 +46,7 @@ describe('projectService', () => {
       providers: [
         ProjectService,
         { provide: PrismaService, useValue: prisma },
-        { provide: EventEmitter2, useValue: events },
+        { provide: AppEventsService, useValue: appEvents },
         { provide: ConfigurationService, useValue: config },
         { provide: LogService, useValue: logs },
       ],
@@ -90,14 +90,12 @@ describe('projectService', () => {
         expect.objectContaining({ where: { slug: { startsWith: body.name } } }),
       )
       expect(tx.project.create).toHaveBeenCalled()
-      expect(events.emitAsync).toHaveBeenCalledWith('project.upsert', expect.anything())
-      expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', pwd.id, {
         action: 'Create Project',
-        requestId,
         userId,
-        projectId: pwd.id,
-      }))
-      expect(logs.addLog).toHaveBeenCalledTimes(5)
+        requestId,
+      })
+      expect(logs.addLog).toHaveBeenCalledTimes(4)
       expect(result).toBeDefined()
       expect(result.slug).toBe(expectedSlug)
     })
@@ -257,13 +255,11 @@ describe('projectService', () => {
       )
 
       expect(result.description).toBe('Updated desc')
-      expect(events.emitAsync).toHaveBeenCalledWith('project.upsert', expect.anything())
-      expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', ctx.id, {
         action: 'Update Project',
-        requestId,
         userId: requestorId,
-        projectId: ctx.id,
-      }))
+        requestId,
+      })
     })
 
     it('strips locked field for non-admin', async () => {
@@ -479,13 +475,11 @@ describe('projectService', () => {
       expect(tx.repository.deleteMany).toHaveBeenCalledWith({ where: { projectId } })
       expect(tx.environment.deleteMany).toHaveBeenCalledWith({ where: { projectId } })
       expect(tx.deployment.deleteMany).toHaveBeenCalledWith({ where: { projectId } })
-      expect(events.emitAsync).toHaveBeenCalledWith('project.delete', pwd)
-      expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.delete', pwd, {
         action: 'Delete all project resources',
-        requestId,
         userId: requestorId,
-        projectId,
-      }))
+        requestId,
+      })
       expect(tx.project.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: projectId },

--- a/apps/server-nestjs/src/modules/project/project.service.ts
+++ b/apps/server-nestjs/src/modules/project/project.service.ts
@@ -4,8 +4,8 @@ import type { UserContext } from '../infrastructure/auth/auth-user.decorator'
 import type { ProjectDataExport, ProjectUpdateContext, ProjectWithDetails } from './project-queries.utils'
 import { AdminAuthorized } from '@cpn-console/shared'
 import { BadRequestException, ForbiddenException, Inject, Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common'
-import { EventEmitter2 } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
+import { AppEventsService } from '../events/app-events.service'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
@@ -29,7 +29,7 @@ export class ProjectService {
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
-    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
+    @Inject(AppEventsService) private readonly appEvents: AppEventsService,
     @Inject(ConfigurationService) private readonly config: ConfigurationService,
     @Inject(LogService) private readonly logs: LogService,
   ) {}
@@ -106,14 +106,11 @@ export class ProjectService {
         if (!loaded) throw new InternalServerErrorException('Project created but cannot be loaded')
         return loaded
       })
-      await this.eventEmitter.emitAsync('project.upsert', project)
-      await this.logProjectAction(
-        'Create Project',
-        project,
-        `Projet créé: ${project.slug} (${project.roles.length} rôles)`,
-        requestorUserId,
+      await this.appEvents.emitProjectEvent('project.upsert', project.id, {
+        action: 'Create Project',
+        userId: requestorUserId,
         requestId,
-      )
+      })
       await Promise.all(project.roles.map(async role => this.logProjectRoleAction(
         'Upsert Project Role',
         project,
@@ -168,14 +165,11 @@ export class ProjectService {
         this.logger.log(`project.update dbUpdated (projectId=${projectId}, requestorUserId=${user.userId}, effectiveKeys=${effectiveKeys.join(',')})`)
         return updated
       })
-      await this.eventEmitter.emitAsync('project.upsert', project)
-      await this.logProjectAction(
-        'Update Project',
-        project,
-        `Projet mis à jour: ${project.slug}`,
-        user.userId,
+      await this.appEvents.emitProjectEvent('project.upsert', project.id, {
+        action: 'Update Project',
+        userId: user.userId,
         requestId,
-      )
+      })
       span?.setAttribute('project.slug', project.slug)
       this.logger.log(`project.update completed (projectId=${projectId}, requestorUserId=${user.userId})`)
       return project
@@ -211,14 +205,13 @@ export class ProjectService {
 
         return loaded
       })
-      await this.eventEmitter.emitAsync('project.delete', project)
-      await this.logProjectAction(
-        'Delete all project resources',
-        project,
-        `Projet archivé: ${project.slug}`,
-        requestorUserId,
+      // pass the pre-archive snapshot: the row was renamed (slug suffixed) in the
+      // transaction above, listeners must clean up resources named after the old slug
+      await this.appEvents.emitProjectEvent('project.delete', project, {
+        action: 'Delete all project resources',
+        userId: requestorUserId,
         requestId,
-      )
+      })
       span?.setAttribute('project.slug', project.slug)
       this.logger.log(`project.archive completed (projectId=${projectId}, slug=${project.slug})`)
     } catch (error) {
@@ -228,26 +221,6 @@ export class ProjectService {
       )
       throw error
     }
-  }
-
-  private async logProjectAction(
-    action: string,
-    project: ProjectWithDetails,
-    messageResume: string,
-    userId: string | undefined,
-    requestId: string | undefined,
-  ): Promise<void> {
-    await this.logs.addLog({
-      action,
-      data: {
-        args: { projectId: project.id },
-        messageResume,
-        results: { projectId: project.id, slug: project.slug },
-      },
-      userId,
-      requestId,
-      projectId: project.id,
-    })
   }
 
   private async logProjectRoleAction(


### PR DESCRIPTION
## Issues liées

Issues numéro: N/A

---------

## Quel est le comportement actuel ?

Chaque service métier (project, project-members, project-roles, project-hooks, deployment) gère lui-même l'émission de ses événements de domaine : appel direct à `EventEmitter2.emitAsync`, chargement du projet, agrégation des résultats des plugins et écriture du log admin. Cette logique est dupliquée dans chaque service, avec des formats de log hétérogènes et un risque d'oubli (événement émis sans log, ou log sans les résultats des plugins).

## Quel est le nouveau comportement ?

Introduction d'un `AppEventsService` (module `events`), point d'entrée unique pour émettre les événements de domaine :

- `emitProjectEvent(event, projectOrId, context)` : charge le projet (après commit de la transaction émettrice, pour que tous les listeners voient le même état), émet via `EventEmitter2`, fusionne les `PluginResults` retournés par les listeners et persiste un log admin unique par événement (format compatible avec les logs existants). Accepte aussi un snapshot déjà chargé pour les cas où la ligne ne reflète plus l'état attendu (ex. archivage qui renomme le slug avant `project.delete`).
- `emitProjectMemberEvent(event, payload, context)` : même mécanique pour les événements membres.
- `app-events.utils.ts` : garde de type `isPluginResults` et formatage des données de log (payload, résultats, temps d'exécution).

Les services project, project-members, project-roles, project-hooks et deployment sont refactorés pour déléguer à `AppEventsService`, ce qui supprime la logique dupliquée d'émission/log. Les specs correspondantes sont mises à jour et de nouveaux tests couvrent le service et les utils.

## Cette PR introduit-elle un breaking change ?

Non. Refactoring interne au serveur NestJS : les noms d'événements, les contrats des listeners et le format des logs admin restent inchangés.

## Autres informations

PR empilée sur `fix/deployment-spec-ts-errors` (corrections TS des specs deployment, actuellement en review) : la base sera rebasculée sur `main` une fois cette PR mergée. Ouverte en draft en attendant.

