### PR TITLE
revert(client): switch environments back from API v2

### DIFF
--- a/apps/client/src/components/EnvironmentForm.vue
+++ b/apps/client/src/components/EnvironmentForm.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type {
   CleanedCluster,
-  CreateEnvironment,
+  CreateEnvironmentBody,
   Environment,
 } from '@cpn-console/shared'
 import {
@@ -46,7 +46,7 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{
-  addEnvironment: [environment: CreateEnvironment]
+  addEnvironment: [environment: Omit<CreateEnvironmentBody, 'projectId'>]
   putEnvironment: [environment: Pick<Environment, 'cpu' | 'gpu' | 'memory' | 'autosync'>]
   deleteEnvironment: [environmentId: Environment['id']]
   cancel: []

--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CleanedCluster, Cluster, CreateEnvironment, Environment, Repo, Stage, UpdateEnvironment, Zone } from '@cpn-console/shared'
+import type { CleanedCluster, Cluster, CreateEnvironmentBody, Environment, Repo, Stage, UpdateEnvironmentBody, Zone } from '@cpn-console/shared'
 import type { Project } from '@/utils/project-utils.js'
 import { logger } from '@cpn-console/logger/browser'
 import { AdminAuthorized, ProjectAuthorized, projectIsLockedInfo } from '@cpn-console/shared'
@@ -68,7 +68,7 @@ watch(selectedRepo, async () => {
   branchName.value = defaultBranchName
 })
 
-async function putEnvironment(environment: UpdateEnvironment, envId: Environment['id']) {
+async function putEnvironment(environment: UpdateEnvironmentBody, envId: Environment['id']) {
   selectedEnv.value = undefined
   if (!props.project.locked) {
     props.project.Environments.update(envId, environment)
@@ -86,7 +86,7 @@ async function deleteEnvironment(environmentId: Environment['id']) {
   }
 }
 
-async function addEnvironment(environment: CreateEnvironment) {
+async function addEnvironment(environment: Omit<CreateEnvironmentBody, 'id' | 'projectId'>) {
   newResource.value = undefined
   if (!props.project.locked) {
     props.project.Environments.create(environment)
@@ -396,7 +396,7 @@ async function copyToClipboard(text: string) {
       :is-editable="false"
       :is-project-locked="project.locked"
       :can-manage="canManageEnvs || (AdminAuthorized.Manage(userStore.adminPerms) && asProfile === 'admin')"
-      @put-environment="(environmentUpdate: UpdateEnvironment) => putEnvironment(environmentUpdate, selectedEnv!.id)"
+      @put-environment="(environmentUpdate: UpdateEnvironmentBody) => putEnvironment(environmentUpdate, selectedEnv!.id)"
       @delete-environment="() => deleteEnvironment(selectedEnv!.id)"
       @cancel="selectedEnv = undefined"
     />
@@ -406,7 +406,7 @@ async function copyToClipboard(text: string) {
       :available-clusters="projectClusters"
       :can-manage="canManageEnvs"
       is-editable
-      @add-environment="(environment: CreateEnvironment) => addEnvironment(environment)"
+      @add-environment="(environment: Omit<CreateEnvironmentBody, 'id' | 'projectId'>) => addEnvironment(environment)"
       @cancel="newResource = undefined"
     />
     <template

--- a/apps/client/src/stores/project.spec.ts
+++ b/apps/client/src/stores/project.spec.ts
@@ -1,12 +1,12 @@
 import { createRandomDbSetup, getRandomMember, getRandomProject } from '@cpn-console/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { apiClient } from '../api/xhr-client.js'
-import { useProjectStore } from './project.js'
+import { apiClient } from '../api/xhr-client'
+import { useProjectStore } from './project'
 
 const getProject = vi.spyOn(apiClient.Projects, 'getProject')
 const listProjects = vi.spyOn(apiClient.Projects, 'listProjects')
-const listEnvironments = vi.spyOn(apiClient.EnvironmentsV2, 'listEnvironmentsV2')
+const listEnvironments = vi.spyOn(apiClient.Environments, 'listEnvironments')
 const listRepositories = vi.spyOn(apiClient.Repositories, 'listRepositories')
 const apiClientPost = vi.spyOn(apiClient.Projects, 'createProject')
 

--- a/apps/client/src/utils/project-utils.ts
+++ b/apps/client/src/utils/project-utils.ts
@@ -1,6 +1,6 @@
 import type {
   CreateDeploymentBody,
-  CreateEnvironment,
+  CreateEnvironmentBody,
   CreateRepositoryBody,
   Deployment,
   Environment,
@@ -16,7 +16,7 @@ import type {
   RepositoryParams,
   Role,
   UpdateDeploymentBody,
-  UpdateEnvironment,
+  UpdateEnvironmentBody,
   UpdateRepositoryBody,
   User,
 } from '@cpn-console/shared'
@@ -274,22 +274,22 @@ export class Project implements ProjectV2 {
 
   Environments = {
     list: async () => {
-      this.environments.value = await apiClient.EnvironmentsV2.listEnvironmentsV2({ params: { projectId: this.id } })
+      this.environments.value = await apiClient.Environments.listEnvironments({ query: { projectId: this.id } })
         .then((response: any) => extractData(response, 200))
       return this.environments.value
     },
-    create: async (envData: CreateEnvironment) => {
+    create: async (envData: Omit<CreateEnvironmentBody, 'projectId'>) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.EnvironmentsV2.createEnvironmentV2({ params: { projectId: this.id }, body: envData })
+        await apiClient.Environments.createEnvironment({ body: { ...envData, projectId: this.id } })
           .then((response: any) => extractData(response, 201))
         return this.Environments.list()
       } finally { callback() }
     },
-    update: async (id: Environment['id'], environment: UpdateEnvironment) => {
+    update: async (id: Environment['id'], environment: UpdateEnvironmentBody) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.EnvironmentsV2.updateEnvironmentV2({ body: environment, params: { projectId: this.id, environmentId: id } })
+        await apiClient.Environments.updateEnvironment({ body: environment, params: { environmentId: id } })
           .then((response: any) => extractData(response, 200))
         await this.Environments.list()
         return this.environments
@@ -298,7 +298,7 @@ export class Project implements ProjectV2 {
     delete: async (environmentId: Environment['id']) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.EnvironmentsV2.deleteEnvironmentV2({ params: { projectId: this.id, environmentId } })
+        await apiClient.Environments.deleteEnvironment({ params: { environmentId } })
           .then((response: any) => extractData(response, 204))
         await this.Environments.list()
         return this.environments


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

Le formulaire d'environnements et les ressources projet utilisent les endpoints API v2 (migration introduite dans le commit `20d97dd`).

## Quel est le nouveau comportement ?

Revert de la migration des environnements vers l'API v2. Les endpoints précédents sont restaurés dans `EnvironmentForm.vue`, `ProjectResources.vue` et `project-utils.ts` (ainsi que le spec associé `project.spec.ts`).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Revert partiel du commit `20d97dd` — seul `xhr-client.ts` n'est pas reverté.
