### PR TITLE
fix(ci): merge digests after both arch image builds

### DIFF
--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -38,11 +38,6 @@ on:
         description: ID number of the pull request to use for deploy preview app
         required: false
         type: string
-      SKIP_MERGE:
-        description: Skip merge step when called from a parent release workflow that merges later
-        required: false
-        type: boolean
-        default: false
     secrets:
       ARGOCD_TOKEN:
         required: false
@@ -77,11 +72,6 @@ on:
         description: ID number of the pull request to use for deploy preview app
         required: false
         type: string
-      SKIP_MERGE:
-        description: Skip merge step when called from a parent release workflow that merges later
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   matrix:
@@ -186,7 +176,6 @@ jobs:
 
   merge:
     name: Merge digest
-    if: ${{ !inputs.SKIP_MERGE }}
     runs-on: ubuntu-latest
     needs:
       - matrix
@@ -255,7 +244,7 @@ jobs:
 
           RESPONSE_CODE=$(curl -s -w "%{http_code}" -o >(RESPONSE_BODY=$(cat)) -X POST ${{ vars.ARGOCD_URL }}/api/v1/applications/${{ steps.feed-template.outputs.ARGOCD_APP_NAME }}/sync \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer *** secrets.ARGOCD_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.ARGOCD_TOKEN }}" \
             -d '${{ steps.feed-template.outputs.ARGOCD_SYNC_PAYLOAD }}')
 
           echo "HTTP response code: $RESPONSE_CODE"

--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -35,6 +35,10 @@ on:
         required: true
         type: boolean
       PR_NUMBER:
+      SKIP_MERGE:
+        required: false
+        type: boolean
+        default: false
         required: false
         type: string
     secrets:
@@ -68,6 +72,10 @@ on:
         type: boolean
         default: false
       PR_NUMBER:
+      SKIP_MERGE:
+        required: false
+        type: boolean
+        default: false
         description: ID number of the pull request to use for deploy preview app
         required: false
         type: string
@@ -174,6 +182,7 @@ jobs:
           retention-days: 1
 
   merge:
+    if: ${{ !inputs.SKIP_MERGE }}
     name: Merge digest
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -39,6 +39,7 @@ on:
         required: false
         type: string
       SKIP_MERGE:
+        description: Skip merge step when called from a parent release workflow that merges later
         required: false
         type: boolean
         default: false
@@ -256,6 +257,7 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer *** secrets.ARGOCD_TOKEN }}" \
             -d '${{ steps.feed-template.outputs.ARGOCD_SYNC_PAYLOAD }}')
+
           echo "HTTP response code: $RESPONSE_CODE"
 
           if [ "$RESPONSE_CODE" -ne 200 ]; then

--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -38,6 +38,10 @@ on:
         description: ID number of the pull request to use for deploy preview app
         required: false
         type: string
+      SKIP_MERGE:
+        required: false
+        type: boolean
+        default: false
     secrets:
       ARGOCD_TOKEN:
         required: false
@@ -72,6 +76,11 @@ on:
         description: ID number of the pull request to use for deploy preview app
         required: false
         type: string
+      SKIP_MERGE:
+        description: Skip merge step when called from a parent release workflow that merges later
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   matrix:
@@ -176,6 +185,7 @@ jobs:
 
   merge:
     name: Merge digest
+    if: ${{ !inputs.SKIP_MERGE }}
     runs-on: ubuntu-latest
     needs:
       - matrix

--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -35,10 +35,7 @@ on:
         required: true
         type: boolean
       PR_NUMBER:
-      SKIP_MERGE:
-        required: false
-        type: boolean
-        default: false
+        description: ID number of the pull request to use for deploy preview app
         required: false
         type: string
     secrets:
@@ -72,10 +69,6 @@ on:
         type: boolean
         default: false
       PR_NUMBER:
-      SKIP_MERGE:
-        required: false
-        type: boolean
-        default: false
         description: ID number of the pull request to use for deploy preview app
         required: false
         type: string
@@ -182,7 +175,6 @@ jobs:
           retention-days: 1
 
   merge:
-    if: ${{ !inputs.SKIP_MERGE }}
     name: Merge digest
     runs-on: ubuntu-latest
     needs:
@@ -252,9 +244,8 @@ jobs:
 
           RESPONSE_CODE=$(curl -s -w "%{http_code}" -o >(RESPONSE_BODY=$(cat)) -X POST ${{ vars.ARGOCD_URL }}/api/v1/applications/${{ steps.feed-template.outputs.ARGOCD_APP_NAME }}/sync \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.ARGOCD_TOKEN }}" \
+            -H "Authorization: Bearer *** secrets.ARGOCD_TOKEN }}" \
             -d '${{ steps.feed-template.outputs.ARGOCD_SYNC_PAYLOAD }}')
-
           echo "HTTP response code: $RESPONSE_CODE"
 
           if [ "$RESPONSE_CODE" -ne 200 ]; then

--- a/.github/workflows/workflow-create-or-update-release.yml
+++ b/.github/workflows/workflow-create-or-update-release.yml
@@ -83,28 +83,43 @@ jobs:
       - build-amd64
       - build-arm64
     steps:
+      - name: Checks-out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Generate matrix
+        id: build-matrix
+        run: |
+          echo "BUILD_MATRIX=$(jq -c . < ./ci/matrix-docker.json)" >> $GITHUB_OUTPUT
+
+      - name: Get lowercase branch name
+        id: lower-branch
+        run: |
+          echo "LOWER_BRANCH=$(echo '${{ github.head_ref || github.ref_name }}' | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: digests-*.*.digest
           path: /tmp/digests
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server
+          images: ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/${{ matrix.images.name }}
           tags: |
+            type=raw,value=${{ steps.lower-branch.outputs.LOWER_BRANCH }},enable=${{ github.head_ref != 'main' }}
             type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}.${{ needs.release.outputs.patch-tag }}
-            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}
-            type=raw,value=${{ needs.release.outputs.major-tag }}
+            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }},enable=${{ needs.release.outputs.major-tag != '' && needs.release.outputs.minor-tag != '' }}
+            type=raw,value=${{ needs.release.outputs.major-tag }},enable=${{ needs.release.outputs.major-tag != '' }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ needs.expose-vars.outputs.REGISTRY }}
           username: ${{ github.actor }}
@@ -112,14 +127,18 @@ jobs:
           logout: true
 
       - name: Create manifest list and push
-        working-directory: /tmp/digests
+        working-directory: /tmp/digests/${{ matrix.images.name }}
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server@sha256:%s ' *)
+            $(printf '${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/${{ matrix.images.name }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/${{ matrix.images.name }}:${{ steps.meta.outputs.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        images: ${{ fromJSON(steps.build-matrix.outputs.BUILD_MATRIX) }}
 
   update-chart:
     runs-on: ubuntu-latest
@@ -128,6 +147,7 @@ jobs:
       - release
       - build-amd64
       - build-arm64
+      - merge-manifests
     steps:
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/workflow-create-or-update-release.yml
+++ b/.github/workflows/workflow-create-or-update-release.yml
@@ -53,7 +53,6 @@ jobs:
       BUILD_AMD64: ${{ needs.expose-vars.outputs.BUILD_AMD64 == 'true' }}
       BUILD_ARM64: false
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
-      SKIP_MERGE: true
 
   build-arm64:
     uses: ./.github/workflows/job-build.yml
@@ -71,74 +70,6 @@ jobs:
       BUILD_AMD64: false
       BUILD_ARM64: ${{ needs.expose-vars.outputs.BUILD_ARM64 == 'true' }}
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
-      SKIP_MERGE: true
-
-  merge-manifests:
-    name: Merge digest
-    runs-on: ubuntu-latest
-    if: ${{ needs.release.outputs.release-created == 'true' }}
-    needs:
-      - expose-vars
-      - release
-      - build-amd64
-      - build-arm64
-    steps:
-      - name: Checks-out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Generate matrix
-        id: build-matrix
-        run: |
-          echo "BUILD_MATRIX=$(jq -c . < ./ci/matrix-docker.json)" >> $GITHUB_OUTPUT
-
-      - name: Get lowercase branch name
-        id: lower-branch
-        run: |
-          echo "LOWER_BRANCH=$(echo '${{ github.head_ref || github.ref_name }}' | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: digests-*.*.digest
-          path: /tmp/digests
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
-        with:
-          images: ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/${{ matrix.images.name }}
-          tags: |
-            type=raw,value=${{ steps.lower-branch.outputs.LOWER_BRANCH }},enable=${{ github.head_ref != 'main' }}
-            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}.${{ needs.release.outputs.patch-tag }}
-            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }},enable=${{ needs.release.outputs.major-tag != '' && needs.release.outputs.minor-tag != '' }}
-            type=raw,value=${{ needs.release.outputs.major-tag }},enable=${{ needs.release.outputs.major-tag != '' }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ needs.expose-vars.outputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          logout: true
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests/${{ matrix.images.name }}
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/${{ matrix.images.name }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/${{ matrix.images.name }}:${{ steps.meta.outputs.version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        images: ${{ fromJSON(steps.build-matrix.outputs.BUILD_MATRIX) }}
 
   update-chart:
     runs-on: ubuntu-latest
@@ -147,7 +78,6 @@ jobs:
       - release
       - build-amd64
       - build-arm64
-      - merge-manifests
     steps:
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/workflow-create-or-update-release.yml
+++ b/.github/workflows/workflow-create-or-update-release.yml
@@ -53,6 +53,7 @@ jobs:
       BUILD_AMD64: ${{ needs.expose-vars.outputs.BUILD_AMD64 == 'true' }}
       BUILD_ARM64: false
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
+      SKIP_MERGE: true
 
   build-arm64:
     uses: ./.github/workflows/job-build.yml
@@ -70,6 +71,55 @@ jobs:
       BUILD_AMD64: false
       BUILD_ARM64: ${{ needs.expose-vars.outputs.BUILD_ARM64 == 'true' }}
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
+      SKIP_MERGE: true
+
+  merge-manifests:
+    name: Merge digest
+    runs-on: ubuntu-latest
+    if: ${{ needs.release.outputs.release-created == 'true' }}
+    needs:
+      - expose-vars
+      - release
+      - build-amd64
+      - build-arm64
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: digests-*.*.digest
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server
+          tags: |
+            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}.${{ needs.release.outputs.patch-tag }}
+            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}
+            type=raw,value=${{ needs.release.outputs.major-tag }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ${{ needs.expose-vars.outputs.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: true
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server:${{ steps.meta.outputs.version }}
 
   update-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-create-or-update-release.yml
+++ b/.github/workflows/workflow-create-or-update-release.yml
@@ -37,7 +37,7 @@ jobs:
   release:
     uses: ./.github/workflows/job-release-please.yml
 
-  build-amd64:
+  build:
     uses: ./.github/workflows/job-build.yml
     if: ${{ needs.release.outputs.release-created == 'true' }}
     needs:
@@ -51,23 +51,6 @@ jobs:
       MINOR_TAG: ${{ needs.release.outputs.minor-tag }}
       PATCH_TAG: ${{ needs.release.outputs.patch-tag }}
       BUILD_AMD64: ${{ needs.expose-vars.outputs.BUILD_AMD64 == 'true' }}
-      BUILD_ARM64: false
-      USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
-
-  build-arm64:
-    uses: ./.github/workflows/job-build.yml
-    if: ${{ needs.release.outputs.release-created == 'true' }}
-    needs:
-      - expose-vars
-      - release
-    with:
-      REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
-      NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
-      TAG: ${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}.${{ needs.release.outputs.patch-tag }}
-      MAJOR_TAG: ${{ needs.release.outputs.major-tag }}
-      MINOR_TAG: ${{ needs.release.outputs.minor-tag }}
-      PATCH_TAG: ${{ needs.release.outputs.patch-tag }}
-      BUILD_AMD64: false
       BUILD_ARM64: ${{ needs.expose-vars.outputs.BUILD_ARM64 == 'true' }}
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
 
@@ -76,8 +59,7 @@ jobs:
     needs:
       - expose-vars
       - release
-      - build-amd64
-      - build-arm64
+      - build
     steps:
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/workflow-create-or-update-release.yml
+++ b/.github/workflows/workflow-create-or-update-release.yml
@@ -53,7 +53,6 @@ jobs:
       BUILD_AMD64: ${{ needs.expose-vars.outputs.BUILD_AMD64 == 'true' }}
       BUILD_ARM64: false
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
-      SKIP_MERGE: true
 
   build-arm64:
     uses: ./.github/workflows/job-build.yml
@@ -71,55 +70,6 @@ jobs:
       BUILD_AMD64: false
       BUILD_ARM64: ${{ needs.expose-vars.outputs.BUILD_ARM64 == 'true' }}
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
-      SKIP_MERGE: true
-
-  merge-manifests:
-    name: Merge digest
-    runs-on: ubuntu-latest
-    if: ${{ needs.release.outputs.release-created == 'true' }}
-    needs:
-      - expose-vars
-      - release
-      - build-amd64
-      - build-arm64
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          pattern: digests-*.*.digest
-          path: /tmp/digests
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
-        with:
-          images: ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server
-          tags: |
-            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}.${{ needs.release.outputs.patch-tag }}
-            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}
-            type=raw,value=${{ needs.release.outputs.major-tag }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-        with:
-          registry: ${{ needs.expose-vars.outputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          logout: true
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server:${{ steps.meta.outputs.version }}
 
   update-chart:
     runs-on: ubuntu-latest
@@ -127,6 +77,7 @@ jobs:
       - expose-vars
       - release
       - build-amd64
+      - build-arm64
     steps:
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/workflow-create-or-update-release.yml
+++ b/.github/workflows/workflow-create-or-update-release.yml
@@ -37,7 +37,7 @@ jobs:
   release:
     uses: ./.github/workflows/job-release-please.yml
 
-  build:
+  build-amd64:
     uses: ./.github/workflows/job-build.yml
     if: ${{ needs.release.outputs.release-created == 'true' }}
     needs:
@@ -51,15 +51,83 @@ jobs:
       MINOR_TAG: ${{ needs.release.outputs.minor-tag }}
       PATCH_TAG: ${{ needs.release.outputs.patch-tag }}
       BUILD_AMD64: ${{ needs.expose-vars.outputs.BUILD_AMD64 == 'true' }}
+      BUILD_ARM64: false
+      USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
+      SKIP_MERGE: true
+
+  build-arm64:
+    uses: ./.github/workflows/job-build.yml
+    if: ${{ needs.release.outputs.release-created == 'true' }}
+    needs:
+      - expose-vars
+      - release
+    with:
+      REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
+      NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
+      TAG: ${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}.${{ needs.release.outputs.patch-tag }}
+      MAJOR_TAG: ${{ needs.release.outputs.major-tag }}
+      MINOR_TAG: ${{ needs.release.outputs.minor-tag }}
+      PATCH_TAG: ${{ needs.release.outputs.patch-tag }}
+      BUILD_AMD64: false
       BUILD_ARM64: ${{ needs.expose-vars.outputs.BUILD_ARM64 == 'true' }}
       USE_QEMU: ${{ needs.expose-vars.outputs.USE_QEMU == 'true' }}
+      SKIP_MERGE: true
+
+  merge-manifests:
+    name: Merge digest
+    runs-on: ubuntu-latest
+    if: ${{ needs.release.outputs.release-created == 'true' }}
+    needs:
+      - expose-vars
+      - release
+      - build-amd64
+      - build-arm64
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: digests-*.*.digest
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server
+          tags: |
+            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}.${{ needs.release.outputs.patch-tag }}
+            type=raw,value=${{ needs.release.outputs.major-tag }}.${{ needs.release.outputs.minor-tag }}
+            type=raw,value=${{ needs.release.outputs.major-tag }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ${{ needs.expose-vars.outputs.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: true
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ needs.expose-vars.outputs.REGISTRY }}/${{ needs.expose-vars.outputs.NAMESPACE }}/server:${{ steps.meta.outputs.version }}
 
   update-chart:
     runs-on: ubuntu-latest
     needs:
       - expose-vars
       - release
-      - build
+      - build-amd64
+      - build-arm64
     steps:
       - name: Generate a token
         id: generate-token


### PR DESCRIPTION
## Related Issues

#2364 

## Problem
The release workflow currently lets each per-architecture build job push its own digest/merge path independently. That can leave separate arch-specific manifests in GHCR and inconsistent image state after release builds.

## Fix
Keep the existing `build-amd64` and `build-arm64` splits, but add one final `merge-manifests` job that waits for both builds, downloads all pushed digests together, and runs `docker buildx imagetools create` once to produce a single merged manifest list with the expected release tags.

## Notes
- `job-build.yml` gets a new optional `SKIP_MERGE` input; per-arch builds set it to `true`.
- The new merge job reuses the existing digest artifact naming and Docker metadata/tagging flow.
- Default/PR/merge-queue workflows remain untouched here.
