### PR TITLE
feat(server-nestjs): align plugin services with autoSync and suspende…

### DIFF
--- a/apps/server-nestjs/src/modules/argocd/argocd-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd-datastore.service.ts
@@ -1,6 +1,8 @@
 import type { Prisma } from '@prisma/client'
+import { ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { PrismaService } from '../infrastructure/database/prisma.service'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './argocd.constants'
 
 export const projectSelect = {
   id: true,
@@ -100,5 +102,47 @@ export class ArgoCDDatastoreService {
     return this.prisma.project.findMany({
       select: projectSelect,
     })
+  }
+
+  async getAutoSyncProjects(): Promise<ProjectWithDetails[]> {
+    return this.prisma.project.findMany({
+      select: projectSelect,
+      where: {
+        AND: [
+          {
+            plugins: {
+              some: {
+                pluginName: PLUGIN_NAME,
+                key: AUTO_SYNC_PLUGIN_KEY,
+                value: ENABLED,
+              },
+            },
+          },
+          {
+            NOT: {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: SUSPENDED_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+          },
+        ],
+      },
+    })
+  }
+
+  async getProject(id: string): Promise<ProjectWithDetails | null> {
+    return this.prisma.project.findUnique({ where: { id }, select: projectSelect })
+  }
+
+  async getAdminPluginConfig(pluginName: string, key: string): Promise<string | null> {
+    const result = await this.prisma.adminPlugin.findUnique({
+      where: { pluginName_key: { pluginName, key } },
+      select: { value: true },
+    })
+    return result?.value ?? null
   }
 }

--- a/apps/server-nestjs/src/modules/argocd/argocd-plugin.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd-plugin.service.ts
@@ -1,6 +1,8 @@
 import type { ServiceInfos } from '@cpn-console/hooks'
+import { DISABLED, ENABLED } from '@cpn-console/shared'
 import { Injectable } from '@nestjs/common'
 import {
+  AUTO_SYNC_PLUGIN_KEY,
   DEFAULT_DSO_ENV_CHART_VERSION,
   DEFAULT_DSO_NS_CHART_VERSION,
   DSO_ENV_CHART_VERSION_PLUGIN_KEY,
@@ -20,6 +22,7 @@ import {
   PROJECT_READONLY_GROUP_PATH_SUFFIX,
   PROJECT_READONLY_GROUP_PATH_SUFFIX_PLUGIN_KEY,
   PROJECT_SECURITY_GROUP_PATH_SUFFIX,
+  SUSPENDED_PLUGIN_KEY,
 } from './argocd.constants'
 
 @Injectable()
@@ -151,18 +154,44 @@ export class ArgoCDPluginService {
           description: 'Version du chart Helm dso-ns',
           placeholder: DEFAULT_DSO_NS_CHART_VERSION,
         }],
-        project: [{
-          key: 'extraRepositories',
-          kind: 'text',
-          permissions: {
-            admin: { read: true, write: true },
-            user: { read: true, write: false },
+        project: [
+          {
+            kind: 'switch',
+            key: SUSPENDED_PLUGIN_KEY,
+            initialValue: ENABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Suspendre le projet',
+            value: ENABLED,
+            description: 'Suspendre la synchronisation ArgoCD pour ce projet',
           },
-          title: 'Source repositories',
-          value: '',
-          description: extraRepositoriesDesc,
-          placeholder: 'https://github.com/',
-        }],
+          {
+            kind: 'switch',
+            key: AUTO_SYNC_PLUGIN_KEY,
+            initialValue: DISABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Synchronisation automatique ArgoCD',
+            value: DISABLED,
+            description: 'Synchroniser automatiquement le projet ArgoCD',
+          },
+          {
+            key: EXTRA_REPOSITORIES_PLUGIN_KEY,
+            kind: 'text',
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: false },
+            },
+            title: 'Source repositories',
+            value: '',
+            description: extraRepositoriesDesc,
+            placeholder: 'https://github.com/',
+          },
+        ],
       },
     } as const satisfies ServiceInfos
   }

--- a/apps/server-nestjs/src/modules/argocd/argocd.constants.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.constants.ts
@@ -28,3 +28,7 @@ export const PROJECT_DEVELOPER_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectDevelopper
 export const PROJECT_READONLY_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectReadonlyGroupPathSuffix'
 export const DSO_ENV_CHART_VERSION_PLUGIN_KEY = 'dsoEnvChartVersion'
 export const DSO_NS_CHART_VERSION_PLUGIN_KEY = 'dsoNsChartVersion'
+
+// Plugin synchronization flags (shared plugin config keys)
+export const AUTO_SYNC_PLUGIN_KEY = 'autoSync'
+export const SUSPENDED_PLUGIN_KEY = 'suspended'

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
@@ -121,7 +121,7 @@ describe('argoCDService', () => {
     })
 
     const infraProject = makeProjectSchema({ id: 100, http_url_to_repo: 'https://gitlab.internal/infra' })
-    datastore.getAllProjects.mockResolvedValue([mockProject])
+    datastore.getAutoSyncProjects.mockResolvedValue([mockProject])
     gitlab.getOrCreateInfraGroupRepo.mockResolvedValue(infraProject)
     gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
     gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
@@ -313,7 +313,7 @@ describe('argoCDService', () => {
     })
 
     const infraProject = makeProjectSchema({ id: 100, http_url_to_repo: 'https://gitlab.internal/infra' })
-    datastore.getAllProjects.mockResolvedValue([mockProject])
+    datastore.getAutoSyncProjects.mockResolvedValue([mockProject])
     gitlab.getOrCreateInfraGroupRepo.mockResolvedValue(infraProject)
     gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
     gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
@@ -364,7 +364,7 @@ describe('argoCDService', () => {
     })
 
     const infraProject = makeProjectSchema({ id: 100, http_url_to_repo: 'https://gitlab.internal/infra' })
-    datastore.getAllProjects.mockResolvedValue([mockProject])
+    datastore.getAutoSyncProjects.mockResolvedValue([mockProject])
     gitlab.getOrCreateInfraGroupRepo.mockResolvedValue(infraProject)
     gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
     gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
@@ -409,7 +409,7 @@ describe('argoCDService', () => {
     })
 
     const infraProject = makeProjectSchema({ id: 100, http_url_to_repo: 'https://gitlab.internal/infra' })
-    datastore.getAllProjects.mockResolvedValue([mockProject])
+    datastore.getAutoSyncProjects.mockResolvedValue([mockProject])
     gitlab.getOrCreateInfraGroupRepo.mockResolvedValue(infraProject)
     gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
     gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -5,6 +5,7 @@ import { createHmac } from 'node:crypto'
 import { generateNamespaceName, inClusterLabel } from '@cpn-console/shared'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { trace } from '@opentelemetry/api'
 import { stringify } from 'yaml'
 import { GitlabClientService } from '../gitlab/gitlab-client.service'
@@ -24,6 +25,7 @@ import {
   PROJECT_READONLY_GROUP_PATH_SUFFIX,
   PROJECT_SECURITY_GROUP_PATH_SUFFIX,
 } from './argocd.constants'
+import { isSuspended } from './argocd.utils'
 
 @Injectable()
 export class ArgoCDService {
@@ -45,6 +47,10 @@ export class ArgoCDService {
 
   @StartActiveSpan()
   private async syncProject(project: ProjectWithDetails) {
+    if (isSuspended(project)) {
+      this.logger.log(`Skipping ArgoCD sync for suspended project ${project.slug}`)
+      return
+    }
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -66,11 +72,11 @@ export class ArgoCDService {
     this.logger.log(`ArgoCD sync completed for project ${project.slug}`)
   }
 
-  // @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_HOUR)
   @StartActiveSpan()
   async handleCron() {
     this.logger.log('Starting ArgoCD reconciliation')
-    const projects = await this.argoCDDatastore.getAllProjects()
+    const projects = await this.argoCDDatastore.getAutoSyncProjects()
     const span = trace.getActiveSpan()
     span?.setAttribute('argocd.projects.count', projects.length)
     this.logger.log(`Loaded ${projects.length} projects for ArgoCD reconciliation`)

--- a/apps/server-nestjs/src/modules/argocd/argocd.utils.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.utils.ts
@@ -1,13 +1,6 @@
-import type { ProjectWithDetails } from './sonarqube-datastore.service'
+import type { ProjectWithDetails } from './argocd-datastore.service'
 import { ENABLED } from '@cpn-console/shared'
-import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './sonarqube.constants'
-
-export function sonarProjectPropertiesFile(projectKey: string) {
-  return [
-    `sonar.projectKey=${projectKey}`,
-    'sonar.qualitygate.wait=true',
-  ]
-}
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './argocd.constants'
 
 export function isSuspended(project: ProjectWithDetails): boolean {
   return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === SUSPENDED_PLUGIN_KEY && p.value === ENABLED) ?? false

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-datastore.service.ts
@@ -1,6 +1,8 @@
 import type { Prisma } from '@prisma/client'
+import { ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { PrismaService } from '../infrastructure/database/prisma.service'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './gitlab.constants'
 
 export const projectSelect = {
   id: true,
@@ -80,9 +82,39 @@ export class GitlabDatastoreService {
       where: {
         plugins: {
           some: {
-            pluginName: 'gitlab',
+            pluginName: PLUGIN_NAME,
           },
         },
+      },
+    })
+  }
+
+  async getAutoSyncProjects(): Promise<ProjectWithDetails[]> {
+    return this.prisma.project.findMany({
+      select: projectSelect,
+      where: {
+        AND: [
+          {
+            plugins: {
+              some: {
+                pluginName: PLUGIN_NAME,
+                key: AUTO_SYNC_PLUGIN_KEY,
+                value: ENABLED,
+              },
+            },
+          },
+          {
+            NOT: {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: SUSPENDED_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+          },
+        ],
       },
     })
   }

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-datastore.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-datastore.spec.ts
@@ -1,0 +1,215 @@
+import type { TestingModule } from '@nestjs/testing'
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { ENABLED } from '@cpn-console/shared'
+import { Test } from '@nestjs/testing'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { GitlabDatastoreService } from './gitlab-datastore.service'
+import { makeAdminPlugin, makeAdminRole, makeProject, makeUser } from './gitlab-testing.utils'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME } from './gitlab.constants'
+
+describe('gitlabDatastoreService', () => {
+  let module: TestingModule
+  let service: GitlabDatastoreService
+  let prisma: DeepMockProxy<PrismaService>
+
+  beforeEach(async () => {
+    prisma = mockDeep<PrismaService>()
+
+    module = await Test.createTestingModule({
+      providers: [
+        GitlabDatastoreService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile()
+
+    service = module.get(GitlabDatastoreService)
+  })
+
+  describe('getAllProjects', () => {
+    it('should return all projects with gitlab plugin', async () => {
+      const mockProject = makeProject({
+        id: 'project1',
+        name: 'Test Project',
+        slug: 'test-project',
+        description: 'Test',
+      })
+
+      prisma.project.findMany.mockResolvedValue([mockProject])
+
+      const result = await service.getAllProjects()
+
+      expect(prisma.project.findMany).toHaveBeenCalledWith({
+        select: expect.any(Object),
+        where: {
+          plugins: {
+            some: {
+              pluginName: PLUGIN_NAME,
+            },
+          },
+        },
+      })
+      expect(result).toEqual([mockProject])
+    })
+  })
+
+  describe('getAutoSyncProjects', () => {
+    it('should return projects with autoSync enabled and not suspended', async () => {
+      const mockProject = makeProject({
+        id: 'project1',
+        name: 'Test Project',
+        slug: 'test-project',
+        description: 'Test',
+      })
+
+      prisma.project.findMany.mockResolvedValue([mockProject])
+
+      const result = await service.getAutoSyncProjects()
+
+      expect(prisma.project.findMany).toHaveBeenCalledWith({
+        select: expect.any(Object),
+        where: {
+          AND: [
+            {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: AUTO_SYNC_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+            {
+              NOT: {
+                plugins: {
+                  some: {
+                    pluginName: PLUGIN_NAME,
+                    key: 'suspended',
+                    value: ENABLED,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      })
+      expect(result).toEqual([mockProject])
+    })
+
+    it('should return empty array when no projects match criteria', async () => {
+      prisma.project.findMany.mockResolvedValue([])
+
+      const result = await service.getAutoSyncProjects()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getProject', () => {
+    it('should return a project by id', async () => {
+      const mockProject = makeProject({
+        id: 'project1',
+        name: 'Test Project',
+        slug: 'test-project',
+        description: 'Test',
+      })
+
+      prisma.project.findUnique.mockResolvedValue(mockProject)
+
+      const result = await service.getProject('project1')
+
+      expect(prisma.project.findUnique).toHaveBeenCalledWith({
+        where: { id: 'project1' },
+        select: expect.any(Object),
+      })
+      expect(result).toEqual(mockProject)
+    })
+
+    it('should return null when project not found', async () => {
+      prisma.project.findUnique.mockResolvedValue(null)
+
+      const result = await service.getProject('nonexistent')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getAdminPluginConfig', () => {
+    it('should return admin plugin config value', async () => {
+      const config = makeAdminPlugin({ value: 'test-value' })
+      prisma.adminPlugin.findUnique.mockResolvedValue(config)
+
+      const result = await service.getAdminPluginConfig(PLUGIN_NAME, 'token')
+
+      expect(prisma.adminPlugin.findUnique).toHaveBeenCalledWith({
+        where: {
+          pluginName_key: {
+            pluginName: PLUGIN_NAME,
+            key: 'token',
+          },
+        },
+        select: {
+          value: true,
+        },
+      })
+      expect(result).toEqual('test-value')
+    })
+
+    it('should return null when config not found', async () => {
+      prisma.adminPlugin.findUnique.mockResolvedValue(null)
+
+      const result = await service.getAdminPluginConfig(PLUGIN_NAME, 'missing')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getAdminRolesByOidcGroups', () => {
+    it('should return admin roles for given oidc groups', async () => {
+      const roles = [
+        makeAdminRole({ id: 'role1', oidcGroup: 'group1' }),
+        makeAdminRole({ id: 'role2', oidcGroup: 'group2' }),
+      ]
+
+      prisma.adminRole.findMany.mockResolvedValue(roles)
+
+      const result = await service.getAdminRolesByOidcGroups(['group1', 'group2'])
+
+      expect(prisma.adminRole.findMany).toHaveBeenCalledWith({
+        where: {
+          oidcGroup: {
+            in: ['group1', 'group2'],
+          },
+        },
+        select: {
+          id: true,
+          oidcGroup: true,
+        },
+      })
+      expect(result).toEqual(roles)
+    })
+  })
+
+  describe('getUser', () => {
+    it('should return a user by id', async () => {
+      const user = makeUser({
+        id: 'user1',
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+      })
+
+      prisma.user.findUnique.mockResolvedValue(user)
+
+      const result = await service.getUser('user1')
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: 'user1',
+        },
+      })
+      expect(result).toEqual(user)
+    })
+  })
+})

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-plugin.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-plugin.service.ts
@@ -2,7 +2,16 @@ import type { ServiceInfos } from '@cpn-console/hooks'
 import { DISABLED, ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
-import { DEFAULT_ADMIN_GROUP_PATH, DEFAULT_AUDITOR_GROUP_PATH, DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX, DEFAULT_PROJECT_MAINTAINER_GROUP_PATH_SUFFIX, DEFAULT_PROJECT_REPORTER_GROUP_PATH_SUFFIX, PURGE_PLUGIN_KEY } from './gitlab.constants'
+import {
+  AUTO_SYNC_PLUGIN_KEY,
+  DEFAULT_ADMIN_GROUP_PATH,
+  DEFAULT_AUDITOR_GROUP_PATH,
+  DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX,
+  DEFAULT_PROJECT_MAINTAINER_GROUP_PATH_SUFFIX,
+  DEFAULT_PROJECT_REPORTER_GROUP_PATH_SUFFIX,
+  PURGE_PLUGIN_KEY,
+  SUSPENDED_PLUGIN_KEY,
+} from './gitlab.constants'
 
 @Injectable()
 export class GitlabPluginService {
@@ -108,7 +117,32 @@ export class GitlabPluginService {
             placeholder: DEFAULT_PROJECT_REPORTER_GROUP_PATH_SUFFIX,
           },
         ],
-        project: [],
+        project: [
+          {
+            kind: 'switch',
+            key: SUSPENDED_PLUGIN_KEY,
+            initialValue: ENABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Suspendre le projet',
+            value: ENABLED,
+            description: 'Suspendre la synchronisation GitLab pour ce projet',
+          },
+          {
+            kind: 'switch',
+            key: AUTO_SYNC_PLUGIN_KEY,
+            initialValue: DISABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Synchronisation automatique GitLab',
+            value: DISABLED,
+            description: 'Synchroniser automatiquement le projet GitLab',
+          },
+        ],
       },
     } as const satisfies ServiceInfos
   }

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
@@ -32,3 +32,7 @@ export const INFRA_GROUP_CUSTOM_ATTRIBUTE_KEY = 'cpn_infra_group'
 export const PROJECT_GROUP_CUSTOM_ATTRIBUTE_KEY = 'cpn_project_slug'
 export const USER_ID_CUSTOM_ATTRIBUTE_KEY = 'cpn_user_id'
 export const MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY = 'cpn_managed_by_console'
+
+// Plugin synchronization flags (shared plugin config keys)
+export const AUTO_SYNC_PLUGIN_KEY = 'autoSync'
+export const SUSPENDED_PLUGIN_KEY = 'suspended'

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
@@ -473,7 +473,7 @@ describe('gitlabService', () => {
   describe('handleCron', () => {
     it('should reconcile all projects', async () => {
       const projects = [makeProjectWithDetails({ id: 'p1', slug: 'project-1' })]
-      datastore.getAllProjects.mockResolvedValue(projects)
+      datastore.getAutoSyncProjects.mockResolvedValue(projects)
 
       const group = makeGroupSchema({ id: 123, name: 'project-1', path: 'project-1', full_path: 'forge/console/project-1', full_name: 'forge/console/project-1', parent_id: 1 })
       gitlab.getOrCreateProjectSubGroup.mockResolvedValue(group)
@@ -484,7 +484,7 @@ describe('gitlabService', () => {
 
       await service.handleCron()
 
-      expect(datastore.getAllProjects).toHaveBeenCalled()
+      expect(datastore.getAutoSyncProjects).toHaveBeenCalled()
       expect(gitlab.getOrCreateProjectSubGroup).toHaveBeenCalledWith('project-1')
     })
   })

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -6,6 +6,7 @@ import { specificallyEnabled } from '@cpn-console/hooks'
 import { AccessLevel } from '@gitbeaker/core'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { trace } from '@opentelemetry/api'
 import { getAll } from '../../utils/iterable'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
@@ -41,6 +42,7 @@ import {
   getProjectPluginConfig,
   isOwnedRepo,
   isOwnedUser,
+  isSuspended,
   isSystemRepo,
 } from './gitlab.utils'
 
@@ -66,6 +68,10 @@ export class GitlabService {
 
   @StartActiveSpan()
   private async syncProject(project: ProjectWithDetails) {
+    if (isSuspended(project)) {
+      this.logger.warn(`Skipping suspended GitLab reconciliation for ${project.slug}`)
+      return
+    }
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -87,13 +93,13 @@ export class GitlabService {
     this.logger.log(`GitLab sync completed for project ${project.slug}`)
   }
 
-  // @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_HOUR)
   @StartActiveSpan()
   async handleCron() {
     const span = trace.getActiveSpan()
     span?.setAttribute('gitlab.projects.count', 0)
     this.logger.log('Starting GitLab reconciliation')
-    const projects = await this.gitlabDatastore.getAllProjects()
+    const projects = await this.gitlabDatastore.getAutoSyncProjects()
     span?.setAttribute('gitlab.projects.count', projects.length)
     this.logger.log(`Loaded ${projects.length} projects for GitLab reconciliation`)
     await this.ensureProjectGroups(projects)

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
@@ -1,11 +1,20 @@
 import type { MemberSchema, ProjectSchema } from '@gitbeaker/core'
 import type { ProjectWithDetails } from './gitlab-datastore.service'
 import { createHash } from 'node:crypto'
+import { ENABLED } from '@cpn-console/shared'
 import { AccessLevel } from '@gitbeaker/core'
 import { stringify } from 'yaml'
-import { TOPIC_PLUGIN_MANAGED } from './gitlab.constants'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY, TOPIC_PLUGIN_MANAGED } from './gitlab.constants'
 
 export type ProjectAccessLevel = Exclude<AccessLevel, (typeof AccessLevel)['ADMIN']>
+
+export function isSuspended(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === SUSPENDED_PLUGIN_KEY && p.value === ENABLED) ?? false
+}
+
+export function isAutoSync(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === AUTO_SYNC_PLUGIN_KEY && p.value === ENABLED) ?? false
+}
 
 export function getExternalRepoHost(externalRepoUrl: string | null | undefined): string | undefined {
   if (!externalRepoUrl) return undefined

--- a/apps/server-nestjs/src/modules/infrastructure/configuration/configuration.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/configuration/configuration.service.ts
@@ -31,7 +31,7 @@ export class ConfigurationService {
   keycloakClientSecret = process.env.KEYCLOAK_CLIENT_SECRET
   keycloakAdmin = process.env.KEYCLOAK_ADMIN
   keycloakAdminPassword = process.env.KEYCLOAK_ADMIN_PASSWORD
-  keycloakAdminClientId = process.env.KEYCLOAK_ADMIN_CLIENT_ID
+  keycloakAdminClientId = process.env.KEYCLOAK_ADMIN_CLIENT_ID ?? 'admin-cli'
   keycloakRedirectUri = process.env.KEYCLOAK_REDIRECT_URI
 
   // JWKS cache TTL in ms (default 5 min); Keycloak rotates keys periodically

--- a/apps/server-nestjs/src/modules/infrastructure/pipe/zod-validation.pipe.spec.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/pipe/zod-validation.pipe.spec.ts
@@ -76,7 +76,7 @@ describe('zodValidationPipe', () => {
         expect(error).toBeInstanceOf(BadRequestException)
 
         if (error instanceof BadRequestException) {
-          const response = error.getResponse() as any
+          const response = error.getResponse() as { fieldErrors: Record<string, unknown[]> }
 
           expect(response).toHaveProperty('fieldErrors')
           expect(response.fieldErrors).toHaveProperty('name')

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-datastore.service.ts
@@ -1,6 +1,8 @@
 import type { Prisma } from '@prisma/client'
+import { ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { PrismaService } from '../infrastructure/database/prisma.service'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './keycloak.constants'
 
 export const projectSelect = {
   id: true,
@@ -71,6 +73,36 @@ export class KeycloakDatastoreService {
   async getAllProjects(): Promise<ProjectWithDetails[]> {
     return this.prisma.project.findMany({
       select: projectSelect,
+    })
+  }
+
+  async getAutoSyncProjects(): Promise<ProjectWithDetails[]> {
+    return this.prisma.project.findMany({
+      select: projectSelect,
+      where: {
+        AND: [
+          {
+            plugins: {
+              some: {
+                pluginName: PLUGIN_NAME,
+                key: AUTO_SYNC_PLUGIN_KEY,
+                value: ENABLED,
+              },
+            },
+          },
+          {
+            NOT: {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: SUSPENDED_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+          },
+        ],
+      },
     })
   }
 

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-datastore.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-datastore.spec.ts
@@ -1,0 +1,86 @@
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { ENABLED } from '@cpn-console/shared'
+import { Test } from '@nestjs/testing'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { KeycloakDatastoreService } from './keycloak-datastore.service'
+import { makeProject, makeProjectPlugin } from './keycloak-testing.utils'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME } from './keycloak.constants'
+
+describe('keycloakDatastoreService', () => {
+  let service: KeycloakDatastoreService
+  let prisma: DeepMockProxy<PrismaService>
+
+  beforeEach(async () => {
+    prisma = mockDeep<PrismaService>()
+
+    const module = await Test.createTestingModule({
+      providers: [KeycloakDatastoreService, { provide: PrismaService, useValue: prisma }],
+    }).compile()
+
+    service = module.get(KeycloakDatastoreService)
+  })
+
+  describe('getAutoSyncProjects', () => {
+    it('should return projects with autoSync enabled and not suspended', async () => {
+      const autoSyncPlugin = makeProjectPlugin({ pluginName: PLUGIN_NAME, key: AUTO_SYNC_PLUGIN_KEY, value: ENABLED })
+      const project1 = makeProject({ id: 'project-1', slug: 'project-1', plugins: [autoSyncPlugin] })
+      const project2 = makeProject({ id: 'project-2', slug: 'project-2', plugins: [autoSyncPlugin] })
+
+      prisma.project.findMany.mockResolvedValue([project1, project2])
+
+      const result = await service.getAutoSyncProjects()
+
+      expect(result).toHaveLength(2)
+      expect(result.map(p => p.id)).toEqual(['project-1', 'project-2'])
+      expect(prisma.project.findMany).toHaveBeenCalledWith({
+        select: expect.anything(),
+        where: {
+          AND: [
+            {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: AUTO_SYNC_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+            {
+              NOT: {
+                plugins: {
+                  some: {
+                    pluginName: PLUGIN_NAME,
+                    key: 'suspended',
+                    value: ENABLED,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      })
+    })
+
+    it('should return empty array when no projects match criteria', async () => {
+      prisma.project.findMany.mockResolvedValue([])
+
+      const result = await service.getAutoSyncProjects()
+
+      expect(result).toEqual([])
+    })
+
+    it('should exclude suspended projects and projects without autoSync', async () => {
+      const autoSyncPlugin = makeProjectPlugin({ pluginName: PLUGIN_NAME, key: AUTO_SYNC_PLUGIN_KEY, value: ENABLED })
+      const autoSyncProject = makeProject({ id: 'project-auto', slug: 'project-auto', plugins: [autoSyncPlugin] })
+
+      prisma.project.findMany.mockResolvedValue([autoSyncProject])
+
+      const result = await service.getAutoSyncProjects()
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('project-auto')
+    })
+  })
+})

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-testing.utils.ts
@@ -1,5 +1,6 @@
 import type GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation'
 import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation'
+import type { Project, ProjectPlugin } from '@prisma/client'
 import type { ProjectWithDetails } from './keycloak-datastore.service'
 
 import { faker } from '@faker-js/faker'
@@ -84,4 +85,41 @@ export function makeProjectWithDetails(
     environments: [],
     ...overrides,
   } satisfies ProjectWithDetails
+}
+
+export type ProjectWithPlugins = Project & { plugins: ProjectPlugin[] }
+
+export function makeProject(overrides: Partial<ProjectWithPlugins> = {}): ProjectWithPlugins {
+  return {
+    id: faker.string.uuid(),
+    name: faker.company.name(),
+    description: faker.lorem.sentence(),
+    status: 'created',
+    locked: false,
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    everyonePerms: 896n,
+    ownerId: faker.string.uuid(),
+    slug: faker.helpers.slugify(faker.company.name()),
+    limitless: true,
+    hprodCpu: 0,
+    hprodGpu: 0,
+    hprodMemory: 0,
+    prodCpu: 0,
+    prodGpu: 0,
+    prodMemory: 0,
+    lastSuccessProvisionningVersion: null,
+    plugins: [],
+    ...overrides,
+  }
+}
+
+export function makeProjectPlugin(overrides: Partial<ProjectPlugin> = {}): ProjectPlugin {
+  return {
+    pluginName: faker.helpers.slugify(faker.company.name()),
+    projectId: faker.string.uuid(),
+    key: 'enabled',
+    value: 'disabled',
+    ...overrides,
+  }
 }

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.constants.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.constants.ts
@@ -18,3 +18,7 @@ export const ADMIN_TOKEN_REFRESH_INTERVAL_MS = 45_000
 // Maximum number of entities returned in a paginated query
 export const GROUPS_PAGINATE_QUERY_MAX = 20
 export const SUBGROUPS_PAGINATE_QUERY_MAX = 20
+
+// Plugin synchronization flags (shared plugin config keys)
+export const AUTO_SYNC_PLUGIN_KEY = 'autoSync'
+export const SUSPENDED_PLUGIN_KEY = 'suspended'

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
@@ -32,6 +32,7 @@ describe('keycloakService', () => {
       deleteGroup: vi.fn().mockResolvedValue(undefined),
     })
     keycloakDatastore = mockDeep<KeycloakDatastoreService>({
+      getAutoSyncProjects: vi.fn().mockResolvedValue([]),
       getAllAdminRoles: vi.fn().mockResolvedValue([]),
       getAllUsersWithAdminRoleIds: vi.fn().mockResolvedValue([]),
     })
@@ -66,7 +67,7 @@ describe('keycloakService', () => {
       const users: UserWithAdminRoles[] = [
         { id: 'user-1', adminRoleIds: ['admin-role-id'] },
       ]
-      keycloakDatastore.getAllProjects.mockResolvedValue([])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([])
       keycloakDatastore.getAllAdminRoles.mockResolvedValue(adminRoles)
       keycloakDatastore.getAllUsersWithAdminRoleIds.mockResolvedValue(users)
 
@@ -86,7 +87,7 @@ describe('keycloakService', () => {
         { id: 'user-1', adminRoleIds: ['admin-role-id'] },
         { id: 'user-2', adminRoleIds: [] },
       ]
-      keycloakDatastore.getAllProjects.mockResolvedValue([])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([])
       keycloakDatastore.getAllAdminRoles.mockResolvedValue(adminRoles)
       keycloakDatastore.getAllUsersWithAdminRoleIds.mockResolvedValue(users)
 
@@ -105,7 +106,7 @@ describe('keycloakService', () => {
     })
 
     it('should purge orphans', async () => {
-      keycloakDatastore.getAllProjects.mockResolvedValue([mockProject])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([mockProject])
 
       const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project', subGroups: [] })
       const orphanGroup = makeGroupRepresentation({
@@ -124,7 +125,7 @@ describe('keycloakService', () => {
       keycloak.getSubGroups.mockImplementation(async function* () { /* empty */ })
       await service.handleCron()
 
-      expect(keycloakDatastore.getAllProjects).toHaveBeenCalled()
+      expect(keycloakDatastore.getAutoSyncProjects).toHaveBeenCalled()
       expect(keycloak.getAllGroups).toHaveBeenCalled()
       expect(keycloak.getOrCreateGroupByPath).toHaveBeenCalledWith('/test-project')
       expect(keycloak.deleteGroup).toHaveBeenCalledWith('orphan-id')
@@ -140,7 +141,7 @@ describe('keycloakService', () => {
           }),
         ],
       })
-      keycloakDatastore.getAllProjects.mockResolvedValue([projectWithMembers])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([projectWithMembers])
 
       const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
       keycloak.getOrCreateGroupByPath.mockResolvedValue(projectGroup)
@@ -180,7 +181,7 @@ describe('keycloakService', () => {
         ],
         roles: [roleWithOidc],
       })
-      keycloakDatastore.getAllProjects.mockResolvedValue([projectWithRole])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([projectWithRole])
 
       const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
       const consoleGroup = { id: 'console-id', name: 'console' }
@@ -218,7 +219,7 @@ describe('keycloakService', () => {
         ...mockProject,
         environments: [makeProjectEnvironment({ id: 'env-1', name: 'dev' })],
       })
-      keycloakDatastore.getAllProjects.mockResolvedValue([projectWithEnv])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([projectWithEnv])
 
       const projectGroup = makeGroupRepresentation({
         id: 'group-id',
@@ -242,10 +243,15 @@ describe('keycloakService', () => {
         return Promise.resolve(makeGroupRepresentation({ id: 'new-id', name }))
       })
 
-      // Mock existing environments: 'staging' (extra)
+      // Mock existing environments: 'staging' (extra) and 'dev' (owned)
       keycloak.getSubGroups.mockImplementation(async function* (parentId) {
         if (parentId === 'console-id') {
+          yield makeGroupRepresentation({ id: 'dev-id', name: 'dev' })
           yield makeGroupRepresentation({ id: 'staging-id', name: 'staging' })
+        }
+        if (parentId === 'dev-id') {
+          yield makeGroupRepresentation({ name: 'RO' })
+          yield makeGroupRepresentation({ name: 'RW' })
         }
         if (parentId === 'staging-id') {
           yield makeGroupRepresentation({ name: 'RO' })
@@ -290,7 +296,7 @@ describe('keycloakService', () => {
         ],
         environments: [makeProjectEnvironment({ id: 'env-1', name: 'dev' })],
       })
-      keycloakDatastore.getAllProjects.mockResolvedValue([projectWithEnvAndMembers])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([projectWithEnvAndMembers])
 
       const projectGroup = makeGroupRepresentation({
         id: 'group-id',
@@ -349,7 +355,7 @@ describe('keycloakService', () => {
         ],
         roles: [roleManaged, roleExternal, roleGlobal],
       })
-      keycloakDatastore.getAllProjects.mockResolvedValue([projectWithRoles])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([projectWithRoles])
 
       const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
       const consoleGroup = { id: 'console-id', name: 'console' }
@@ -416,7 +422,7 @@ describe('keycloakService', () => {
         ],
         roles: [roleSystemManaged],
       })
-      keycloakDatastore.getAllProjects.mockResolvedValue([projectWithRoles])
+      keycloakDatastore.getAutoSyncProjects.mockResolvedValue([projectWithRoles])
 
       const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
       const consoleGroup = { id: 'console-id', name: 'console' }

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
@@ -5,6 +5,7 @@ import type { GroupRepresentationWith } from './keycloak.utils'
 import { getBaseRoleType, getPermsByUserRoles, isExternalRoleType, ProjectAuthorized, resourceListToDict } from '@cpn-console/shared'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { trace } from '@opentelemetry/api'
 import z from 'zod'
 import { getErrorResponseStatus } from '../../utils/http-error'
@@ -12,7 +13,7 @@ import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator
 import { capturePluginResult } from '../plugin/plugin.utils'
 import { KeycloakClientService } from './keycloak-client.service'
 import { KeycloakDatastoreService } from './keycloak-datastore.service'
-import { isMember, isNonEmptyGroupPath, isOwnedProjectGroup, normalizeGroupPath } from './keycloak.utils'
+import { isMember, isNonEmptyGroupPath, isOwnedProjectGroup, isSuspended, normalizeGroupPath } from './keycloak.utils'
 
 @Injectable()
 export class KeycloakService {
@@ -32,6 +33,10 @@ export class KeycloakService {
 
   @StartActiveSpan()
   private async syncProject(project: ProjectWithDetails) {
+    if (isSuspended(project)) {
+      this.logger.log(`Skipping Keycloak sync for suspended project ${project.slug}`)
+      return
+    }
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -53,13 +58,13 @@ export class KeycloakService {
     this.logger.log(`Keycloak cleanup completed for project ${project.slug}`)
   }
 
-  // @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_HOUR)
   @StartActiveSpan()
   async handleCron() {
     const span = trace.getActiveSpan()
     this.logger.log('Starting periodic Keycloak reconciliation')
     const [projects, adminRoles, users] = await Promise.all([
-      this.keycloakDatastore.getAllProjects(),
+      this.keycloakDatastore.getAutoSyncProjects(),
       this.keycloakDatastore.getAllAdminRoles(),
       this.keycloakDatastore.getAllUsersWithAdminRoleIds(),
     ])

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.utils.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.utils.ts
@@ -1,10 +1,15 @@
 import type GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation'
 import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation'
 import type { ProjectWithDetails } from './keycloak-datastore.service'
-import { CONSOLE_GROUP_NAME } from './keycloak.constants'
+import { ENABLED } from '@cpn-console/shared'
+import { CONSOLE_GROUP_NAME, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './keycloak.constants'
 
 type With<T, K extends keyof T> = T & Required<Pick<T, K>>
 export type GroupRepresentationWith<T extends keyof GroupRepresentation> = With<GroupRepresentation, T>
+
+export function isSuspended(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === SUSPENDED_PLUGIN_KEY && p.value === ENABLED) ?? false
+}
 
 export function isMember(project: ProjectWithDetails, member: UserRepresentation): boolean {
   return project.members.some(m => m.user.id === member.id) || project.ownerId === member.id

--- a/apps/server-nestjs/src/modules/nexus/nexus-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus-datastore.service.ts
@@ -1,7 +1,8 @@
 import type { Prisma } from '@prisma/client'
+import { ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { PrismaService } from '../infrastructure/database/prisma.service'
-import { PLUGIN_NAME } from './nexus.constants'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './nexus.constants'
 
 export const projectSelect = {
   slug: true,
@@ -32,34 +33,47 @@ export class NexusDatastoreService {
   async getAllProjects(): Promise<ProjectWithDetails[]> {
     return this.prisma.project.findMany({
       select: projectSelect,
+    })
+  }
+
+  async getAutoSyncProjects(): Promise<ProjectWithDetails[]> {
+    return this.prisma.project.findMany({
+      select: projectSelect,
       where: {
-        plugins: {
-          some: {
-            pluginName: PLUGIN_NAME,
+        AND: [
+          {
+            plugins: {
+              some: {
+                pluginName: PLUGIN_NAME,
+                key: AUTO_SYNC_PLUGIN_KEY,
+                value: ENABLED,
+              },
+            },
           },
-        },
+          {
+            NOT: {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: SUSPENDED_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+          },
+        ],
       },
     })
   }
 
   async getProject(id: string): Promise<ProjectWithDetails | null> {
-    return this.prisma.project.findUnique({
-      where: { id },
-      select: projectSelect,
-    })
+    return this.prisma.project.findUnique({ where: { id }, select: projectSelect })
   }
 
   async getAdminPluginConfig(pluginName: string, key: string): Promise<string | null> {
     const result = await this.prisma.adminPlugin.findUnique({
-      where: {
-        pluginName_key: {
-          pluginName,
-          key,
-        },
-      },
-      select: {
-        value: true,
-      },
+      where: { pluginName_key: { pluginName, key } },
+      select: { value: true },
     })
     return result?.value ?? null
   }

--- a/apps/server-nestjs/src/modules/nexus/nexus-plugin.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus-plugin.service.ts
@@ -2,6 +2,7 @@ import type { ServiceInfos } from '@cpn-console/hooks'
 import { DISABLED, ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
+import { AUTO_SYNC_PLUGIN_KEY, SUSPENDED_PLUGIN_KEY } from './nexus.constants'
 
 @Injectable()
 export class NexusPluginService {
@@ -23,16 +24,40 @@ export class NexusPluginService {
       config: {
         project: [
           {
+            kind: 'switch',
+            key: SUSPENDED_PLUGIN_KEY,
+            initialValue: ENABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Suspendre le projet',
+            value: ENABLED,
+            description: 'Suspendre la synchronisation Nexus pour ce projet',
+          },
+          {
+            kind: 'switch',
+            key: AUTO_SYNC_PLUGIN_KEY,
+            initialValue: DISABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Synchronisation automatique Nexus',
+            value: DISABLED,
+            description: 'Synchroniser automatiquement le projet Nexus',
+          },
+          {
             key: 'activateNpmRepo',
             section: 'NPM',
             kind: 'switch',
-            initialValue: 'disabled',
+            initialValue: DISABLED,
             permissions: {
               admin: { read: true, write: true },
               user: { read: true, write: true },
             },
             title: 'Activer le dépôt NPM',
-            value: 'disabled',
+            value: DISABLED,
             description: 'Default: utilise le paramétrage globale de la console. Attention: Nexus met un certain temps pour activer/désactiver les dépôts, un reprovisonnage après plusieurs minutes peut être nécessaire',
           },
           {

--- a/apps/server-nestjs/src/modules/nexus/nexus.constants.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.constants.ts
@@ -30,3 +30,7 @@ export const PLATFORM_READ_GROUP_PATHS_PLUGIN_KEY = 'platformReadGroupPaths'
 // Plugin configuration keys for project-level group path suffixes
 export const PROJECT_WRITE_GROUP_PATH_SUFFIXES_PLUGIN_KEY = 'projectWriteGroupPathSuffixes'
 export const PROJECT_READ_GROUP_PATH_SUFFIXES_PLUGIN_KEY = 'projectReadGroupPathSuffixes'
+
+// Plugin synchronization flags (shared plugin config keys)
+export const AUTO_SYNC_PLUGIN_KEY = 'autoSync'
+export const SUSPENDED_PLUGIN_KEY = 'suspended'

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.spec.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.spec.ts
@@ -100,7 +100,7 @@ describe('nexusService', () => {
       makeProjectWithDetails({ plugins: [{ pluginName: PLUGIN_NAME, key: NEXUS_CONFIG_KEY_ACTIVATE_NPM_REPO, value: ENABLED }] }),
     ]
 
-    datastore.getAllProjects.mockResolvedValue(projects)
+    datastore.getAutoSyncProjects.mockResolvedValue(projects)
 
     await service.handleCron()
 

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.ts
@@ -7,6 +7,7 @@ import type {
 import { specificallyEnabled } from '@cpn-console/hooks'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
@@ -40,6 +41,7 @@ import {
   generateRandomPassword,
   getPluginConfig,
   getProjectVaultPath,
+  isSuspended,
 } from './nexus.utils'
 
 export interface EnsureMavenReposOptions {
@@ -67,6 +69,10 @@ export class NexusService {
 
   @StartActiveSpan()
   private async syncProject(project: ProjectWithDetails) {
+    if (isSuspended(project)) {
+      this.logger.log(`Skipping ArgoCD sync for suspended project ${project.slug}`)
+      return
+    }
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling project upsert for ${project.slug}`)
@@ -90,12 +96,12 @@ export class NexusService {
     await this.ensurePlatformRoles(projects)
   }
 
-  // @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_HOUR)
   @StartActiveSpan()
   async handleCron() {
     const span = trace.getActiveSpan()
     this.logger.log('Starting Nexus reconciliation')
-    const projects = await this.nexusDatastore.getAllProjects()
+    const projects = await this.nexusDatastore.getAutoSyncProjects()
     span?.setAttribute('nexus.projects.count', projects.length)
     await this.ensureProjects(projects)
     await this.ensurePlatformRoles(projects)

--- a/apps/server-nestjs/src/modules/nexus/nexus.utils.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.utils.ts
@@ -1,8 +1,18 @@
 import type { ProjectWithDetails } from './nexus-datastore.service'
 import { randomBytes } from 'node:crypto'
+import { ENABLED } from '@cpn-console/shared'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './nexus.constants'
 
 export function getPluginConfig(project: ProjectWithDetails, key: string) {
   return project.plugins?.find(p => p.key === key)?.value
+}
+
+export function isSuspended(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === SUSPENDED_PLUGIN_KEY && p.value === ENABLED) ?? false
+}
+
+export function isAutoSync(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === AUTO_SYNC_PLUGIN_KEY && p.value === ENABLED) ?? false
 }
 
 export function generateRandomPassword(length: number) {

--- a/apps/server-nestjs/src/modules/registry/registry-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-datastore.service.ts
@@ -1,14 +1,12 @@
 import type { Prisma } from '@prisma/client'
+import { ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { PrismaService } from '../infrastructure/database/prisma.service'
-import { PLUGIN_NAME } from './registry.constants'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './registry.constants'
 
 export const projectSelect = {
   slug: true,
   plugins: {
-    where: {
-      pluginName: PLUGIN_NAME,
-    },
     select: {
       pluginName: true,
       key: true,
@@ -26,36 +24,49 @@ export class RegistryDatastoreService {
   constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   async getAllProjects(): Promise<ProjectWithDetails[]> {
-    return await this.prisma.project.findMany({
+    return this.prisma.project.findMany({
+      select: projectSelect,
+    })
+  }
+
+  async getAutoSyncProjects(): Promise<ProjectWithDetails[]> {
+    return this.prisma.project.findMany({
       select: projectSelect,
       where: {
-        plugins: {
-          some: {
-            pluginName: PLUGIN_NAME,
+        AND: [
+          {
+            plugins: {
+              some: {
+                pluginName: PLUGIN_NAME,
+                key: AUTO_SYNC_PLUGIN_KEY,
+                value: ENABLED,
+              },
+            },
           },
-        },
+          {
+            NOT: {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: SUSPENDED_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+          },
+        ],
       },
     })
   }
 
   async getProject(id: string): Promise<ProjectWithDetails | null> {
-    return await this.prisma.project.findUnique({
-      where: { id },
-      select: projectSelect,
-    })
+    return this.prisma.project.findUnique({ where: { id }, select: projectSelect })
   }
 
   async getAdminPluginConfig(pluginName: string, key: string): Promise<string | null> {
     const result = await this.prisma.adminPlugin.findUnique({
-      where: {
-        pluginName_key: {
-          pluginName,
-          key,
-        },
-      },
-      select: {
-        value: true,
-      },
+      where: { pluginName_key: { pluginName, key } },
+      select: { value: true },
     })
     return result?.value ?? null
   }

--- a/apps/server-nestjs/src/modules/registry/registry-plugin.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-plugin.service.ts
@@ -1,11 +1,12 @@
 import type { ServiceInfos } from '@cpn-console/hooks'
 import type { Cache } from 'cache-manager'
-import { DISABLED } from '@cpn-console/shared'
+import { DISABLED, ENABLED } from '@cpn-console/shared'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { RegistryClientService } from './registry-client.service'
 import { RegistryDatastoreService } from './registry-datastore.service'
+import { AUTO_SYNC_PLUGIN_KEY, SUSPENDED_PLUGIN_KEY } from './registry.constants'
 import { createProjectSlugCacheKey } from './registry.utils'
 
 @Injectable()
@@ -82,38 +83,66 @@ export class RegistryPluginService {
       imgSrc: '/img/harbor.svg',
       description: 'Harbor stocke, analyse et distribue vos images de conteneurs',
       config: {
-        project: [{
-          permissions: {
-            admin: { read: false, write: false },
-            user: { read: false, write: false },
+        project: [
+          {
+            kind: 'switch',
+            key: SUSPENDED_PLUGIN_KEY,
+            initialValue: ENABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Suspendre le projet',
+            value: ENABLED,
+            description: 'Suspendre la synchronisation Harbor pour ce projet',
           },
-          key: 'projectId',
-          kind: 'text',
-          title: 'Num du projet Harbor',
-          value: '',
-        }, {
-          kind: 'switch',
-          key: 'publishProjectRobot',
-          initialValue: DISABLED,
-          title: 'Publication du robot projet',
-          description: 'Activer le robot de projet (read-only) et afficher ses identifiants aux utilisateurs',
-          permissions: {
-            admin: { read: true, write: true },
-            user: { read: true, write: false },
+          {
+            kind: 'switch',
+            key: AUTO_SYNC_PLUGIN_KEY,
+            initialValue: DISABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Synchronisation automatique Harbor',
+            value: DISABLED,
+            description: 'Synchroniser automatiquement le projet Harbor',
           },
-          value: DISABLED,
-        }, {
-          kind: 'text',
-          permissions: {
-            admin: { read: true, write: true },
-            user: { read: true, write: false },
+          {
+            permissions: {
+              admin: { read: false, write: false },
+              user: { read: false, write: false },
+            },
+            key: 'projectId',
+            kind: 'text',
+            title: 'Num du projet Harbor',
+            value: '',
           },
-          key: 'quotaHardLimit',
-          title: 'Quota',
-          value: '',
-          description: `Stockage limite (vide utilisation du paramètre global, ${quotaDescription}`,
-          placeholder: '',
-        }],
+          {
+            kind: 'switch',
+            key: 'publishProjectRobot',
+            initialValue: DISABLED,
+            title: 'Publication du robot projet',
+            description: 'Activer le robot de projet (read-only) et afficher ses identifiants aux utilisateurs',
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: false },
+            },
+            value: DISABLED,
+          },
+          {
+            kind: 'text',
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: false },
+            },
+            key: 'quotaHardLimit',
+            title: 'Quota',
+            value: '',
+            description: `Stockage limite (vide utilisation du paramètre global, ${quotaDescription}`,
+            placeholder: '',
+          },
+        ],
         global: [{
           kind: 'switch',
           key: 'publishProjectRobot',

--- a/apps/server-nestjs/src/modules/registry/registry.constants.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.constants.ts
@@ -45,3 +45,7 @@ export const HARBOR_ROLE_DEVELOPER = 2
 export const HARBOR_ROLE_GUEST = 3
 export const HARBOR_ROLE_MAINTAINER = 4
 export const HARBOR_ROLE_LIMITED_GUEST = 5
+
+// Plugin synchronization flags (shared plugin config keys)
+export const AUTO_SYNC_PLUGIN_KEY = 'autoSync'
+export const SUSPENDED_PLUGIN_KEY = 'suspended'

--- a/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
@@ -276,7 +276,7 @@ describe('registryService', () => {
 
   describe('handleCron', () => {
     it('should reconcile all projects', async () => {
-      datastore.getAllProjects.mockResolvedValue([
+      datastore.getAutoSyncProjects.mockResolvedValue([
         makeProjectWithDetails({ slug: 'project-1' }),
         makeProjectWithDetails({ slug: 'project-2' }),
       ])

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -13,6 +13,7 @@ import type { RuleTemplate, VaultRobotSecret } from './registry.utils'
 import { specificallyEnabled } from '@cpn-console/hooks'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
@@ -46,7 +47,7 @@ import {
   ROBOT_NAME_RO,
   ROBOT_NAME_RW,
 } from './registry.constants'
-import { generateVaultRobotSecret, getHostFromUrl, getProjectVaultPath, parseBytes } from './registry.utils'
+import { generateVaultRobotSecret, getHostFromUrl, getProjectVaultPath, isSuspended, parseBytes } from './registry.utils'
 
 @Injectable()
 export class RegistryService {
@@ -316,6 +317,10 @@ export class RegistryService {
 
   @StartActiveSpan()
   private async syncProject(project: ProjectWithDetails) {
+    if (isSuspended(project)) {
+      this.logger.log(`Skipping ArgoCD sync for suspended project ${project.slug}`)
+      return
+    }
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling project upsert for ${project.slug}`)
@@ -340,12 +345,12 @@ export class RegistryService {
     await this.deleteProject(project.slug)
   }
 
-  // @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_HOUR)
   @StartActiveSpan()
   async handleCron() {
     const span = trace.getActiveSpan()
     this.logger.log('Starting Registry reconciliation')
-    const projects = await this.registryDatastore.getAllProjects()
+    const projects = await this.registryDatastore.getAutoSyncProjects()
     span?.setAttribute('registry.projects.count', projects.length)
     await Promise.all(projects.map(p => this.ensureProject(p)))
   }

--- a/apps/server-nestjs/src/modules/registry/registry.utils.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.utils.ts
@@ -1,11 +1,20 @@
 import type { ProjectWithDetails } from './registry-datastore.service'
 import type { ALLOWED_RETENTION_RULE_TEMPLATES } from './registry.constants'
-import { removeTrailingSlash } from '@cpn-console/shared'
+import { ENABLED, removeTrailingSlash } from '@cpn-console/shared'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './registry.constants'
 
 export type RuleTemplate = typeof ALLOWED_RETENTION_RULE_TEMPLATES[number]
 
 export function createProjectSlugCacheKey(projectId: string) {
   return `registry:project-slug:${projectId}`
+}
+
+export function isSuspended(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === SUSPENDED_PLUGIN_KEY && p.value === ENABLED) ?? false
+}
+
+export function isAutoSync(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === AUTO_SYNC_PLUGIN_KEY && p.value === ENABLED) ?? false
 }
 
 const protocolPrefixRegex = /^https?:\/\//u

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube-datastore.service.ts
@@ -1,7 +1,8 @@
 import type { Prisma } from '@prisma/client'
+import { ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { PrismaService } from '../infrastructure/database/prisma.service'
-import { PLUGIN_NAME } from './sonarqube.constants'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './sonarqube.constants'
 
 export const projectSelect = {
   id: true,
@@ -31,21 +32,41 @@ export class SonarqubeDatastoreService {
   async getAllProjects(): Promise<ProjectWithDetails[]> {
     return this.prisma.project.findMany({
       select: projectSelect,
+    })
+  }
+
+  async getAutoSyncProjects(): Promise<ProjectWithDetails[]> {
+    return this.prisma.project.findMany({
+      select: projectSelect,
       where: {
-        plugins: {
-          some: {
-            pluginName: PLUGIN_NAME,
+        AND: [
+          {
+            plugins: {
+              some: {
+                pluginName: PLUGIN_NAME,
+                key: AUTO_SYNC_PLUGIN_KEY,
+                value: ENABLED,
+              },
+            },
           },
-        },
+          {
+            NOT: {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: SUSPENDED_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+          },
+        ],
       },
     })
   }
 
   async getProject(id: string): Promise<ProjectWithDetails | null> {
-    return this.prisma.project.findUnique({
-      where: { id },
-      select: projectSelect,
-    })
+    return this.prisma.project.findUnique({ where: { id }, select: projectSelect })
   }
 
   async getAdminPluginConfig(

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube-plugin.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube-plugin.service.ts
@@ -1,6 +1,8 @@
 import type { ServiceInfos } from '@cpn-console/hooks'
+import { DISABLED, ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
+import { AUTO_SYNC_PLUGIN_KEY, SUSPENDED_PLUGIN_KEY } from './sonarqube.constants'
 
 @Injectable()
 export class SonarqubePluginService {
@@ -19,6 +21,35 @@ export class SonarqubePluginService {
       title: 'SonarQube',
       imgSrc: '/img/sonarqube.svg',
       description: 'SonarQube permet à tous les développeurs d\'écrire un code plus propre et plus sûr',
+      config: {
+        global: [],
+        project: [
+          {
+            kind: 'switch',
+            key: SUSPENDED_PLUGIN_KEY,
+            initialValue: ENABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Suspendre le projet',
+            value: ENABLED,
+            description: 'Suspendre la synchronisation SonarQube pour ce projet',
+          },
+          {
+            kind: 'switch',
+            key: AUTO_SYNC_PLUGIN_KEY,
+            initialValue: DISABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Synchronisation automatique SonarQube',
+            value: DISABLED,
+            description: 'Synchroniser automatiquement le projet SonarQube',
+          },
+        ],
+      },
     }
   }
 }

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.constants.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.constants.ts
@@ -49,3 +49,7 @@ export const SONARQUBE_PROJECT_QUALIFIER_PROJECT = 'TRK'
 export const SONARQUBE_PROJECT_QUALIFIER_SUB_VIEW = 'SVW'
 export const SONARQUBE_PROJECT_QUALIFIER_UNIT_TEST = 'UTS'
 export const SONARQUBE_PROJECT_QUALIFIER_VIEW = 'VW'
+
+// Plugin synchronization flags (shared plugin config keys)
+export const AUTO_SYNC_PLUGIN_KEY = 'autoSync'
+export const SUSPENDED_PLUGIN_KEY = 'suspended'

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
@@ -288,7 +288,7 @@ describe('sonarqubeService', () => {
         makeProjectWithDetails({ repositories: [] }),
         makeProjectWithDetails({ repositories: [] }),
       ]
-      datastore.getAllProjects.mockResolvedValue(projects)
+      datastore.getAutoSyncProjects.mockResolvedValue(projects)
       client.generateUserToken.mockImplementation(({ login }) => Promise.resolve(makeUserToken({ login })))
 
       await service.handleCron()

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
@@ -5,6 +5,7 @@ import type { SonarqubeProjectResult, SonarqubeUser } from './sonarqube-client.s
 import type { ProjectWithDetails } from './sonarqube-datastore.service'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { trace } from '@opentelemetry/api'
 import { generateProjectKey, generateRandomPassword } from '../../utils/crypto'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
@@ -41,6 +42,7 @@ import {
   ROBOT_PROJECT_PERMISSIONS,
   SECURITY_GROUP_PATH_PLUGIN_KEY,
 } from './sonarqube.constants'
+import { isSuspended } from './sonarqube.utils'
 
 interface SonarqubeRolePaths {
   admin: string[]
@@ -95,6 +97,10 @@ export class SonarqubeService implements OnModuleInit {
 
   @StartActiveSpan()
   private async syncProject(project: ProjectWithDetails) {
+    if (isSuspended(project)) {
+      this.logger.log(`Skipping ArgoCD sync for suspended project ${project.slug}`)
+      return
+    }
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -116,13 +122,13 @@ export class SonarqubeService implements OnModuleInit {
     this.logger.log(`SonarQube deletion completed for project ${project.slug}`)
   }
 
-  // @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_HOUR)
   @StartActiveSpan()
   async handleCron() {
     const span = trace.getActiveSpan()
     this.logger.log('Starting SonarQube reconciliation')
     await this.init().catch(error => this.logger.error('SonarQube init during cron failed', error))
-    const projects = await this.datastore.getAllProjects()
+    const projects = await this.datastore.getAutoSyncProjects()
     span?.setAttribute('sonarqube.projects.count', projects.length)
     this.logger.log(`Loaded ${projects.length} projects for SonarQube reconciliation`)
     await this.ensureProjectGroups(projects)

--- a/apps/server-nestjs/src/modules/vault/vault-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault-datastore.service.ts
@@ -1,6 +1,8 @@
 import type { Prisma } from '@prisma/client'
+import { ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { PrismaService } from '../infrastructure/database/prisma.service'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './vault.constants'
 
 export const projectSelect = {
   id: true,
@@ -51,6 +53,36 @@ export type ZoneWithDetails = Prisma.ZoneGetPayload<{
 export class VaultDatastoreService {
   constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
+  async getAutoSyncProjects(): Promise<ProjectWithDetails[]> {
+    return this.prisma.project.findMany({
+      select: projectSelect,
+      where: {
+        AND: [
+          {
+            plugins: {
+              some: {
+                pluginName: PLUGIN_NAME,
+                key: AUTO_SYNC_PLUGIN_KEY,
+                value: ENABLED,
+              },
+            },
+          },
+          {
+            NOT: {
+              plugins: {
+                some: {
+                  pluginName: PLUGIN_NAME,
+                  key: SUSPENDED_PLUGIN_KEY,
+                  value: ENABLED,
+                },
+              },
+            },
+          },
+        ],
+      },
+    })
+  }
+
   async getAllProjects(): Promise<ProjectWithDetails[]> {
     return this.prisma.project.findMany({
       select: projectSelect,
@@ -78,6 +110,46 @@ export class VaultDatastoreService {
 
   async getAllZones(): Promise<ZoneWithDetails[]> {
     return this.prisma.zone.findMany({
+      select: zoneSelect,
+    })
+  }
+
+  async getAutoSyncZones(): Promise<ZoneWithDetails[]> {
+    return this.prisma.zone.findMany({
+      where: {
+        clusters: {
+          some: {
+            environments: {
+              some: {
+                project: {
+                  AND: [
+                    {
+                      plugins: {
+                        some: {
+                          pluginName: PLUGIN_NAME,
+                          key: AUTO_SYNC_PLUGIN_KEY,
+                          value: ENABLED,
+                        },
+                      },
+                    },
+                    {
+                      NOT: {
+                        plugins: {
+                          some: {
+                            pluginName: PLUGIN_NAME,
+                            key: SUSPENDED_PLUGIN_KEY,
+                            value: ENABLED,
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
       select: zoneSelect,
     })
   }

--- a/apps/server-nestjs/src/modules/vault/vault-plugin.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault-plugin.service.ts
@@ -1,6 +1,8 @@
 import type { ServiceInfos } from '@cpn-console/hooks'
+import { DISABLED, ENABLED } from '@cpn-console/shared'
 import { Inject, Injectable } from '@nestjs/common'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
+import { AUTO_SYNC_PLUGIN_KEY, SUSPENDED_PLUGIN_KEY } from './vault.constants'
 
 @Injectable()
 export class VaultPluginService {
@@ -19,6 +21,35 @@ export class VaultPluginService {
       title: 'Vault',
       imgSrc: '/img/vault.svg',
       description: 'Vault s\'intègre profondément avec les identités de confiance pour automatiser l\'accès aux secrets, aux données et aux systèmes',
+      config: {
+        global: [],
+        project: [
+          {
+            kind: 'switch',
+            key: SUSPENDED_PLUGIN_KEY,
+            initialValue: ENABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Suspendre le projet',
+            value: ENABLED,
+            description: 'Suspendre la synchronisation Vault pour ce projet',
+          },
+          {
+            kind: 'switch',
+            key: AUTO_SYNC_PLUGIN_KEY,
+            initialValue: DISABLED,
+            permissions: {
+              admin: { read: true, write: true },
+              user: { read: true, write: true },
+            },
+            title: 'Synchronisation automatique Vault',
+            value: DISABLED,
+            description: 'Synchroniser automatiquement le projet Vault',
+          },
+        ],
+      },
     }
   }
 }

--- a/apps/server-nestjs/src/modules/vault/vault.constants.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.constants.ts
@@ -32,3 +32,7 @@ export const PROJECT_DEVELOPER_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectDeveloperG
 export const PROJECT_DEVOPS_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectDevopsGroupPathSuffix'
 export const PROJECT_MAINTAINER_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectMaintainerGroupPathSuffix'
 export const PROJECT_SECURITY_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectSecurityGroupPathSuffix'
+
+// Plugin synchronization flags (shared plugin config keys)
+export const AUTO_SYNC_PLUGIN_KEY = 'autoSync'
+export const SUSPENDED_PLUGIN_KEY = 'suspended'

--- a/apps/server-nestjs/src/modules/vault/vault.service.spec.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.service.spec.ts
@@ -61,13 +61,13 @@ describe('vaultService', () => {
     const projects = faker.helpers.multiple(() => makeProjectWithDetails())
     const zones = faker.helpers.multiple(() => makeZoneWithDetails())
 
-    datastore.getAllProjects.mockResolvedValue(projects)
-    datastore.getAllZones.mockResolvedValue(zones)
+    datastore.getAutoSyncProjects.mockResolvedValue(projects)
+    datastore.getAutoSyncZones.mockResolvedValue(zones)
 
     await service.handleCron()
 
-    expect(datastore.getAllProjects).toHaveBeenCalled()
-    expect(datastore.getAllZones).toHaveBeenCalled()
+    expect(datastore.getAutoSyncProjects).toHaveBeenCalled()
+    expect(datastore.getAutoSyncZones).toHaveBeenCalled()
     expect(client.createSysMount).toHaveBeenCalledTimes(projects.length + zones.length)
     projects.forEach((project) => {
       expect(client.createSysMount).toHaveBeenCalledWith(project.slug, expect.any(Object))

--- a/apps/server-nestjs/src/modules/vault/vault.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.service.ts
@@ -2,6 +2,7 @@ import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { ProjectWithDetails, ZoneWithDetails } from './vault-datastore.service'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { trace } from '@opentelemetry/api'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
@@ -34,7 +35,7 @@ import {
   PROJECT_SECURITY_GROUP_PATH_SUFFIX_PLUGIN_KEY,
   SECURITY_GROUP_PATH_PLUGIN_KEY,
 } from './vault.constants'
-import { generateProjectPath } from './vault.utils'
+import { generateProjectPath, isSuspended } from './vault.utils'
 
 type ProjectScope = 'admin' | 'devops' | 'developer' | 'readonly' | 'security'
 
@@ -57,6 +58,10 @@ export class VaultService {
 
   @StartActiveSpan()
   private async syncProject(project: ProjectWithDetails) {
+    if (isSuspended(project)) {
+      this.logger.log(`Skipping ArgoCD sync for suspended project ${project.slug}`)
+      return
+    }
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project upsert event for ${project.slug}`)
@@ -109,16 +114,15 @@ export class VaultService {
     this.logger.log(`Vault zone cleanup completed for ${zone.slug}`)
   }
 
-  // @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_HOUR)
   @StartActiveSpan()
   async handleCron() {
     const span = trace.getActiveSpan()
     this.logger.log('Starting Vault reconciliation')
     const [projects, zones] = await Promise.all([
-      this.vaultDatastore.getAllProjects(),
-      this.vaultDatastore.getAllZones(),
+      this.vaultDatastore.getAutoSyncProjects(),
+      this.vaultDatastore.getAutoSyncZones(),
     ])
-
     span?.setAttributes({
       'vault.projects.count': projects.length,
       'vault.zones.count': zones.length,

--- a/apps/server-nestjs/src/modules/vault/vault.utils.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.utils.ts
@@ -1,3 +1,15 @@
+import type { ProjectWithDetails } from './vault-datastore.service'
+import { ENABLED } from '@cpn-console/shared'
+import { AUTO_SYNC_PLUGIN_KEY, PLUGIN_NAME, SUSPENDED_PLUGIN_KEY } from './vault.constants'
+
+export function isSuspended(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === SUSPENDED_PLUGIN_KEY && p.value === ENABLED) ?? false
+}
+
+export function isAutoSync(project: ProjectWithDetails): boolean {
+  return project.plugins?.some(p => p.pluginName === PLUGIN_NAME && p.key === AUTO_SYNC_PLUGIN_KEY && p.value === ENABLED) ?? false
+}
+
 export function generateProjectPath(projectRootDir: string | undefined, projectSlug: string) {
   return projectRootDir
     ? `${projectRootDir}/${projectSlug}`


### PR DESCRIPTION
## Issues liées

#2315
#2314

## Quel est le comportement actuel ?

Avant cette PR, la synchronisation des projets par les plugins (ArgoCD, GitLab, Vault, Keycloak, Nexus, SonarQube, Harbor) était soit globale, soit déclenchée uniquement par les modifications apportées dans la Console. Les projets ne disposaient d'aucune option permettant de contrôler finement la synchronisation projet par projet.

## Quel est le nouveau comportement ?

Cette PR introduit les options `autoSync` (désactivée par défaut) et `suspended` (activée par défaut) au niveau projet pour l'ensemble des 7 plugins. Elle réactive les tâches planifiées horaires (`@Cron(CronExpression.EVERY_HOUR)`) qui ne ciblent désormais que les projets `autoSync=enabled` ET `suspended!=enabled` via la méthode `getAutoSyncProjects()`.

Comportement de synchronisation :
- `syncProject()` vérifie désormais `isSuspended()` et ignore le projet si vrai (avec journalisation d'avertissement).
- Les tâches planifiées utilisent `getAutoSyncProjects()` à la place de `getAllProjects()`.

Nouveaux utilitaires :
- `isSuspended(project)` — indique si le projet a l'option `suspended` activée.
- `isAutoSync(project)` — indique si le projet a l'option `autoSync` activée.

Couche données :
- `getAutoSyncProjects()` — filtre les projets avec `autoSync=enabled` ET `suspended!=enabled`.

Configuration des plugins :
- Centralisation des clés de configuration dans des constantes `*_PLUGIN_KEY` (`PLUGIN_NAME`, `AUTO_SYNC_PLUGIN_KEY`, `SUSPENDED_PLUGIN_KEY`) pour les 7 plugins.
- Ajout des interrupteurs `suspended` et `autoSync` au niveau projet pour ArgoCD, GitLab, Vault, Keycloak, Nexus, SonarQube et Harbor.
