### PR TITLE
fix(server-nestjs/keycloak): tolerate concurrent subgroup creation conflicts

### DIFF
--- a/apps/server-nestjs/src/modules/events/app-events.utils.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.utils.ts
@@ -1,5 +1,6 @@
 import type { LogData } from '../log/log.service'
 import type { PluginName, PluginResult, PluginResults } from '../plugin/plugin.utils'
+import { getErrorHttpDetails } from '../../utils/http-error'
 import { getFailedPlugins } from '../plugin/plugin.utils'
 
 /** Per-service result as persisted in the admin logs (legacy hooks format, parsed by LogSchema). */
@@ -30,7 +31,12 @@ export function isPluginResults(response: unknown): response is PluginResults {
 
 export function serializeError(error: unknown): string {
   if (error instanceof Error) {
-    return JSON.stringify({ name: error.name, message: error.message, stack: error.stack })
+    return JSON.stringify({
+      name: error.name,
+      message: error.message,
+      ...getErrorHttpDetails(error),
+      stack: error.stack,
+    })
   }
   try {
     return JSON.stringify(error)

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
@@ -1,0 +1,181 @@
+import KcAdminClient from '@keycloak/keycloak-admin-client'
+import { Test } from '@nestjs/testing'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
+import { KEYCLOAK_ADMIN_CLIENT, KeycloakClientService } from './keycloak-client.service'
+
+const keycloakUrl = 'https://keycloak.internal'
+const projectRealm = 'project-realm'
+const tokenUrl = `${keycloakUrl}/realms/master/protocol/openid-connect/token`
+const childrenUrl = `${keycloakUrl}/admin/realms/${projectRealm}/groups/:parentId/children`
+
+const server = setupServer()
+
+function useTokenEndpoint() {
+  server.use(
+    http.post(tokenUrl, () =>
+      HttpResponse.json({ access_token: 'access-token', refresh_token: 'refresh-token', expires_in: 300 })),
+  )
+}
+
+function createKeycloakClientServiceTestingModule(config: Partial<ConfigurationService> = {}) {
+  return Test.createTestingModule({
+    providers: [
+      KeycloakClientService,
+      { provide: KEYCLOAK_ADMIN_CLIENT, useValue: new KcAdminClient({ baseUrl: keycloakUrl }) },
+      {
+        provide: ConfigurationService,
+        useValue: mockDeep<ConfigurationService>({
+          keycloakRealm: projectRealm,
+          keycloakAdmin: 'admin',
+          keycloakAdminPassword: 'admin-password',
+          ...config,
+        }),
+      },
+    ],
+  })
+}
+
+describe('keycloakClientService authentication lifecycle', () => {
+  let service: KeycloakClientService
+  let client: KcAdminClient
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  beforeEach(async () => {
+    const module = await createKeycloakClientServiceTestingModule().compile()
+    service = module.get(KeycloakClientService)
+    client = module.get(KEYCLOAK_ADMIN_CLIENT)
+  })
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('should authenticate with the password grant then switch to the project realm', async () => {
+    server.use(
+      http.post(tokenUrl, async ({ request }) => {
+        const body = new URLSearchParams(await request.text())
+        expect(body.get('grant_type')).toBe('password')
+        expect(body.get('client_id')).toBe('admin-cli')
+        expect(body.get('username')).toBe('admin')
+        expect(body.get('password')).toBe('admin-password')
+        return HttpResponse.json({ access_token: 'access-token', refresh_token: 'refresh-token', expires_in: 300 })
+      }),
+    )
+
+    await service.onModuleInit()
+
+    expect(client.accessToken).toBe('access-token')
+    expect(client.realmName).toBe(projectRealm)
+  })
+
+  it('should rethrow when the initial authentication fails', async () => {
+    server.use(
+      http.post(tokenUrl, () =>
+        HttpResponse.json({ error: 'invalid_grant' }, { status: 401 })),
+    )
+
+    await expect(service.onModuleInit()).rejects.toThrow('Network response was not OK.')
+    expect(client.realmName).toBe('master')
+  })
+
+  it('should not authenticate when the Keycloak realm is not configured', async () => {
+    const module = await createKeycloakClientServiceTestingModule({ keycloakRealm: undefined }).compile()
+    const serviceWithoutRealm = module.get(KeycloakClientService)
+
+    // No token endpoint handler: any authentication attempt would fail the test
+    await expect(serviceWithoutRealm.onModuleInit()).resolves.toBeUndefined()
+  })
+
+  it('should not authenticate when the admin credentials are not configured', async () => {
+    const module = await createKeycloakClientServiceTestingModule({ keycloakAdminPassword: undefined }).compile()
+    const serviceWithoutCredentials = module.get(KeycloakClientService)
+
+    await expect(serviceWithoutCredentials.onModuleInit()).resolves.toBeUndefined()
+  })
+})
+
+describe('getOrCreateSubGroupByName', () => {
+  let service: KeycloakClientService
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  beforeEach(async () => {
+    const module = await createKeycloakClientServiceTestingModule().compile()
+    service = module.get(KeycloakClientService)
+    useTokenEndpoint()
+    await service.onModuleInit()
+  })
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('should return the existing subgroup without creating it', async () => {
+    // No POST handler: a create attempt would fail the test
+    server.use(
+      http.get(childrenUrl, ({ params }) => {
+        expect(params.parentId).toBe('parent-id')
+        return HttpResponse.json([{ id: 'sub-id', name: 'sub' }])
+      }),
+    )
+
+    const result = await service.getOrCreateSubGroupByName('parent-id', 'sub')
+
+    expect(result).toMatchObject({ id: 'sub-id', name: 'sub' })
+  })
+
+  it('should create the subgroup when it does not exist', async () => {
+    server.use(
+      http.get(childrenUrl, () => HttpResponse.json([])),
+      http.post(childrenUrl, async ({ request, params }) => {
+        expect(params.parentId).toBe('parent-id')
+        expect(await request.json()).toEqual({ name: 'sub' })
+        return new HttpResponse(null, {
+          status: 201,
+          headers: { location: `${keycloakUrl}/admin/realms/${projectRealm}/groups/created-id` },
+        })
+      }),
+    )
+
+    const result = await service.getOrCreateSubGroupByName('parent-id', 'sub')
+
+    expect(result).toEqual({ id: 'created-id', name: 'sub' })
+  })
+
+  it('should re-fetch the subgroup when a concurrent creation causes a 409', async () => {
+    server.use(
+      http.get(childrenUrl, () => HttpResponse.json([]), { once: true }),
+      http.get(childrenUrl, () => HttpResponse.json([{ id: 'concurrent-id', name: 'sub' }])),
+      http.post(childrenUrl, () =>
+        HttpResponse.json({ errorMessage: 'Sibling group named \'sub\' already exists.' }, { status: 409 })),
+    )
+
+    const result = await service.getOrCreateSubGroupByName('parent-id', 'sub')
+
+    expect(result).toMatchObject({ id: 'concurrent-id', name: 'sub' })
+  })
+
+  it('should rethrow the 409 when the subgroup still cannot be found', async () => {
+    server.use(
+      http.get(childrenUrl, () => HttpResponse.json([])),
+      http.post(childrenUrl, () =>
+        HttpResponse.json({ errorMessage: 'Sibling group named \'sub\' already exists.' }, { status: 409 })),
+    )
+
+    await expect(service.getOrCreateSubGroupByName('parent-id', 'sub')).rejects.toThrow('Network response was not OK.')
+  })
+
+  it('should rethrow non-409 errors without re-fetching', async () => {
+    let listCalls = 0
+    server.use(
+      http.get(childrenUrl, () => {
+        listCalls++
+        return HttpResponse.json([])
+      }),
+      http.post(childrenUrl, () =>
+        HttpResponse.json({ error: 'unauthorized' }, { status: 401 })),
+    )
+
+    await expect(service.getOrCreateSubGroupByName('parent-id', 'sub')).rejects.toThrow('Network response was not OK.')
+    expect(listCalls).toBe(1)
+  })
+})

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
@@ -7,6 +7,7 @@ import type { GroupRepresentationWith } from './keycloak.utils'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { trace } from '@opentelemetry/api'
 import z from 'zod'
+import { getErrorResponseStatus } from '../../utils/http-error'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { CONSOLE_GROUP_NAME, SUBGROUPS_PAGINATE_QUERY_MAX } from './keycloak.constants'
@@ -185,14 +186,31 @@ export class KeycloakClientService implements OnModuleInit {
     const span = trace.getActiveSpan()
     span?.setAttribute('group.name', name)
     span?.setAttribute('parent.id', parentId)
+    const existing = await this.findSubGroupByName(parentId, name)
+    if (existing) return existing
+
+    this.logger.debug(`Creating Keycloak subgroup ${name} under parentId=${parentId}`)
+    try {
+      const createdGroup = await this.client.groups.createChildGroup({ id: parentId }, { name })
+      return { id: createdGroup.id, name } satisfies GroupRepresentation
+    } catch (err) {
+      // A concurrent reconciliation may have created the subgroup between the
+      // scan and the create; treat the 409 as "already exists" and re-fetch it
+      if (getErrorResponseStatus(err) !== 409) throw err
+      this.logger.verbose(`Keycloak subgroup ${name} was created concurrently under parentId=${parentId}, fetching it`)
+      const subgroup = await this.findSubGroupByName(parentId, name)
+      if (!subgroup) throw err
+      return subgroup
+    }
+  }
+
+  private async findSubGroupByName(parentId: string, name: string): Promise<GroupRepresentation | undefined> {
     for await (const subgroup of this.getSubGroups(parentId)) {
       if (subgroup.name === name) {
         return subgroup
       }
     }
-    this.logger.debug(`Creating Keycloak subgroup ${name} under parentId=${parentId}`)
-    const createdGroup = await this.client.groups.createChildGroup({ id: parentId }, { name })
-    return { id: createdGroup.id, name } satisfies GroupRepresentation
+    return undefined
   }
 
   async getOrCreateConsoleGroup(projectGroup: GroupRepresentationWith<'id'>) {

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
@@ -7,6 +7,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
 import { trace } from '@opentelemetry/api'
 import z from 'zod'
+import { getErrorResponseStatus } from '../../utils/http-error'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { capturePluginResult } from '../plugin/plugin.utils'
 import { KeycloakClientService } from './keycloak-client.service'
@@ -646,14 +647,6 @@ export class KeycloakService {
       rw: ProjectAuthorized.ManageEnvironments({ adminPermissions: 0n, projectPermissions }),
     }
   }
-}
-
-/** HTTP status carried by errors such as keycloak-admin-client's NetworkError. */
-function getErrorResponseStatus(error: unknown): number | undefined {
-  if (error instanceof Error && 'response' in error && error.response instanceof Response) {
-    return error.response.status
-  }
-  return undefined
 }
 
 async function* map<T, U>(

--- a/apps/server-nestjs/src/utils/http-error.ts
+++ b/apps/server-nestjs/src/utils/http-error.ts
@@ -1,0 +1,20 @@
+/** HTTP status carried by errors such as keycloak-admin-client's NetworkError. */
+export function getErrorResponseStatus(error: unknown): number | undefined {
+  if (error instanceof Error && 'response' in error && error.response instanceof Response) {
+    return error.response.status
+  }
+  return undefined
+}
+
+/** HTTP details (status, url, response body) attached to errors carrying a fetch Response. */
+export function getErrorHttpDetails(error: Error): Record<string, unknown> {
+  const details: Record<string, unknown> = {}
+  if ('response' in error && error.response instanceof Response) {
+    details.status = error.response.status
+    details.url = error.response.url
+  }
+  if ('responseData' in error && error.responseData !== undefined && error.responseData !== '') {
+    details.responseData = error.responseData
+  }
+  return details
+}


### PR DESCRIPTION
# Issues liées

Issues numéro: N/A

---------

## Quel est le comportement actuel ?

Lorsque plusieurs réconciliations Keycloak s'exécutent en parallèle (plusieurs rôles d'un même projet synchronisés via `Promise.all`), `getOrCreateSubGroupByName` peut subir une race condition : deux appels concurrents constatent tous les deux que le sous-groupe n'existe pas, puis tentent chacun de le créer. Keycloak rejette le second `createChildGroup` avec un **409 Conflict** (« Sibling group named '…' already exists. »), ce qui fait échouer toute la synchronisation du projet avec l'erreur générique « Network response was not OK. ».

<img width="2804" height="1756" alt="image" src="https://github.com/user-attachments/assets/f5f40e18-760b-49ab-b574-0f70df98c319" />


De plus, ce statut HTTP et le corps de la réponse Keycloak n'apparaissaient pas dans les logs d'événements (`serializeError` ne conservait que `name`, `message` et `stack`), ce qui rendait ce type d'erreur très difficile à diagnostiquer.

## Quel est le nouveau comportement ?

- `getOrCreateSubGroupByName` est désormais idempotent en cas de concurrence : si `createChildGroup` échoue avec un 409, le sous-groupe créé concurremment est re-récupéré et retourné au lieu de faire échouer la réconciliation. Tout autre statut est toujours propagé, et si le sous-groupe reste introuvable après le 409, l'erreur d'origine est relancée.
- Nouveaux helpers partagés dans `src/utils/http-error.ts` : `getErrorResponseStatus()` (extraction du statut HTTP avec narrowing correct, forme du `NetworkError` de keycloak-admin-client) et `getErrorHttpDetails()` (statut, URL et corps de réponse). Ils remplacent les accès non typés `e.response?.status` dans `keycloak.service.ts`.
- `serializeError` (logs d'événements) inclut désormais `status`, `url` et `responseData` quand l'erreur porte une `Response`, ce qui rend les échecs HTTP directement lisibles dans les logs admin.
- Tests ajoutés sur `getOrCreateSubGroupByName` : retour du groupe existant sans création, création quand absent, récupération après un 409 concurrent, relance du 409 si le groupe reste introuvable, propagation des erreurs non-409.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Race condition observée en local lors de la synchronisation d'un projet dont plusieurs rôles partagent un segment de chemin OIDC : la création du sous-groupe échouait aléatoirement selon l'ordonnancement des promesses. Le correctif rend la création tolérante au conflit plutôt que de sérialiser les réconciliations, ce qui est la sémantique attendue pour un réconciliateur.

