### PR TITLE
fix(server-nestjs/environment): exclude updated environment from quota sums

### DIFF
--- a/apps/server-nestjs/src/modules/environment/environment-validation.service.spec.ts
+++ b/apps/server-nestjs/src/modules/environment/environment-validation.service.spec.ts
@@ -15,6 +15,7 @@ describe('environmentValidationService', () => {
   let datastore: DeepMockProxy<EnvironmentDatastoreService>
 
   const projectId = '11111111-1111-1111-1111-111111111111'
+  const environmentId = '22222222-2222-2222-2222-222222222222'
   const clusterId = '33333333-3333-3333-3333-333333333333'
   const stageId = '44444444-4444-4444-4444-444444444444'
 
@@ -99,6 +100,7 @@ describe('environmentValidationService', () => {
 
       await expect(service.validateCreate(projectId, validCreateEnvironment))
         .rejects.toThrow('Le cluster ne dispose pas de suffisamment de ressources : CPU, Mémoire.')
+      expect(datastore.sumEnvironmentResources).toHaveBeenCalledWith({ clusterId })
     })
 
     it('should reject when the project does not have enough prod resources', async () => {
@@ -165,6 +167,56 @@ describe('environmentValidationService', () => {
 
       await expect(service.validateUpdate(environment, validUpdateEnvironment))
         .rejects.toThrow('Le cluster ne dispose pas de suffisamment de ressources : CPU, GPU, Mémoire.')
+    })
+
+    it('should not count the environment being updated in the cluster consumed resources', async () => {
+      const environment = makeEnvironmentWithCluster({
+        id: environmentId,
+        projectId,
+        cluster: makeCluster({ id: clusterId, cpu: 8, gpu: 2, memory: 16 }),
+      })
+      datastore.getProjectById.mockResolvedValue(makeProject({ id: projectId, limitless: true }))
+      // the sum only covers the other environments of the cluster
+      datastore.sumEnvironmentResources.mockResolvedValue({
+        _sum: { cpu: 3, gpu: 0, memory: 6 },
+      })
+
+      await expect(service.validateUpdate(environment, validUpdateEnvironment)).resolves.toBeUndefined()
+
+      expect(datastore.sumEnvironmentResources).toHaveBeenCalledWith({
+        clusterId,
+        id: { not: environmentId },
+      })
+    })
+
+    it('should not count the environment being updated in the project consumed resources', async () => {
+      const environment = makeEnvironmentWithCluster({
+        id: environmentId,
+        projectId,
+        stageId,
+        cluster: makeCluster({ id: clusterId, cpu: 0, memory: 0 }),
+      })
+      datastore.getProjectById.mockResolvedValue(makeProject({
+        id: projectId,
+        limitless: false,
+        prodCpu: 8,
+        prodGpu: 2,
+        prodMemory: 16,
+      }))
+      datastore.getStageById.mockResolvedValue(makeStage({ id: stageId, name: 'prod' }))
+      datastore.getProdStageIds.mockResolvedValue([{ id: stageId }])
+      // the sum only covers the other prod environments of the project
+      datastore.sumEnvironmentResources.mockResolvedValue({
+        _sum: { cpu: 3, gpu: 0, memory: 6 },
+      })
+
+      await expect(service.validateUpdate(environment, validUpdateEnvironment)).resolves.toBeUndefined()
+
+      expect(datastore.sumEnvironmentResources).toHaveBeenCalledWith({
+        projectId,
+        stageId: { in: [stageId] },
+        id: { not: environmentId },
+      })
     })
   })
 })

--- a/apps/server-nestjs/src/modules/environment/environment-validation.service.ts
+++ b/apps/server-nestjs/src/modules/environment/environment-validation.service.ts
@@ -55,11 +55,11 @@ export class EnvironmentValidationService {
 
   async validateUpdate(environment: EnvironmentWithCluster, input: UpdateEnvironment): Promise<void> {
     const errorMessages: string[] = []
-    const clusterError = await this.checkClusterResources(input, environment.cluster)
+    const clusterError = await this.checkClusterResources(input, environment.cluster, environment.id)
     if (clusterError) errorMessages.push(clusterError)
 
     const project = await this.environmentDatastoreService.getProjectById(environment.projectId)
-    const projectError = await this.checkProjectResources(input, environment.stageId, project)
+    const projectError = await this.checkProjectResources(input, environment.stageId, project, environment.id)
     if (projectError) errorMessages.push(projectError)
 
     if (errorMessages.length > 0) {
@@ -67,11 +67,12 @@ export class EnvironmentValidationService {
     }
   }
 
-  private async checkClusterResources(request: EnvironmentResources, cluster: Cluster): Promise<string | undefined> {
+  private async checkClusterResources(request: EnvironmentResources, cluster: Cluster, excludedEnvironmentId?: string): Promise<string | undefined> {
     const overflowResources = await this.getOverflowResources({
       request,
       limit: { cpu: cluster.cpu, gpu: cluster.gpu, memory: cluster.memory },
       where: { clusterId: cluster.id },
+      excludedEnvironmentId,
     })
     if (overflowResources.length > 0) {
       return `Le cluster ne dispose pas de suffisamment de ressources : ${overflowResources.join(', ')}.`
@@ -79,7 +80,7 @@ export class EnvironmentValidationService {
     return undefined
   }
 
-  private async checkProjectResources(request: EnvironmentResources, stageId: string, project: Project): Promise<string | undefined> {
+  private async checkProjectResources(request: EnvironmentResources, stageId: string, project: Project, excludedEnvironmentId?: string): Promise<string | undefined> {
     if (project.limitless) {
       // No limits
       return undefined
@@ -99,6 +100,7 @@ export class EnvironmentValidationService {
           projectId: project.id,
           stageId: { in: prodStageIds },
         },
+        excludedEnvironmentId,
       })
     } else { // hprod
       overflowResources = await this.getOverflowResources({
@@ -108,6 +110,7 @@ export class EnvironmentValidationService {
           projectId: project.id,
           stageId: { notIn: prodStageIds },
         },
+        excludedEnvironmentId,
       })
     }
     if (overflowResources.length > 0) {
@@ -116,15 +119,23 @@ export class EnvironmentValidationService {
     return undefined
   }
 
-  private async getOverflowResources({ request, limit, where }: {
+  /**
+   * On update, the environment being updated must be excluded from the consumed-resources
+   * sum: its requested resources replace its current ones. Counting both would reject
+   * legitimate updates within the quota (#1911).
+   */
+  private async getOverflowResources({ request, limit, where, excludedEnvironmentId }: {
     request: EnvironmentResources
     limit: EnvironmentResources
     where: Prisma.EnvironmentWhereInput
+    excludedEnvironmentId?: string
   }): Promise<string[]> {
     if (!areResourceLimitsConfigured(limit)) {
       return []
     }
-    const environmentResources = await this.environmentDatastoreService.sumEnvironmentResources(where)
+    const environmentResources = await this.environmentDatastoreService.sumEnvironmentResources(
+      excludedEnvironmentId === undefined ? where : { ...where, id: { not: excludedEnvironmentId } },
+    )
     // A null sum means no environment matched: nothing is consumed yet.
     const insufficientResources: string[] = []
     if ((environmentResources._sum.cpu ?? 0) + request.cpu > limit.cpu) {


### PR DESCRIPTION
## Issues liées

Issues numéro: Fixes #1911 — #2322 (migration API v2)

---------

## Quel est le comportement actuel ?

Lors de la mise à jour d'un environnement, le contrôle des quotas compte l'environnement modifié en double : la somme des ressources consommées (cluster et projet) inclut ses ressources actuelles, auxquelles s'ajoutent les ressources demandées. Exemple du ticket : passer un environnement de 4 à 7 CPU avec un quota de 8 est rejeté à tort (4 + 7 = 11 > 8) avec l'erreur « Le projet ne dispose pas de suffisamment de ressources ».

## Quel est le nouveau comportement ?

Dans l'API v2 (`EnvironmentValidationService`), lors d'un update, l'environnement en cours de modification est exclu de la somme des ressources consommées (`id: { not: environmentId }` dans l'agrégation Prisma), pour le quota cluster comme pour les quotas projet (prod/hprod) : ses ressources demandées remplacent les actuelles au lieu de s'y ajouter. Le comportement à la création est inchangé (aucune exclusion).

Tests ajoutés :

- un update dans les limites du quota passe, et la somme cluster est interrogée en excluant l'environnement modifié ;
- même vérification pour le quota projet (projet non limitless, stage prod) ;
- à la création, la somme est interrogée sans exclusion.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

PR stackée sur #2310 (`feat/environment-api-v2`) : à merger après elle. Le double comptage reste présent côté serveur legacy (`apps/server`) ; il disparaîtra avec la bascule du client vers l'API v2.

