### PR TITLE
fix(server-nestjs/keycloak): resolve base role type for system-prefixed roles

### DIFF
--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
@@ -424,5 +424,48 @@ describe('keycloakService', () => {
       // Global: should sync group but no members
       expect(keycloak.getOrCreateRoleGroup).toHaveBeenCalledWith(consoleGroup, '/global-group')
     })
+
+    it('should treat system-prefixed role types as their base type', async () => {
+      const roleSystemManaged = makeProjectRole({ id: 'role-system-managed', permissions: 0n, oidcGroup: '/system-managed-group', type: 'system:managed' })
+
+      const projectWithRoles = makeProjectWithDetails({
+        ...mockProject,
+        members: [
+          makeProjectMember({
+            user: makeProjectUser({ id: 'user-1', email: 'user1@example.com' }),
+            roleIds: ['role-system-managed'],
+          }),
+        ],
+        roles: [roleSystemManaged],
+      })
+      keycloakDatastore.getAllProjects.mockResolvedValue([projectWithRoles])
+
+      const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
+      const consoleGroup = { id: 'console-id', name: 'console' }
+      const systemManagedGroup = makeGroupRepresentation({ id: 'system-managed-id', name: 'system-managed-group' })
+
+      keycloak.getOrCreateGroupByPath.mockImplementation((path) => {
+        if (path === '/test-project') return Promise.resolve(projectGroup)
+        return Promise.resolve({})
+      })
+      keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
+      keycloak.getOrCreateRoleGroup.mockResolvedValue({ ...systemManagedGroup, path: '/console/system-managed-group' })
+
+      keycloak.getGroupMembers.mockImplementation((groupId) => {
+        if (groupId === 'group-id') return Promise.resolve([makeUserRepresentation({ id: 'owner-id' })])
+        // has extra user-2, missing user-1
+        if (groupId === 'system-managed-id') return Promise.resolve([makeUserRepresentation({ id: 'user-2' })])
+        return Promise.resolve([])
+      })
+
+      keycloak.getSubGroups.mockImplementation(async function* () { /* empty */ })
+
+      await service.handleCron()
+
+      // system:managed behaves like managed: add user-1, remove user-2
+      expect(keycloak.getOrCreateRoleGroup).toHaveBeenCalledWith(consoleGroup, '/system-managed-group')
+      expect(keycloak.addUserToGroup).toHaveBeenCalledWith('user-1', 'system-managed-id')
+      expect(keycloak.removeUserFromGroup).toHaveBeenCalledWith('user-2', 'system-managed-id')
+    })
   })
 })

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
@@ -2,7 +2,7 @@ import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/us
 import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { AdminRoleWithDetails, ProjectWithDetails, UserWithAdminRoles } from './keycloak-datastore.service'
 import type { GroupRepresentationWith } from './keycloak.utils'
-import { getPermsByUserRoles, isExternalRoleType, ProjectAuthorized, resourceListToDict } from '@cpn-console/shared'
+import { getBaseRoleType, getPermsByUserRoles, isExternalRoleType, ProjectAuthorized, resourceListToDict } from '@cpn-console/shared'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
@@ -223,9 +223,10 @@ export class KeycloakService {
       await this.keycloak.addUserToGroup(userId, groupId)
       this.logger.log(`Added user to Keycloak group: userId=${userId} groupId=${groupId} groupName=${groupName}`)
     } catch (e) {
-      if (e.response?.status === 404) {
+      const status = getErrorResponseStatus(e)
+      if (status === 404) {
         this.logger.warn(`User not found in Keycloak, skipping addition: userId=${userId} groupId=${groupId} groupName=${groupName}`)
-      } else if (e.response?.status === 409) {
+      } else if (status === 409) {
         this.logger.verbose(`User already a member of Keycloak group: userId=${userId} groupId=${groupId} groupName=${groupName}`)
       } else {
         throw e
@@ -238,7 +239,7 @@ export class KeycloakService {
       await this.keycloak.removeUserFromGroup(userId, groupId)
       this.logger.log(`Removed user from Keycloak group: userId=${userId} groupId=${groupId} groupName=${groupName}`)
     } catch (e) {
-      if (e.response?.status === 404) {
+      if (getErrorResponseStatus(e) === 404) {
         this.logger.warn(`User not found in Keycloak, skipping removal: userId=${userId} groupId=${groupId} groupName=${groupName}`)
       } else {
         throw e
@@ -323,7 +324,7 @@ export class KeycloakService {
     const groupMembers = await this.keycloak.getGroupMembers(roleGroup.id)
     span?.setAttribute('keycloak.group.members.current', groupMembers.length)
 
-    switch (role.type) {
+    switch (getBaseRoleType(role.type)) {
       case 'managed':
         await Promise.all([
           this.ensureRoleGroupMembers(project, role, roleGroup, groupMembers),
@@ -645,6 +646,14 @@ export class KeycloakService {
       rw: ProjectAuthorized.ManageEnvironments({ adminPermissions: 0n, projectPermissions }),
     }
   }
+}
+
+/** HTTP status carried by errors such as keycloak-admin-client's NetworkError. */
+function getErrorResponseStatus(error: unknown): number | undefined {
+  if (error instanceof Error && 'response' in error && error.response instanceof Response) {
+    return error.response.status
+  }
+  return undefined
 }
 
 async function* map<T, U>(


### PR DESCRIPTION
## Issues liées

Issues numéro: N/A

---------

## Quel est le comportement actuel ?

La réconciliation Keycloak échoue pour tous les rôles système des projets. Depuis la migration `20260330122500`, les rôles système ont le type `system:managed`, mais `ensureRoleGroup` (`keycloak.service.ts`) fait un `switch` sur le type brut et ne connaît que `managed`, `external` et `global`. Chaque rôle système tombe donc dans la branche `default` et lève `Error: Unknown role type system:managed`, ce qui fait échouer la synchronisation des groupes (événement `project.upsert` et cron de réconciliation).

Par ailleurs, les blocs `catch` de `maybeAddUserToGroup` / `maybeRemoveUserFromGroup` accédaient à `e.response?.status` sans narrowing (`e` est `unknown`), ce qui provoquait une erreur TypeScript TS18046.

## Quel est le nouveau comportement ?

- `ensureRoleGroup` résout désormais le type de base via `getBaseRoleType()` (utilitaire existant de `@cpn-console/shared`) : `system:managed` est traité comme `managed` (synchronisation des membres + purge des membres orphelins), et il en va de même pour tout futur type préfixé `system:`.
- Ajout d'un helper `getErrorResponseStatus()` qui extrait le statut HTTP des erreurs portant une `Response` (forme du `NetworkError` de keycloak-admin-client), avec un narrowing correct. Le comportement reste identique : 404 ignoré avec un warn, 409 à l'ajout traité comme « déjà membre », toute autre erreur relancée.
- Ajout d'un test vérifiant qu'un rôle `system:managed` se comporte comme un rôle `managed` (ajout des membres manquants, retrait des orphelins).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Bug découvert lors du debug de la réconciliation Keycloak : l'erreur était masquée en amont par le message générique « Network response was not OK. » du client admin Keycloak.

