### PR TITLE
feat(client): switch environments to API v2

### DIFF
--- a/apps/client/src/api/xhr-client.ts
+++ b/apps/client/src/api/xhr-client.ts
@@ -38,8 +38,12 @@ export function extractData<T extends { status: number, body: unknown, headers: 
     }
   }
   if (response.status >= 400) {
+    // `message` d'abord : les erreurs gérées du legacy (ErrorResType) et celles de NestJS
+    // (HttpException) portent le vrai message dans `message` — chez NestJS, `error` ne contient
+    // que la raison HTTP générique ("Forbidden", "Bad Request"). `error` reste en repli pour
+    // les erreurs non gérées du legacy (setErrorHandler), qui n'ont pas de champ `message`.
     // @ts-ignore
-    throw new Error(response.body?.error ?? response.body?.message ?? 'Erreur inconnue')
+    throw new Error(response.body?.message ?? response.body?.error ?? 'Erreur inconnue')
   }
   if (response.status === expectedStatus) return response.body
   try {

--- a/apps/client/src/components/EnvironmentForm.vue
+++ b/apps/client/src/components/EnvironmentForm.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type {
   CleanedCluster,
-  CreateEnvironmentBody,
+  CreateEnvironment,
   Environment,
 } from '@cpn-console/shared'
 import {
@@ -46,7 +46,7 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{
-  addEnvironment: [environment: Omit<CreateEnvironmentBody, 'projectId'>]
+  addEnvironment: [environment: CreateEnvironment]
   putEnvironment: [environment: Pick<Environment, 'cpu' | 'gpu' | 'memory' | 'autosync'>]
   deleteEnvironment: [environmentId: Environment['id']]
   cancel: []

--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CleanedCluster, Cluster, CreateEnvironmentBody, Environment, Repo, Stage, UpdateEnvironmentBody, Zone } from '@cpn-console/shared'
+import type { CleanedCluster, Cluster, CreateEnvironment, Environment, Repo, Stage, UpdateEnvironment, Zone } from '@cpn-console/shared'
 import type { Project } from '@/utils/project-utils.js'
 import { logger } from '@cpn-console/logger/browser'
 import { AdminAuthorized, ProjectAuthorized, projectIsLockedInfo } from '@cpn-console/shared'
@@ -68,7 +68,7 @@ watch(selectedRepo, async () => {
   branchName.value = defaultBranchName
 })
 
-async function putEnvironment(environment: UpdateEnvironmentBody, envId: Environment['id']) {
+async function putEnvironment(environment: UpdateEnvironment, envId: Environment['id']) {
   selectedEnv.value = undefined
   if (!props.project.locked) {
     props.project.Environments.update(envId, environment)
@@ -86,7 +86,7 @@ async function deleteEnvironment(environmentId: Environment['id']) {
   }
 }
 
-async function addEnvironment(environment: Omit<CreateEnvironmentBody, 'id' | 'projectId'>) {
+async function addEnvironment(environment: CreateEnvironment) {
   newResource.value = undefined
   if (!props.project.locked) {
     props.project.Environments.create(environment)
@@ -396,7 +396,7 @@ async function copyToClipboard(text: string) {
       :is-editable="false"
       :is-project-locked="project.locked"
       :can-manage="canManageEnvs || (AdminAuthorized.Manage(userStore.adminPerms) && asProfile === 'admin')"
-      @put-environment="(environmentUpdate: UpdateEnvironmentBody) => putEnvironment(environmentUpdate, selectedEnv!.id)"
+      @put-environment="(environmentUpdate: UpdateEnvironment) => putEnvironment(environmentUpdate, selectedEnv!.id)"
       @delete-environment="() => deleteEnvironment(selectedEnv!.id)"
       @cancel="selectedEnv = undefined"
     />
@@ -406,7 +406,7 @@ async function copyToClipboard(text: string) {
       :available-clusters="projectClusters"
       :can-manage="canManageEnvs"
       is-editable
-      @add-environment="(environment: Omit<CreateEnvironmentBody, 'id' | 'projectId'>) => addEnvironment(environment)"
+      @add-environment="(environment: CreateEnvironment) => addEnvironment(environment)"
       @cancel="newResource = undefined"
     />
     <template

--- a/apps/client/src/stores/project.spec.ts
+++ b/apps/client/src/stores/project.spec.ts
@@ -6,7 +6,7 @@ import { useProjectStore } from './project.js'
 
 const getProject = vi.spyOn(apiClient.Projects, 'getProject')
 const listProjects = vi.spyOn(apiClient.Projects, 'listProjects')
-const listEnvironments = vi.spyOn(apiClient.Environments, 'listEnvironments')
+const listEnvironments = vi.spyOn(apiClient.EnvironmentsV2, 'listEnvironmentsV2')
 const listRepositories = vi.spyOn(apiClient.Repositories, 'listRepositories')
 const apiClientPost = vi.spyOn(apiClient.Projects, 'createProject')
 

--- a/apps/client/src/utils/project-utils.ts
+++ b/apps/client/src/utils/project-utils.ts
@@ -1,6 +1,6 @@
 import type {
   CreateDeploymentBody,
-  CreateEnvironmentBody,
+  CreateEnvironment,
   CreateRepositoryBody,
   Deployment,
   Environment,
@@ -16,7 +16,7 @@ import type {
   RepositoryParams,
   Role,
   UpdateDeploymentBody,
-  UpdateEnvironmentBody,
+  UpdateEnvironment,
   UpdateRepositoryBody,
   User,
 } from '@cpn-console/shared'
@@ -274,22 +274,22 @@ export class Project implements ProjectV2 {
 
   Environments = {
     list: async () => {
-      this.environments.value = await apiClient.Environments.listEnvironments({ query: { projectId: this.id } })
+      this.environments.value = await apiClient.EnvironmentsV2.listEnvironmentsV2({ params: { projectId: this.id } })
         .then((response: any) => extractData(response, 200))
       return this.environments.value
     },
-    create: async (envData: Omit<CreateEnvironmentBody, 'projectId'>) => {
+    create: async (envData: CreateEnvironment) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.Environments.createEnvironment({ body: { ...envData, projectId: this.id } })
+        await apiClient.EnvironmentsV2.createEnvironmentV2({ params: { projectId: this.id }, body: envData })
           .then((response: any) => extractData(response, 201))
         return this.Environments.list()
       } finally { callback() }
     },
-    update: async (id: Environment['id'], environment: UpdateEnvironmentBody) => {
+    update: async (id: Environment['id'], environment: UpdateEnvironment) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.Environments.updateEnvironment({ body: environment, params: { environmentId: id } })
+        await apiClient.EnvironmentsV2.updateEnvironmentV2({ body: environment, params: { projectId: this.id, environmentId: id } })
           .then((response: any) => extractData(response, 200))
         await this.Environments.list()
         return this.environments
@@ -298,7 +298,7 @@ export class Project implements ProjectV2 {
     delete: async (environmentId: Environment['id']) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.Environments.deleteEnvironment({ params: { environmentId } })
+        await apiClient.EnvironmentsV2.deleteEnvironmentV2({ params: { projectId: this.id, environmentId } })
           .then((response: any) => extractData(response, 204))
         await this.Environments.list()
         return this.environments


### PR DESCRIPTION
## Issues liées

Issue numéro: #2322 (migration API v2). Suite de #2310.

---------

## Quel est le comportement actuel ?

Le client consomme l'API environnements legacy `/api/v1/environments` (contrat `environmentContract`, servi par `apps/server`) : `projectId` est passé en query pour le listing et dans le body à la création, et les routes update/delete ne sont pas scopées au projet.

Par ailleurs, `extractData` (`xhr-client.ts`) construit le message d'erreur avec `body.error ?? body.message`. Cet ordre est calé sur les formats du serveur legacy, mais pas sur celui de NestJS.

## Quel est le nouveau comportement ?

Le client bascule sur l'API v2 `/api/v2/projects/:projectId/environments` (contrat `environmentContractV2`, servi par `apps/server-nestjs`, introduite par #2310) :

- `Project.Environments` (`project-utils.ts`) utilise `apiClient.EnvironmentsV2` : `projectId` passe dans le path pour toutes les opérations, ce qui active le scoping projet côté serveur (404 pour un environnement d'un autre projet) ;
- les types v1 `CreateEnvironmentBody`/`UpdateEnvironmentBody` sont remplacés par `CreateEnvironment`/`UpdateEnvironment` (v2) dans `EnvironmentForm.vue` et `ProjectResources.vue` — même forme, sans `projectId` dans le body, ce qui supprime les `Omit<..., 'projectId'>` ;
- le spec du store projet espionne désormais `listEnvironmentsV2`.

### Correctif `extractData` : priorité à `body.message`

L'ordre devient `body.message ?? body.error ?? 'Erreur inconnue'`. Justification :

- **Legacy, erreurs gérées** (`ErrorResType`) : body `{ message }` → inchangé, `message` est lu.
- **Legacy, erreurs non gérées** (`setErrorHandler`) : body `{ status, error, stack }`, sans champ `message` → inchangé, repli sur `error`.
- **NestJS (v2)** : les `HttpException` sérialisent `{ message, error, statusCode }` où `error` ne contient que la raison HTTP générique (« Forbidden », « Bad Request ») et `message` le vrai message métier (« Le projet est verrouillé », « Environnement introuvable »…). Avec l'ancien ordre, l'utilisateur voyait « Forbidden » au lieu du message utile.

Le flip côté client couvre donc les trois formats sans casser le legacy. L'alternative — un `ExceptionFilter` global côté `server-nestjs` pour normaliser le format d'erreur v2 — reste souhaitable à terme, mais dépasse le périmètre de cette PR de bascule.

Aucun autre changement fonctionnel ni visuel pour l'utilisateur. Le contrat v1 et la route legacy restent en place ; leur retrait se fera dans une PR ultérieure.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Une fois #2318 mergée, cette bascule fait également bénéficier le client du correctif du double comptage des quotas (#1911), porté uniquement par l'API v2.

Limite connue : les erreurs de validation Zod v2 (`ZodValidationPipe` lève `BadRequestException(error.flatten())`, dont le body n'a ni `message` ni `error`) s'affichent encore « Erreur inconnue ». Ce cas sera traité avec le futur filtre d'exceptions global côté `server-nestjs`.

Le retrait des routes v1 legacy et du contrat `environmentContract` viendra dans une PR de nettoyage dédiée, après validation de la bascule.


