### PR TITLE
fix(server-nestjs/nexus): fall back to public Nexus URL when internal URL is unset

### DIFF
--- a/apps/server-nestjs/src/modules/nexus/nexus-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus-client.service.spec.ts
@@ -29,6 +29,7 @@ describe('nexusClientService', () => {
       nexusAdmin: 'admin',
       nexusAdminPassword,
       projectRootDir: 'forge',
+      getInternalOrPublicNexusUrl: () => nexusUrl,
     })
 
     const module = await Test.createTestingModule({

--- a/apps/server-nestjs/src/modules/nexus/nexus-http-client.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus-http-client.service.ts
@@ -76,10 +76,11 @@ export class NexusHttpClientService {
   }
 
   private get baseUrl() {
-    if (!this.config.nexusInternalUrl) {
-      throw new NexusError('NotConfigured', 'NEXUS_INTERNAL_URL is required')
+    const url = this.config.getInternalOrPublicNexusUrl()
+    if (!url) {
+      throw new NexusError('NotConfigured', 'NEXUS_INTERNAL_URL or NEXUS_URL is required')
     }
-    return this.config.nexusInternalUrl
+    return url
   }
 
   private get apiBaseUrl() {


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

Le `NexusHttpClientService` exige que la variable d'environnement `NEXUS_INTERNAL_URL` soit définie. Si elle est absente, une `NexusError` (`NotConfigured`) est levée immédiatement, même lorsqu'une URL publique Nexus (`NEXUS_URL`) est disponible et pourrait être utilisée.

## Quel est le nouveau comportement ?

Le getter `baseUrl` utilise désormais `config.getInternalOrPublicNexusUrl()` : il privilégie l'URL interne (`NEXUS_INTERNAL_URL`) et se rabat sur l'URL publique (`NEXUS_URL`) si l'URL interne n'est pas définie. L'erreur `NotConfigured` n'est levée que si aucune des deux URLs n'est configurée, avec un message mis à jour (`NEXUS_INTERNAL_URL or NEXUS_URL is required`).

## Cette PR introduit-elle un breaking change ?

Non. Les déploiements existants avec `NEXUS_INTERNAL_URL` définie conservent le même comportement. Le changement rend simplement la configuration plus permissive pour les environnements où seule `NEXUS_URL` est définie.

## Autres informations

Aucune.
