### PR TITLE
feat(client): restrict deployment visibility to console admins

### DIFF
--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -62,7 +62,7 @@ const projectClusters = computed(() => ([
 
 const canManageEnvs = computed(() => !props.project.locked && props.asProfile === 'user' && ProjectAuthorized.ManageEnvironments({ projectPermissions: props.project.myPerms }))
 const canManageRepos = computed(() => !props.project.locked && props.asProfile === 'user' && ProjectAuthorized.ManageRepositories({ projectPermissions: props.project.myPerms }))
-const canListDeploy = computed(() => ProjectAuthorized.ListDeployments({ projectPermissions: props.project.myPerms }))
+const canListDeploy = computed(() => AdminAuthorized.Manage(userStore.adminPerms) && ProjectAuthorized.ListDeployments({ projectPermissions: props.project.myPerms }))
 
 watch(selectedRepo, async () => {
   branchName.value = defaultBranchName

--- a/apps/client/src/components/ProjectRoleForm.vue
+++ b/apps/client/src/components/ProjectRoleForm.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { Member, ProjectRoleBigint, ProjectV2 } from '@cpn-console/shared'
 import {
+  AdminAuthorized,
   isManagedRoleType,
   isSystemRoleType,
   PROJECT_PERMS,
@@ -8,6 +9,7 @@ import {
   shallowEqual,
 } from '@cpn-console/shared'
 import { computed, ref } from 'vue'
+import { useUserStore } from '@/stores/user'
 
 const props = defineProps<{
   id: string
@@ -26,6 +28,8 @@ defineEmits<{
   save: [value: Omit<ProjectRoleBigint, 'position' | 'projectId'>]
   cancel: []
 }>()
+
+const userStore = useUserStore()
 const router = useRouter()
 const role = ref({
   ...props,
@@ -37,6 +41,7 @@ const role = ref({
 
 const isSystem = computed(() => isSystemRoleType(role.value.type))
 const isManaged = computed(() => isManagedRoleType(role.value.type))
+const isUserAdmin = computed(() => AdminAuthorized.Manage(userStore.adminPerms))
 
 const isUpdated = computed(() => {
   if (role.value.isEveryone)
@@ -91,27 +96,30 @@ function updateChecked(checked: boolean, value: bigint) {
       />
       <h6>Permissions de la Console</h6>
       <div v-for="scope in projectPermsDetails" :key="scope.name">
-        <p class="mb-3 ml-2 font-bold font-underline">
-          {{ scope.name }}
-        </p>
-        <DsfrCheckbox
-          v-for="perm in scope.perms"
-          :id="`${perm.key}-cbx`"
-          :key="perm.key"
-          value=""
-          :model-value="!!(PROJECT_PERMS[perm.key] & role.permissions)"
-          :label="perm?.label"
-          :hint="perm?.hint"
-          :name="perm.key"
-          :disabled="
-            isSystem
-              || (role.permissions & PROJECT_PERMS.MANAGE && perm.key !== 'MANAGE')
-          "
-          @update:model-value="
-            (checked: boolean) =>
-              updateChecked(checked, PROJECT_PERMS[perm.key])
-          "
-        />
+        <!-- Déploiements is only visible to admin users -->
+        <template v-if="(scope.name !== 'Déploiements') || isUserAdmin ">
+          <p class="mb-3 ml-2 font-bold font-underline">
+            {{ scope.name }}
+          </p>
+          <DsfrCheckbox
+            v-for="perm in scope.perms"
+            :id="`${perm.key}-cbx`"
+            :key="perm.key"
+            value=""
+            :model-value="!!(PROJECT_PERMS[perm.key] & role.permissions)"
+            :label="perm?.label"
+            :hint="perm?.hint"
+            :name="perm.key"
+            :disabled="
+              isSystem
+                || (role.permissions & PROJECT_PERMS.MANAGE && perm.key !== 'MANAGE')
+            "
+            @update:model-value="
+              (checked: boolean) =>
+                updateChecked(checked, PROJECT_PERMS[perm.key])
+            "
+          />
+        </template>
       </div>
       <DsfrButton
         label="Enregistrer"


### PR DESCRIPTION
## Issues liées

Issues numéro: #2332

---------

## Quel est le comportement actuel ?

La fonctionnalité déploiement est visibles par tout utilisateur disposant de la permission projet `ListDeployments`. De plus, le scope de permissions « Déploiements » est affiché dans le formulaire de rôle projet pour tous les utilisateurs.

## Quel est le nouveau comportement ?

La visibilité des déploiements est désormais réservée aux administrateurs de la Console :

- `ProjectResources.vue` : la fonctionnalité des déploiements (`canListDeploy`) requiert désormais également `AdminAuthorized.Manage` en plus de la permission projet `ListDeployments`.
- `ProjectRoleForm.vue` : le scope de permissions « Déploiements » n'est affiché dans le formulaire de rôle que pour les administrateurs de la Console.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

_Aucune._
