### PR TITLE
fix(nestjs/nexus): fix nexus project sync and deletion errors

### DIFF
--- a/apps/server-nestjs/src/modules/nexus/nexus-http-client.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus-http-client.service.ts
@@ -65,7 +65,7 @@ export class NexusHttpClientService {
     span?.setAttribute('nexus.http.status', response.status)
     const result = await handleResponse<T>(response)
     if (!response.ok) {
-      throw new NexusError('HttpError', 'Request failed', {
+      throw new NexusError('HttpError', `Request failed: ${method} ${path} responded ${result.status} ${response.statusText}`, {
         status: result.status,
         method,
         path,

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.spec.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.spec.ts
@@ -176,6 +176,20 @@ describe('nexusService', () => {
     }), `forge/${project.slug}/tech/NEXUS`)
   })
 
+  it('deletes group repos before their hosted members', async () => {
+    const project = makeProjectWithDetails()
+
+    await service.handleDelete(project)
+
+    const deletedRepos = client.deleteRepositoriesByName.mock.calls.map(([name]) => name)
+    expect(deletedRepos.indexOf(`${project.slug}-repository-group`))
+      .toBeLessThan(deletedRepos.indexOf(`${project.slug}-repository-snapshot`))
+    expect(deletedRepos.indexOf(`${project.slug}-repository-group`))
+      .toBeLessThan(deletedRepos.indexOf(`${project.slug}-repository-release`))
+    expect(deletedRepos.indexOf(`${project.slug}-npm-group`))
+      .toBeLessThan(deletedRepos.indexOf(`${project.slug}-npm`))
+  })
+
   it('tolerates platform role failures when ensuring platform roles', async () => {
     const project = makeProjectWithDetails({
       owner: { email: 'owner@example.com', firstName: 'Owner', lastName: 'User' },

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.spec.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.spec.ts
@@ -176,6 +176,25 @@ describe('nexusService', () => {
     }), `forge/${project.slug}/tech/NEXUS`)
   })
 
+  it('tolerates platform role failures when ensuring platform roles', async () => {
+    const project = makeProjectWithDetails({
+      owner: { email: 'owner@example.com', firstName: 'Owner', lastName: 'User' },
+      plugins: [{ key: NEXUS_CONFIG_KEY_ACTIVATE_MAVEN_REPO, value: ENABLED }],
+    })
+    const staleProject = makeProjectWithDetails({
+      plugins: [{ key: NEXUS_CONFIG_KEY_ACTIVATE_NPM_REPO, value: ENABLED }],
+    })
+
+    nexusDatastore.getAllProjects.mockResolvedValue([project, staleProject])
+    client.createSecurityRoles.mockImplementation(async (body) => {
+      if (body.id.startsWith('console-')) throw new Error('Request failed: POST security/roles responded 400 Bad Request')
+    })
+
+    await expect(service.handleUpsert(project)).resolves.not.toThrow()
+
+    expect(client.createSecurityRoles).toHaveBeenCalledWith(expect.objectContaining({ id: 'console-admin' }))
+  })
+
   it('dedupes project group roles by role id and keeps the highest privileges', async () => {
     const project = makeProjectWithDetails({
       owner: { email: 'owner@example.com', firstName: 'Owner', lastName: 'User' },

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.ts
@@ -533,7 +533,15 @@ export class NexusService {
       writePrivileges: [...writePrivileges],
     })
 
-    await Promise.all(Array.from(byId.entries(), ([id, privileges]) => this.ensureSecurityRole(id, privileges)))
+    // Platform roles aggregate privileges of every Nexus-enabled project; a stale
+    // project (e.g. privileges missing on this instance) must not block the current one.
+    const entries = Array.from(byId.entries())
+    const results = await Promise.allSettled(entries.map(([id, privileges]) => this.ensureSecurityRole(id, privileges)))
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        this.logger.warn(`Failed to ensure platform role ${entries[index][0]}: ${result.reason instanceof Error ? result.reason.message : result.reason}`)
+      }
+    })
   }
 
   private async deleteProjectGroupRoles(project: ProjectWithDetails) {

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.ts
@@ -340,8 +340,7 @@ export class NexusService {
   }
 
   private async deleteMavenRepos(project: ProjectWithDetails) {
-    const repoPaths = [
-      generateMavenGroupRepoName(project),
+    const hostedRepoNames = [
       generateMavenHostedRepoName(project, 'release'),
       generateMavenHostedRepoName(project, 'snapshot'),
     ]
@@ -354,7 +353,9 @@ export class NexusService {
       generateMavenHostedPrivilegeNameReadonly(project, 'snapshot'),
     ]
     await Promise.all(privileges.map(privilege => this.client.deleteSecurityPrivileges(privilege)))
-    await Promise.all(repoPaths.map(repo => this.client.deleteRepositoriesByName(repo)))
+    // Nexus responds 500 when deleting a hosted repo still referenced by a group, so delete the group first
+    await this.client.deleteRepositoriesByName(generateMavenGroupRepoName(project))
+    await Promise.all(hostedRepoNames.map(repo => this.client.deleteRepositoriesByName(repo)))
   }
 
   private async ensureNpmRepos(project: ProjectWithDetails, writePolicy: string) {
@@ -396,10 +397,6 @@ export class NexusService {
   }
 
   private async deleteNpmRepos(project: ProjectWithDetails) {
-    const repoPaths = [
-      generateNpmGroupRepoName(project),
-      generateNpmHostedRepoName(project),
-    ]
     const privileges = [
       generateNpmGroupPrivilegeName(project),
       generateNpmHostedPrivilegeName(project),
@@ -407,7 +404,9 @@ export class NexusService {
       generateNpmHostedPrivilegeNameReadonly(project),
     ]
     await Promise.all(privileges.map(privilege => this.client.deleteSecurityPrivileges(privilege)))
-    await Promise.all(repoPaths.map(repo => this.client.deleteRepositoriesByName(repo)))
+    // Nexus responds 500 when deleting a hosted repo still referenced by a group, so delete the group first
+    await this.client.deleteRepositoriesByName(generateNpmGroupRepoName(project))
+    await this.client.deleteRepositoriesByName(generateNpmHostedRepoName(project))
   }
 
   private async ensureRole(project: ProjectWithDetails, privileges: string[]) {


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

## Quel est le comportement actuel ?

Deux erreurs bloquantes lors du cycle de vie d'un projet lorsque le plugin Nexus est activé :

1. **Création de projet** : `ensurePlatformRoles` agrège les privilèges de *tous* les projets ayant Nexus activé en base et les pousse sur les rôles plateforme (`console-admin`, `console-readonly`, …). Si un autre projet a Nexus activé dans sa config mais que ses privilèges n'existent pas sur l'instance Nexus (projet jamais réconcilié), Nexus rejette la mise à jour du rôle (HTTP 400) et la création de **tout** nouveau projet échoue.

2. **Suppression de projet** : `deleteMavenRepos` / `deleteNpmRepos` suppriment le dépôt group et les dépôts hosted en parallèle (`Promise.all`). Nexus renvoie une 500 quand on supprime un dépôt hosted encore membre d'un group — la suppression échouait donc de façon aléatoire selon l'ordre d'exécution.

Par ailleurs, les erreurs HTTP Nexus remontaient un message opaque (`Request failed`) sans méthode, chemin ni statut.

## Quel est le nouveau comportement ?

1. `ensurePlatformRoles` met à jour les rôles plateforme via `Promise.allSettled` : l'échec de mise à jour d'un rôle (privilèges manquants, 5xx transitoire, …) est loggé en warning et ne bloque plus le cycle de vie du projet. Le comportement est auto-réparateur : les rôles plateforme sont re-synchronisés à chaque upsert et à chaque réconciliation.

2. Le dépôt group est supprimé **avant** ses membres hosted (Maven et npm), ce qui élimine la 500 de Nexus.

3. Les erreurs HTTP Nexus incluent désormais la méthode, le chemin et le statut (ex : `Request failed: DELETE repositories/xxx responded 500 Server Error`).

Tests unitaires ajoutés pour les deux correctifs (`nexus.service.spec.ts`).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Les suppressions étant idempotentes (404 tolérées), une suppression de projet ayant échoué avant ce correctif peut simplement être relancée pour nettoyer les dépôts restants.
