### PR TITLE
refactor(server-nestjs): migrate health modules from HealthIndicatorService to TerminusModule

### DIFF
--- a/apps/server-nestjs/src/modules/argocd/argocd.module.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { GitlabModule } from '../gitlab/gitlab.module'
 import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
@@ -10,8 +10,8 @@ import { ArgoCDPluginService } from './argocd-plugin.service'
 import { ArgoCDService } from './argocd.service'
 
 @Module({
-  imports: [ConfigurationModule, InfrastructureModule, GitlabModule, VaultModule],
-  providers: [HealthIndicatorService, ArgoCDHealthService, ArgoCDPluginService, ArgoCDService, ArgoCDDatastoreService],
+  imports: [ConfigurationModule, InfrastructureModule, TerminusModule, GitlabModule, VaultModule],
+  providers: [ArgoCDHealthService, ArgoCDPluginService, ArgoCDService, ArgoCDDatastoreService],
   exports: [ArgoCDHealthService, ArgoCDPluginService, ArgoCDService],
 })
 export class ArgoCDModule {}

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.module.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.module.ts
@@ -1,6 +1,6 @@
 import { Gitlab } from '@gitbeaker/rest'
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
@@ -12,7 +12,7 @@ import { GitlabPluginService } from './gitlab-plugin.service'
 import { GitlabService } from './gitlab.service'
 
 @Module({
-  imports: [ConfigurationModule, InfrastructureModule, VaultModule],
+  imports: [ConfigurationModule, InfrastructureModule, TerminusModule, VaultModule],
   providers: [
     {
       provide: GITLAB_REST_CLIENT,
@@ -22,7 +22,6 @@ import { GitlabService } from './gitlab.service'
         host: config.getInternalOrPublicGitlabUrl(),
       }),
     },
-    HealthIndicatorService,
     GitlabClientService,
     GitlabDatastoreService,
     GitlabHealthService,

--- a/apps/server-nestjs/src/modules/infrastructure/database/database.module.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/database/database.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { ConfigurationModule } from '../configuration/configuration.module'
 import { DatabaseHealthService } from './database-health.service'
 import { DatabaseService } from './database.service'
 import { PrismaService } from './prisma.service'
 
 @Module({
-  imports: [ConfigurationModule],
-  providers: [HealthIndicatorService, DatabaseHealthService, DatabaseService, PrismaService],
+  imports: [ConfigurationModule, TerminusModule],
+  providers: [DatabaseHealthService, DatabaseService, PrismaService],
   exports: [DatabaseHealthService, DatabaseService, PrismaService],
 })
 export class DatabaseModule {}

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.module.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.module.ts
@@ -1,6 +1,6 @@
 import KcAdminClient from '@keycloak/keycloak-admin-client'
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { ConfigurationService } from '../infrastructure/configuration/configuration.service'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
@@ -11,7 +11,7 @@ import { KeycloakPluginService } from './keycloak-plugin.service'
 import { KeycloakService } from './keycloak.service'
 
 @Module({
-  imports: [ConfigurationModule, InfrastructureModule],
+  imports: [ConfigurationModule, InfrastructureModule, TerminusModule],
   providers: [
     {
       provide: KEYCLOAK_ADMIN_CLIENT,
@@ -20,7 +20,6 @@ import { KeycloakService } from './keycloak.service'
         baseUrl: config.getKeycloakUrl(),
       }),
     },
-    HealthIndicatorService,
     KeycloakClientService,
     KeycloakDatastoreService,
     KeycloakHealthService,

--- a/apps/server-nestjs/src/modules/nexus/nexus.module.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
 import { VaultModule } from '../vault/vault.module'
@@ -11,8 +11,15 @@ import { NexusPluginService } from './nexus-plugin.service'
 import { NexusService } from './nexus.service'
 
 @Module({
-  imports: [ConfigurationModule, InfrastructureModule, VaultModule],
-  providers: [HealthIndicatorService, NexusHealthService, NexusPluginService, NexusService, NexusDatastoreService, NexusHttpClientService, NexusClientService],
+  imports: [ConfigurationModule, InfrastructureModule, TerminusModule, VaultModule],
+  providers: [
+    NexusHealthService,
+    NexusPluginService,
+    NexusService,
+    NexusDatastoreService,
+    NexusHttpClientService,
+    NexusClientService,
+  ],
   exports: [NexusClientService, NexusHealthService, NexusPluginService, NexusService],
 })
 export class NexusModule {}

--- a/apps/server-nestjs/src/modules/opencds/opencds.module.ts
+++ b/apps/server-nestjs/src/modules/opencds/opencds.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { OpenCdsHealthService } from './opencds-health.service'
 
 @Module({
-  imports: [ConfigurationModule],
-  providers: [HealthIndicatorService, OpenCdsHealthService],
+  imports: [ConfigurationModule, TerminusModule],
+  providers: [OpenCdsHealthService],
   exports: [OpenCdsHealthService],
 })
 export class OpenCdsModule {}

--- a/apps/server-nestjs/src/modules/registry/registry.module.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.module.ts
@@ -1,6 +1,6 @@
 import { CacheModule } from '@nestjs/cache-manager'
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
 import { VaultModule } from '../vault/vault.module'
@@ -12,8 +12,8 @@ import { RegistryPluginService } from './registry-plugin.service'
 import { RegistryService } from './registry.service'
 
 @Module({
-  imports: [ConfigurationModule, InfrastructureModule, VaultModule, CacheModule.register()],
-  providers: [HealthIndicatorService, RegistryHealthService, RegistryPluginService, RegistryService, RegistryDatastoreService, RegistryHttpClientService, RegistryClientService],
+  imports: [ConfigurationModule, InfrastructureModule, TerminusModule, VaultModule, CacheModule.register()],
+  providers: [RegistryHealthService, RegistryPluginService, RegistryService, RegistryDatastoreService, RegistryHttpClientService, RegistryClientService],
   exports: [RegistryHealthService, RegistryPluginService, RegistryService],
 })
 export class RegistryModule {}

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.module.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
 import { VaultModule } from '../vault/vault.module'
@@ -11,9 +11,8 @@ import { SonarqubePluginService } from './sonarqube-plugin.service'
 import { SonarqubeService } from './sonarqube.service'
 
 @Module({
-  imports: [ConfigurationModule, InfrastructureModule, VaultModule],
+  imports: [ConfigurationModule, InfrastructureModule, TerminusModule, VaultModule],
   providers: [
-    HealthIndicatorService,
     SonarqubeHttpClientService,
     SonarqubeClientService,
     SonarqubeDatastoreService,

--- a/apps/server-nestjs/src/modules/vault/vault.module.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common'
-import { HealthIndicatorService } from '@nestjs/terminus'
+import { TerminusModule } from '@nestjs/terminus'
 import { ConfigurationModule } from '../infrastructure/configuration/configuration.module'
 import { InfrastructureModule } from '../infrastructure/infrastructure.module'
 import { VaultClientService } from './vault-client.service'
@@ -10,9 +10,8 @@ import { VaultPluginService } from './vault-plugin.service'
 import { VaultService } from './vault.service'
 
 @Module({
-  imports: [ConfigurationModule, InfrastructureModule],
+  imports: [ConfigurationModule, InfrastructureModule, TerminusModule],
   providers: [
-    HealthIndicatorService,
     VaultHealthService,
     VaultHttpClientService,
     VaultClientService,


### PR DESCRIPTION
## Issues liées

Extrait de: #2293

## Quel est le comportement actuel ?

Les modules de `apps/server-nestjs` importent l'agrégateur `InfrastructureModule` pour accéder aux services d'infrastructure (auth, database, configuration, events, logger, permissions).

## Quel est le nouveau comportement ?

Chaque module déclare explicitement ses dépendances d'infrastructure (ex. `AuthModule`, `DatabaseModule`, `EventsModule`, `PermissionModule`, `LoggerModule`, `ConfigurationModule`) au lieu de passer par l'agrégateur `InfrastructureModule`, qui n'est plus utilisé que comme point d'entrée racine dans `main.module.ts`.

`ServiceChainModule` exporte désormais `ServiceChainService`. Les tests e2e (`test/*.e2e-spec.ts`) utilisent les modules explicites à la place de `InfrastructureModule`.

## Cette PR introduit-elle un breaking change ?

Non. Refactorisation interne de l'injection de dépendances, sans changement de contrat ni d'API.

## Pourquoi ce changement ?

L'utilisation de l'agrégateur `InfrastructureModule` masquait les dépendances réelles de chaque module : un import unique exposait l'ensemble des services d'infrastructure, rendant le graphe de dépendances illisible et compliquant le diagnostic des erreurs d'injection (ex. `Nest can't resolve dependencies`). En déclarant les modules explicitement, chaque module expose uniquement ce dont il a besoin, ce qui réduit le couplage implicite, facilite la réutilisation isolée (tests, modules autonomes) et rend les erreurs de DI immédiatement localisables.
