### PR TITLE
fix(server-nestjs/events): update project status after events

### DIFF
--- a/apps/server-nestjs/src/modules/events/app-events.service.spec.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.service.spec.ts
@@ -5,6 +5,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter'
 import { Test } from '@nestjs/testing'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { LogService } from '../log/log.service'
 import { projectSelect } from '../project/project-queries.utils'
@@ -17,11 +18,14 @@ describe('appEventsService', () => {
   let prisma: DeepMockProxy<PrismaService>
   let eventEmitter: DeepMockProxy<EventEmitter2Type>
   let logs: DeepMockProxy<LogService>
+  let config: DeepMockProxy<ConfigurationService>
 
   beforeEach(async () => {
     prisma = mockDeep<PrismaService>()
     eventEmitter = mockDeep<EventEmitter2>({ emitAsync: vi.fn().mockResolvedValue([]) })
     logs = mockDeep<LogService>()
+    config = mockDeep<ConfigurationService>()
+    config.appVersion = 'test-version'
 
     module = await Test.createTestingModule({
       providers: [
@@ -29,6 +33,7 @@ describe('appEventsService', () => {
         { provide: PrismaService, useValue: prisma },
         { provide: EventEmitter2, useValue: eventEmitter },
         { provide: LogService, useValue: logs },
+        { provide: ConfigurationService, useValue: config },
       ],
     }).compile()
 
@@ -86,6 +91,45 @@ describe('appEventsService', () => {
         messageResume: 'Errors:\nargocd: Sync failed;',
       },
     })
+  })
+
+  it('marks the project as failed when a listener reports a KO result', async () => {
+    const project = makeProject()
+    eventEmitter.emitAsync.mockResolvedValue([
+      { argocd: { status: 'KO', message: 'Sync failed', executionTime: 20, error: new Error('Sync failed') } },
+    ])
+
+    await service.emitProjectEvent('project.upsert', project, { action: 'Update Project' })
+
+    expect(prisma.project.update).toHaveBeenCalledWith({
+      where: { id: project.id },
+      data: { status: 'failed' },
+    })
+  })
+
+  it('marks the project as created with the provisioning version after a successful upsert', async () => {
+    const project = makeProject()
+    eventEmitter.emitAsync.mockResolvedValue([
+      { gitlab: { status: 'OK', message: 'Up to date', executionTime: 10 } },
+    ])
+
+    await service.emitProjectEvent('project.upsert', project, { action: 'Create Project' })
+
+    expect(prisma.project.update).toHaveBeenCalledWith({
+      where: { id: project.id },
+      data: { status: 'created', lastSuccessProvisionningVersion: 'test-version' },
+    })
+  })
+
+  it('does not touch the project status after a successful delete', async () => {
+    const project = makeProject()
+    eventEmitter.emitAsync.mockResolvedValue([
+      { gitlab: { status: 'OK', message: 'Up to date', executionTime: 10 } },
+    ])
+
+    await service.emitProjectEvent('project.delete', project, { action: 'Delete all project resources' })
+
+    expect(prisma.project.update).not.toHaveBeenCalled()
   })
 
   it('uses a provided project snapshot without fetching it again', async () => {

--- a/apps/server-nestjs/src/modules/events/app-events.service.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.service.ts
@@ -2,9 +2,10 @@ import type { PluginResults } from '../plugin/plugin.utils'
 import type { ProjectWithDetails } from '../project/project-queries.utils'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { EventEmitter2 } from '@nestjs/event-emitter'
+import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { LogService } from '../log/log.service'
-import { mergePluginResults } from '../plugin/plugin.utils'
+import { getFailedPlugins, mergePluginResults } from '../plugin/plugin.utils'
 import { getProject } from '../project/project-queries.utils'
 import { formatEventLogData, isPluginResults } from './app-events.utils'
 
@@ -44,6 +45,7 @@ export class AppEventsService {
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
     @Inject(LogService) private readonly logs: LogService,
+    @Inject(ConfigurationService) private readonly config: ConfigurationService,
   ) {}
 
   /**
@@ -68,7 +70,9 @@ export class AppEventsService {
       return {}
     }
 
-    return this.emitAndLog(event, project, project.id, context)
+    const results = await this.emitAndLog(event, project, project.id, context)
+    await this.updateProjectStatus(event, project.id, results)
+    return results
   }
 
   async emitProjectMemberEvent(
@@ -101,5 +105,32 @@ export class AppEventsService {
     })
 
     return results
+  }
+
+  /**
+   * Reflects the listeners' outcome on the project row (legacy hooks behavior):
+   * any KO result marks the project `failed`; a fully successful upsert marks it
+   * `created` and records the provisioning version. A successful `project.delete`
+   * leaves the `archived` status set when the project was archived.
+   */
+  private async updateProjectStatus(
+    event: ProjectEventName,
+    projectId: string,
+    results: PluginResults,
+  ): Promise<void> {
+    const failed = getFailedPlugins(results)
+
+    if (failed.length) {
+      this.logger.warn(`${event} marked project as failed (projectId=${projectId}, failed=${failed.join(',')})`)
+      await this.prisma.project.update({ where: { id: projectId }, data: { status: 'failed' } })
+      return
+    }
+
+    if (event === 'project.upsert') {
+      await this.prisma.project.update({
+        where: { id: projectId },
+        data: { status: 'created', lastSuccessProvisionningVersion: this.config.appVersion },
+      })
+    }
   }
 }

--- a/apps/server-nestjs/src/modules/events/app-events.utils.spec.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.utils.spec.ts
@@ -1,4 +1,5 @@
 import type { PluginResults } from '../plugin/plugin.utils'
+import { NetworkError } from '@keycloak/keycloak-admin-client'
 import { describe, expect, it } from 'vitest'
 import { formatEventLogData, isPluginResults, serializeError } from './app-events.utils'
 
@@ -22,6 +23,22 @@ describe('serializeError', () => {
   it('should serialize an Error with name, message and stack', () => {
     const parsed = JSON.parse(serializeError(new Error('boom')))
     expect(parsed).toEqual({ name: 'Error', message: 'boom', stack: expect.any(String) })
+  })
+
+  it('should include HTTP details from errors carrying a fetch Response', () => {
+    const error = new NetworkError('Network response was not OK.', {
+      response: new Response('conflict', { status: 409 }),
+      responseData: { errorMessage: 'Sibling group named \'admin\' already exists.' },
+    })
+    const parsed = JSON.parse(serializeError(error))
+    expect(parsed).toEqual({
+      name: 'Error',
+      message: 'Network response was not OK.',
+      status: 409,
+      url: expect.any(String),
+      responseData: { errorMessage: 'Sibling group named \'admin\' already exists.' },
+      stack: expect.any(String),
+    })
   })
 
   it('should serialize non-Error values', () => {
@@ -58,21 +75,19 @@ describe('formatEventLogData', () => {
     })
   })
 
-  it('should produce an empty failed list and a success resume when everything is OK', () => {
+  it('should omit the failed list and produce a success resume when everything is OK', () => {
     const results: PluginResults = {
       gitlab: { status: 'OK', message: 'Up to date', executionTime: 10 },
     }
 
-    expect(formatEventLogData(args, results, 10)).toEqual(expect.objectContaining({
-      failed: [],
-      messageResume: 'Success',
-    }))
+    const data = formatEventLogData(args, results, 10)
+    expect(data).not.toHaveProperty('failed')
+    expect(data.messageResume).toBe('Success')
   })
 
   it('should handle events without any listener', () => {
     expect(formatEventLogData(args, {}, 1)).toEqual({
       args,
-      failed: [],
       results: {},
       totalExecutionTime: 1,
       messageResume: 'Success',

--- a/apps/server-nestjs/src/modules/events/app-events.utils.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.utils.ts
@@ -69,7 +69,7 @@ export function formatEventLogData(args: unknown, results: PluginResults, totalE
 
   return {
     args,
-    failed,
+    ...(failed.length ? { failed } : {}),
     results: Object.fromEntries(entries.map(([service, result]) => [service, toLoggableResult(result)])),
     totalExecutionTime: Math.round(totalExecutionTime),
     messageResume: buildMessageResume(results, failed),


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

- Le statut du projet n'était jamais mis à jour après l'exécution des listeners d'événements : un projet restait en `initializing` après une création réussie, et un échec des services n'était pas reflété à l'utilisateur.
- Les logs d'événements (`AppEventsService`) persistent toujours un tableau `failed: []`, même quand tous les listeners ont réussi. Côté client, `LogsViewer.vue` teste la truthiness de `log.data?.failed` — or un tableau vide est truthy en JavaScript, donc les événements en succès s'affichaient avec le badge et la bordure d'erreur au lieu du style succès.
<img width="1499" height="559" alt="Screenshot 2026-07-10 at 20 16 11" src="https://github.com/user-attachments/assets/7588e73b-dde0-4957-912a-86eff1fd4b90" />

## Quel est le nouveau comportement ?

- `formatEventLogData` omet la clé `failed` quand aucun service n'a échoué : un événement en succès est maintenant loggé `{ args, results, totalExecutionTime, messageResume: "Success" }` et s'affiche correctement en vert dans le `LogsViewer`.
- `AppEventsService` met à jour le statut du projet après chaque événement projet, en reprenant le comportement legacy de `manageProjectStatus` (hook-wrapper) :
  - au moins un résultat KO → statut `failed` (pour `project.upsert` comme `project.delete`) + warning loggé avec les services en échec ;
  - `project.upsert` entièrement réussi → statut `created` + mise à jour de `lastSuccessProvisionningVersion` (utilisé par le filtre « outdated ») ;
  - `project.delete` réussi → statut inchangé (`archived` est déjà posé par la transaction d'archivage).
- Les événements membres (`projectMember.*`) ne touchent pas au statut, comme en legacy.

## Cette PR introduit-elle un breaking change ?

Non. La clé `failed` était déjà optionnelle dans le schéma des logs (`LogData` / LogSchema) et le client gère déjà son absence.

## Autres informations

- Injection de `ConfigurationService` dans `AppEventsService` pour récupérer `appVersion` (déjà exporté par `InfrastructureModule`, pas de changement de wiring).
- Tests mis à jour/ajoutés : omission de `failed` dans `app-events.utils.spec.ts`, et 3 cas de mise à jour de statut (échec, upsert réussi, delete réussi) dans `app-events.service.spec.ts`.
