### PR TITLE
docs(nestjs): correct migration stats in MODULARISATION-STATUT

### DIFF
--- a/apps/server-nestjs/documentation/Modularisation-de-console-server/MODULARISATION-STATUT.md
+++ b/apps/server-nestjs/documentation/Modularisation-de-console-server/MODULARISATION-STATUT.md
@@ -1,7 +1,7 @@
 # État de la modularisation Backend → NestJS
 
 > 📋 **Ce fichier est mis à jour en temps réel**
-> Dernière mise à jour : **2026-06-16**
+> Dernière mise à jour : **2026-07-23**
 
 ---
 
@@ -9,7 +9,7 @@
 
 ![Progress](https://progress-bar.dev/7/?title=modularisation&width=400)
 
-**~7%** complété (1/18 modules métier migrés, 5/75 routes)
+**~60%** complété (16/18 modules métier migrés, 45/75 routes)
 
 ---
 
@@ -17,9 +17,9 @@
 
 | Statut | Nombre de modules | % du total |
 |--------|-------------------|------------|
-| ✅ Migré | 1 (ServiceChain) | ~6% |
+| ✅ Migré | 16 | ~89% |
 | 🚧 En cours | 0 | 0% |
-| 📅 Planifié | 17 | ~94% |
+| 📅 Planifié | 2 | ~11% |
 | ⏳ En attente de cartographie | 0 | 0% |
 
 ---
@@ -140,9 +140,9 @@ créés :
 ### Routes par statut
 
 - **Total** : ~75 routes métier
-- **Migrés** : 5 (~7%)
+- **Migrés** : 45 (~60%)
 - **En cours** : 0 (0%)
-- **Restants** : ~70 (~93%)
+- **Restants** : ~30 (~40%)
 
 ---
 


### PR DESCRIPTION
## Issues liées

#2358

## Quel est le comportement actuel ?

Le fichier `apps/server-nestjs/documentation/Modularisation-de-console-server/MODULARISATION-STATUT.md` indique des statistiques obsolètes : ~7 % (1/18 modules métier migrés, 5/75 routes). Ces chiffres sous-estiment fortement l'état réel de la migration et faussent le suivi des décisions listées dans #2358.

## Quel est le nouveau comportement ?

Correction des statistiques pour refléter l'état réel vérifié du code :

- **~60 %** complété (16/18 modules métier migrés, 45/75 routes)
- Tableau « Vue d'ensemble » : 16 migrés (~89 %), 2 planifiés (~11 %)
- Section « Routes par statut » : 45 migrés (~60 %), ~30 restants (~40 %)
- Date de dernière mise à jour : 2026-07-23

Vérifié par grep direct des contrôleurs NestJS (`apps/server-nestjs/src/modules/*`) : 16 contrôleurs, 45 décorateurs de route (`@Get/@Post/@Put/@Delete/@Patch/@All`).

## Cette PR introduit-elle un breaking change ?

Non. Modification de documentation uniquement, aucun code modifié.

## Autres informations

N/A