### PR TITLE
refactor(server-nestjs): rename permission services to disambiguate

### DIFF
--- a/apps/server-nestjs/src/modules/infrastructure/permission/permission.module.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/permission.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common'
-import { ProjectModule } from './project/project.module'
-import { UserModule } from './user/user.module'
+import { ProjectPermissionModule } from './project/project.module'
+import { UserPermissionModule } from './user/user.module'
 
 @Module({
-  imports: [UserModule, ProjectModule],
-  exports: [UserModule, ProjectModule],
+  imports: [UserPermissionModule, ProjectPermissionModule],
+  exports: [UserPermissionModule, ProjectPermissionModule],
 })
 export class PermissionModule {}

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project-loader.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project-loader.service.ts
@@ -13,7 +13,7 @@ interface ProjectParams {
 }
 
 @Injectable()
-export class ProjectLoaderService {
+export class ProjectPermissionLoaderService {
   constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   async load(request: RequestWithProjectParams, userId: string, requirements?: ProjectRequirements): Promise<ProjectContext> {

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.guard.spec.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.guard.spec.ts
@@ -6,33 +6,33 @@ import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { AuthService } from '../../auth/auth.service'
-import { ProjectLoaderService } from './project-loader.service'
+import { ProjectPermissionLoaderService } from './project-loader.service'
 import { ProjectGuard } from './project.guard'
-import { ProjectPolicy } from './project.policy'
-import { ProjectService } from './project.service'
+import { ProjectPermissionPolicy } from './project.policy'
+import { ProjectPermissionService } from './project.service'
 import { makeExecutionContext, makeProjectContext, makeProjectPolicy } from './project.testing.utils'
 
 describe('projectGuard', () => {
   let module: TestingModule
   let guard: ProjectGuard
   let authService: DeepMockProxy<AuthService>
-  let projectService: DeepMockProxy<ProjectService>
-  let projectPolicy: DeepMockProxy<ProjectPolicy>
-  let loader: DeepMockProxy<ProjectLoaderService>
+  let projectService: DeepMockProxy<ProjectPermissionService>
+  let projectPolicy: DeepMockProxy<ProjectPermissionPolicy>
+  let loader: DeepMockProxy<ProjectPermissionLoaderService>
 
   beforeEach(async () => {
     authService = mockDeep<AuthService>()
-    projectService = mockDeep<ProjectService>()
-    projectPolicy = mockDeep<ProjectPolicy>()
-    loader = mockDeep<ProjectLoaderService>()
+    projectService = mockDeep<ProjectPermissionService>()
+    projectPolicy = mockDeep<ProjectPermissionPolicy>()
+    loader = mockDeep<ProjectPermissionLoaderService>()
 
     module = await Test.createTestingModule({
       providers: [
         ProjectGuard,
         { provide: AuthService, useValue: authService },
-        { provide: ProjectService, useValue: projectService },
-        { provide: ProjectPolicy, useValue: projectPolicy },
-        { provide: ProjectLoaderService, useValue: loader },
+        { provide: ProjectPermissionService, useValue: projectService },
+        { provide: ProjectPermissionPolicy, useValue: projectPolicy },
+        { provide: ProjectPermissionLoaderService, useValue: loader },
       ],
     }).compile()
 

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.guard.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.guard.ts
@@ -4,9 +4,9 @@ import type { FastifyRequest } from 'fastify'
 import type { UserContext } from '../../auth/auth-user.decorator'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { AuthService } from '../../auth/auth.service'
-import { ProjectLoaderService } from './project-loader.service'
-import { ProjectPolicy } from './project.policy'
-import { ProjectService } from './project.service'
+import { ProjectPermissionLoaderService } from './project-loader.service'
+import { ProjectPermissionPolicy } from './project.policy'
+import { ProjectPermissionService } from './project.service'
 
 export interface ProjectContext {
   id: string
@@ -37,9 +37,9 @@ export class ProjectGuard implements CanActivate {
 
   constructor(
     @Inject(AuthService) private readonly authService: AuthService,
-    @Inject(ProjectService) private readonly projectService: ProjectService,
-    @Inject(ProjectLoaderService) private readonly loader: ProjectLoaderService,
-    @Inject(ProjectPolicy) private readonly projectPolicy: ProjectPolicy,
+    @Inject(ProjectPermissionService) private readonly projectService: ProjectPermissionService,
+    @Inject(ProjectPermissionLoaderService) private readonly loader: ProjectPermissionLoaderService,
+    @Inject(ProjectPermissionPolicy) private readonly projectPolicy: ProjectPermissionPolicy,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.module.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common'
 import { AuthModule } from '../../auth/auth.module'
 import { DatabaseModule } from '../../database/database.module'
-import { ProjectLoaderService } from './project-loader.service'
+import { ProjectPermissionLoaderService } from './project-loader.service'
 import { ProjectGuard } from './project.guard'
-import { ProjectPolicy } from './project.policy'
-import { ProjectService } from './project.service'
+import { ProjectPermissionPolicy } from './project.policy'
+import { ProjectPermissionService } from './project.service'
 
 @Module({
   imports: [
@@ -13,15 +13,15 @@ import { ProjectService } from './project.service'
   ],
   providers: [
     ProjectGuard,
-    ProjectLoaderService,
-    ProjectService,
-    ProjectPolicy,
+    ProjectPermissionLoaderService,
+    ProjectPermissionService,
+    ProjectPermissionPolicy,
   ],
   exports: [
     ProjectGuard,
-    ProjectLoaderService,
-    ProjectService,
-    ProjectPolicy,
+    ProjectPermissionLoaderService,
+    ProjectPermissionService,
+    ProjectPermissionPolicy,
   ],
 })
-export class ProjectModule {}
+export class ProjectPermissionModule {}

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.policy.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.policy.ts
@@ -20,7 +20,7 @@ export interface ProjectPolicyConfig {
 }
 
 @Injectable()
-export class ProjectPolicy {
+export class ProjectPermissionPolicy {
   constructor(@Inject(Reflector) private readonly reflector: Reflector) {}
 
   build(context: ExecutionContext): ProjectPolicyConfig {

--- a/apps/server-nestjs/src/modules/infrastructure/permission/project/project.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/project/project.service.ts
@@ -6,8 +6,8 @@ import { AdminAuthorized, ProjectAuthorized } from '@cpn-console/shared'
 import { ForbiddenException, Injectable, Logger } from '@nestjs/common'
 
 @Injectable()
-export class ProjectService {
-  private readonly logger = new Logger(ProjectService.name)
+export class ProjectPermissionService {
+  private readonly logger = new Logger(ProjectPermissionService.name)
 
   validate(policy: ProjectPolicyConfig, project: ProjectContext, user: UserContext): void {
     this.validateUserType(policy, user.userType)

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user-policy.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user-policy.service.ts
@@ -12,7 +12,7 @@ export interface UserPolicyConfig {
 }
 
 @Injectable()
-export class UserPolicy {
+export class UserPermissionPolicy {
   constructor(@Inject(Reflector) private readonly reflector: Reflector) {}
 
   build(context: ExecutionContext): UserPolicyConfig {

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user.guard.spec.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user.guard.spec.ts
@@ -7,28 +7,28 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { makeExecutionContext } from '../../auth/auth-testing.utils'
 import { AuthService } from '../../auth/auth.service'
-import { UserPolicy } from './user-policy.service'
+import { UserPermissionPolicy } from './user-policy.service'
 import { UserGuard } from './user.guard'
-import { UserService } from './user.service'
+import { UserPermissionService } from './user.service'
 
 describe('userGuard', () => {
   let module: TestingModule
   let guard: UserGuard
   let authService: DeepMockProxy<AuthService>
-  let userService: DeepMockProxy<UserService>
-  let userPolicy: DeepMockProxy<UserPolicy>
+  let userService: DeepMockProxy<UserPermissionService>
+  let userPolicy: DeepMockProxy<UserPermissionPolicy>
 
   beforeEach(async () => {
     authService = mockDeep<AuthService>()
-    userService = mockDeep<UserService>()
-    userPolicy = mockDeep<UserPolicy>()
+    userService = mockDeep<UserPermissionService>()
+    userPolicy = mockDeep<UserPermissionPolicy>()
 
     module = await Test.createTestingModule({
       providers: [
         UserGuard,
         { provide: AuthService, useValue: authService },
-        { provide: UserService, useValue: userService },
-        { provide: UserPolicy, useValue: userPolicy },
+        { provide: UserPermissionService, useValue: userService },
+        { provide: UserPermissionPolicy, useValue: userPolicy },
       ],
     }).compile()
 

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user.guard.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user.guard.ts
@@ -2,8 +2,8 @@ import type { CanActivate, ExecutionContext } from '@nestjs/common'
 import type { FastifyRequest } from 'fastify'
 import { Inject, Injectable, Logger, UnauthorizedException } from '@nestjs/common'
 import { AuthService } from '../../auth/auth.service'
-import { UserPolicy } from './user-policy.service'
-import { UserService } from './user.service'
+import { UserPermissionPolicy } from './user-policy.service'
+import { UserPermissionService } from './user.service'
 
 type RequestWithAuthContext = FastifyRequest & {
   userId?: string
@@ -17,8 +17,8 @@ export class UserGuard implements CanActivate {
 
   constructor(
     @Inject(AuthService) private readonly authService: AuthService,
-    @Inject(UserService) private readonly userService: UserService,
-    @Inject(UserPolicy) private readonly userPolicy: UserPolicy,
+    @Inject(UserPermissionService) private readonly userService: UserPermissionService,
+    @Inject(UserPermissionPolicy) private readonly userPolicy: UserPermissionPolicy,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -54,7 +54,7 @@ export class UserGuard implements CanActivate {
     }
   }
 
-  private validate(policy: ReturnType<UserPolicy['build']>, user: Awaited<ReturnType<UserGuard['authenticate']>>) {
+  private validate(policy: ReturnType<UserPermissionPolicy['build']>, user: Awaited<ReturnType<UserGuard['authenticate']>>) {
     this.userService.validate(policy, user)
   }
 }

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user.module.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common'
 import { AuthModule } from '../../auth/auth.module'
 import { DatabaseModule } from '../../database/database.module'
-import { UserPolicy } from './user-policy.service'
+import { UserPermissionPolicy } from './user-policy.service'
 import { UserGuard } from './user.guard'
-import { UserService } from './user.service'
+import { UserPermissionService } from './user.service'
 
 @Module({
   imports: [
@@ -12,13 +12,13 @@ import { UserService } from './user.service'
   ],
   providers: [
     UserGuard,
-    UserService,
-    UserPolicy,
+    UserPermissionService,
+    UserPermissionPolicy,
   ],
   exports: [
     UserGuard,
-    UserService,
-    UserPolicy,
+    UserPermissionService,
+    UserPermissionPolicy,
   ],
 })
-export class UserModule {}
+export class UserPermissionModule {}

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user.service.spec.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user.service.spec.ts
@@ -4,17 +4,17 @@ import { ForbiddenException } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { makeUserContext, makeUserPolicy } from './user-testing.utils'
-import { UserService } from './user.service'
+import { UserPermissionService } from './user.service'
 
 describe('userService', () => {
-  let service: UserService
+  let service: UserPermissionService
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [UserPermissionService],
     }).compile()
 
-    service = module.get(UserService)
+    service = module.get(UserPermissionService)
   })
 
   describe('validateAdminPermissions', () => {

--- a/apps/server-nestjs/src/modules/infrastructure/permission/user/user.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/permission/user/user.service.ts
@@ -5,8 +5,8 @@ import { AdminAuthorized } from '@cpn-console/shared'
 import { ForbiddenException, Injectable, Logger } from '@nestjs/common'
 
 @Injectable()
-export class UserService {
-  private readonly logger = new Logger(UserService.name)
+export class UserPermissionService {
+  private readonly logger = new Logger(UserPermissionService.name)
 
   validate(policy: UserPolicyConfig, user: UserContext): void {
     this.validateAdminPermissions(policy, user.adminPermissions)

--- a/apps/server-nestjs/src/modules/log/log.controller.spec.ts
+++ b/apps/server-nestjs/src/modules/log/log.controller.spec.ts
@@ -5,7 +5,7 @@ import { ForbiddenException } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
-import { ProjectLoaderService } from '../infrastructure/permission/project/project-loader.service'
+import { ProjectPermissionLoaderService } from '../infrastructure/permission/project/project-loader.service'
 import { makeProjectContext } from '../infrastructure/permission/project/project.testing.utils'
 import { UserGuard } from '../infrastructure/permission/user/user.guard'
 import { LogController } from './log.controller'
@@ -15,17 +15,17 @@ describe('logController', () => {
   let module: TestingModule
   let controller: LogController
   let logs: DeepMockProxy<LogService>
-  let projectLoader: DeepMockProxy<ProjectLoaderService>
+  let projectLoader: DeepMockProxy<ProjectPermissionLoaderService>
 
   beforeEach(async () => {
     logs = mockDeep<LogService>()
-    projectLoader = mockDeep<ProjectLoaderService>()
+    projectLoader = mockDeep<ProjectPermissionLoaderService>()
 
     module = await Test.createTestingModule({
       controllers: [LogController],
       providers: [
         { provide: LogService, useValue: logs },
-        { provide: ProjectLoaderService, useValue: projectLoader },
+        { provide: ProjectPermissionLoaderService, useValue: projectLoader },
       ],
     })
       .overrideGuard(UserGuard)

--- a/apps/server-nestjs/src/modules/log/log.controller.ts
+++ b/apps/server-nestjs/src/modules/log/log.controller.ts
@@ -3,7 +3,7 @@ import type { UserContext } from '../infrastructure/auth/auth-user.decorator'
 import { AdminAuthorized, logContract } from '@cpn-console/shared'
 import { Controller, ForbiddenException, Get, Inject, Query, UseGuards } from '@nestjs/common'
 import { AuthUser } from '../infrastructure/auth/auth-user.decorator'
-import { ProjectLoaderService } from '../infrastructure/permission/project/project-loader.service'
+import { ProjectPermissionLoaderService } from '../infrastructure/permission/project/project-loader.service'
 import { UserGuard } from '../infrastructure/permission/user/user.guard'
 import { ZodValidationPipe } from '../infrastructure/pipe/zod-validation.pipe'
 import { LogService } from './log.service'
@@ -13,7 +13,7 @@ import { LogService } from './log.service'
 export class LogController {
   constructor(
     @Inject(LogService) private readonly logs: LogService,
-    @Inject(ProjectLoaderService) private readonly projectLoader: ProjectLoaderService,
+    @Inject(ProjectPermissionLoaderService) private readonly projectLoader: ProjectPermissionLoaderService,
   ) {}
 
   @Get('')
@@ -30,7 +30,7 @@ export class LogController {
       }
 
       const project = await this.projectLoader.load(
-        { params: { projectId: query.projectId } } as Parameters<ProjectLoaderService['load']>[0],
+        { params: { projectId: query.projectId } } as Parameters<ProjectPermissionLoaderService['load']>[0],
         user.userId,
         { includePermissions: true, includeLocked: false, includeStatus: false },
       )

--- a/apps/server-nestjs/src/modules/system-config/system-config.module.ts
+++ b/apps/server-nestjs/src/modules/system-config/system-config.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
-import { UserModule } from '../infrastructure/permission/user/user.module'
+import { UserPermissionModule } from '../infrastructure/permission/user/user.module'
 import { SystemConfigController } from './system-config.controller'
 import { SystemConfigService } from './system-config.service'
 
 @Module({
-  imports: [InfrastructureModule, UserModule],
+  imports: [InfrastructureModule, UserPermissionModule],
   controllers: [SystemConfigController],
   providers: [SystemConfigService],
 })


### PR DESCRIPTION
NestJS dependency injection error messages do not explicitly indicate which module has the DI problem. When a generic name like `ProjectService` is used in multiple modules (e.g., `ProjectService` for domain logic vs. `ProjectService` for permissions), the error messages become ambiguous and debugging becomes difficult. By making permission service names explicit (`ProjectPermissionService`), the DI errors immediately identify the problematic module and service.

- UserService → UserPermissionService
- UserPolicy → UserPermissionPolicy
- ProjectService → ProjectPermissionService
- ProjectPolicy → ProjectPermissionPolicy
- ProjectLoaderService → ProjectPermissionLoaderService

## Issues liées

Extrait de #2298 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->