### PR TITLE
fix(server-nestjs): silence successful healthz request logs

### DIFF
--- a/apps/server-nestjs/src/modules/infrastructure/logger/logger.module.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/logger/logger.module.ts
@@ -12,7 +12,22 @@ import { ConfigurationService } from '../configuration/configuration.service'
       inject: [ConfigurationService],
       useFactory: async (configService: ConfigurationService) => {
         return {
-          pinoHttp: getLoggerOptions(configService.isProd ? 'production' : 'development', configService.isTest ? 'info' : 'debug'),
+          pinoHttp: {
+            ...getLoggerOptions(configService.isProd ? 'production' : 'development', configService.isTest ? 'info' : 'debug'),
+            customLogLevel: (req, res, err) => {
+              if (err || res.statusCode >= 500) {
+                return 'error'
+              }
+              if (res.statusCode >= 400) {
+                return 'warn'
+              }
+              // kube liveness/readiness probes hit healthz constantly, only log it on failure
+              if (req.url?.split('?')[0] === '/api/v1/healthz') {
+                return 'silent'
+              }
+              return 'info'
+            },
+          },
         }
       },
     }),


### PR DESCRIPTION
## Issues liées

Issues numéro: N/A

---------

## Quel est le comportement actuel ?

Chaque requête sur `/api/v1/healthz` génère une ligne de log au niveau `info`. Or les probes Kubernetes interrogent cet endpoint en continu : la liveness probe toutes les 30 s (~2 880 requêtes/jour) et la readiness probe toutes les 10 s (~8 640 requêtes/jour), soit environ 11 500 lignes de log inutiles par pod et par jour, ce qui pollue les logs et complique leur lecture.

Par ailleurs, toutes les requêtes HTTP étaient loguées au niveau `info`, y compris celles en erreur (4xx/5xx).

## Quel est le nouveau comportement ?

Ajout d'une fonction `customLogLevel` dans la configuration `pinoHttp` du `LoggerModule` :

- Les requêtes réussies sur `/api/v1/healthz` ne sont plus loguées (`silent`).
- Les échecs restent visibles : niveau `error` en cas d'exception ou de réponse 5xx, niveau `warn` pour les 4xx — on garde donc le signal utile quand le healthcheck échoue réellement.
- Pour toutes les autres routes, les réponses 4xx sont désormais loguées en `warn` et les 5xx en `error` au lieu d'un niveau `info` uniforme.

L'approche `customLogLevel` a été préférée à `autoLogging.ignore`, qui aurait également masqué les échecs du healthcheck.

## Cette PR introduit-elle un breaking change ?

Non. Seul le niveau de log des requêtes HTTP change, aucune API n'est impactée.

## Autres informations

Exemple de log supprimé :

<img width="1476" height="796" alt="Screenshot 2026-07-10 at 12 38 00" src="https://github.com/user-attachments/assets/2f30ff1f-e88b-4f21-8059-b6165ea4305f" />

