### PR TITLE
feat(deployment): add DeploymentValueSource model

### DIFF
--- a/apps/server-nestjs/src/prisma/migrations/20260728095729_add_deployment_value_sources/migration.sql
+++ b/apps/server-nestjs/src/prisma/migrations/20260728095729_add_deployment_value_sources/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "DeploymentInternalValueSource" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deploymentSourceId" UUID NOT NULL,
+    "order" INTEGER NOT NULL,
+    "path" TEXT NOT NULL DEFAULT '',
+
+    CONSTRAINT "DeploymentInternalValueSource_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DeploymentExternalValueSource" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deploymentSourceId" UUID NOT NULL,
+    "order" INTEGER NOT NULL,
+    "path" TEXT NOT NULL DEFAULT '',
+    "ref" TEXT NOT NULL,
+    "targetRevision" TEXT NOT NULL DEFAULT '',
+    "repositoryId" UUID NOT NULL,
+
+    CONSTRAINT "DeploymentExternalValueSource_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeploymentInternalValueSource_id_key" ON "DeploymentInternalValueSource"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeploymentExternalValueSource_id_key" ON "DeploymentExternalValueSource"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeploymentExternalValueSource_deploymentSourceId_key" ON "DeploymentExternalValueSource"("deploymentSourceId");
+
+-- AddForeignKey
+ALTER TABLE "DeploymentInternalValueSource" ADD CONSTRAINT "DeploymentInternalValueSource_deploymentSourceId_fkey" FOREIGN KEY ("deploymentSourceId") REFERENCES "DeploymentSource"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DeploymentExternalValueSource" ADD CONSTRAINT "DeploymentExternalValueSource_deploymentSourceId_fkey" FOREIGN KEY ("deploymentSourceId") REFERENCES "DeploymentSource"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DeploymentExternalValueSource" ADD CONSTRAINT "DeploymentExternalValueSource_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/server-nestjs/src/prisma/schema/project.prisma
+++ b/apps/server-nestjs/src/prisma/schema/project.prisma
@@ -12,17 +12,43 @@ model Deployment {
 }
 
 model DeploymentSource {
-  id              String               @id @unique @default(uuid()) @db.Uuid
-  createdAt       DateTime             @default(now())
-  updatedAt       DateTime             @updatedAt
-  deploymentId    String               @db.Uuid
-  repositoryId    String               @db.Uuid
-  type            DeploymentSourceType
-  targetRevision  String               @default("")
-  path            String               @default("")
-  helmValuesFiles String               @default("")
-  repository      Repository           @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
-  deployment      Deployment           @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
+  id                   String                          @id @unique @default(uuid()) @db.Uuid
+  createdAt            DateTime                        @default(now())
+  updatedAt            DateTime                        @updatedAt
+  deploymentId         String                          @db.Uuid
+  repositoryId         String                          @db.Uuid
+  type                 DeploymentSourceType
+  targetRevision       String                          @default("")
+  path                 String                          @default("")
+  helmValuesFiles      String                          @default("")
+  repository           Repository                      @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+  deployment           Deployment                      @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
+  internalValueSources DeploymentInternalValueSource[]
+  externalValueSource  DeploymentExternalValueSource?
+}
+
+model DeploymentInternalValueSource {
+  id                 String           @id @unique @default(uuid()) @db.Uuid
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+  deploymentSourceId String           @db.Uuid
+  order              Int
+  path               String           @default("")
+  deploymentSource   DeploymentSource @relation(fields: [deploymentSourceId], references: [id], onDelete: Cascade)
+}
+
+model DeploymentExternalValueSource {
+  id                 String           @id @unique @default(uuid()) @db.Uuid
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+  deploymentSourceId String           @unique @db.Uuid
+  order              Int
+  path               String           @default("")
+  ref                String
+  targetRevision     String           @default("")
+  repositoryId       String           @db.Uuid
+  deploymentSource   DeploymentSource @relation(fields: [deploymentSourceId], references: [id], onDelete: Cascade)
+  repository         Repository       @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
 }
 
 model Environment {
@@ -46,20 +72,21 @@ model Environment {
 }
 
 model Repository {
-  id                String             @id @default(uuid()) @db.Uuid
-  projectId         String             @db.Uuid
-  internalRepoName  String
-  externalRepoUrl   String             @default("")
-  externalUserName  String             @default("")
-  isInfra           Boolean            @default(false)
-  isPrivate         Boolean            @default(false)
-  deployRevision    String             @default("")
-  deployPath        String             @default("")
-  helmValuesFiles   String             @default("")
-  createdAt         DateTime           @default(now())
-  updatedAt         DateTime           @updatedAt
-  project           Project            @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  deploymentSources DeploymentSource[]
+  id                             String                          @id @default(uuid()) @db.Uuid
+  projectId                      String                          @db.Uuid
+  internalRepoName               String
+  externalRepoUrl                String                          @default("")
+  externalUserName               String                          @default("")
+  isInfra                        Boolean                         @default(false)
+  isPrivate                      Boolean                         @default(false)
+  deployRevision                 String                          @default("")
+  deployPath                     String                          @default("")
+  helmValuesFiles                String                          @default("")
+  createdAt                      DateTime                        @default(now())
+  updatedAt                      DateTime                        @updatedAt
+  project                        Project                         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  deploymentSources              DeploymentSource[]
+  deploymentExternalValueSources DeploymentExternalValueSource[]
 }
 
 model ProjectClusterHistory {

--- a/apps/server/src/prisma/migrations/20260728095729_add_deployment_value_sources/migration.sql
+++ b/apps/server/src/prisma/migrations/20260728095729_add_deployment_value_sources/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "DeploymentInternalValueSource" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deploymentSourceId" UUID NOT NULL,
+    "order" INTEGER NOT NULL,
+    "path" TEXT NOT NULL DEFAULT '',
+
+    CONSTRAINT "DeploymentInternalValueSource_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DeploymentExternalValueSource" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deploymentSourceId" UUID NOT NULL,
+    "order" INTEGER NOT NULL,
+    "path" TEXT NOT NULL DEFAULT '',
+    "ref" TEXT NOT NULL,
+    "targetRevision" TEXT NOT NULL DEFAULT '',
+    "repositoryId" UUID NOT NULL,
+
+    CONSTRAINT "DeploymentExternalValueSource_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeploymentInternalValueSource_id_key" ON "DeploymentInternalValueSource"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeploymentExternalValueSource_id_key" ON "DeploymentExternalValueSource"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeploymentExternalValueSource_deploymentSourceId_key" ON "DeploymentExternalValueSource"("deploymentSourceId");
+
+-- AddForeignKey
+ALTER TABLE "DeploymentInternalValueSource" ADD CONSTRAINT "DeploymentInternalValueSource_deploymentSourceId_fkey" FOREIGN KEY ("deploymentSourceId") REFERENCES "DeploymentSource"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DeploymentExternalValueSource" ADD CONSTRAINT "DeploymentExternalValueSource_deploymentSourceId_fkey" FOREIGN KEY ("deploymentSourceId") REFERENCES "DeploymentSource"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DeploymentExternalValueSource" ADD CONSTRAINT "DeploymentExternalValueSource_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "Repository"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/server/src/prisma/schema/project.prisma
+++ b/apps/server/src/prisma/schema/project.prisma
@@ -12,17 +12,43 @@ model Deployment {
 }
 
 model DeploymentSource {
-  id              String               @id @unique @default(uuid()) @db.Uuid
-  createdAt       DateTime             @default(now())
-  updatedAt       DateTime             @updatedAt
-  deploymentId    String               @db.Uuid
-  repositoryId    String               @db.Uuid
-  type            DeploymentSourceType
-  targetRevision  String               @default("")
-  path            String               @default("")
-  helmValuesFiles String               @default("")
-  repository      Repository           @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
-  deployment      Deployment           @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
+  id                   String                          @id @unique @default(uuid()) @db.Uuid
+  createdAt            DateTime                        @default(now())
+  updatedAt            DateTime                        @updatedAt
+  deploymentId         String                          @db.Uuid
+  repositoryId         String                          @db.Uuid
+  type                 DeploymentSourceType
+  targetRevision       String                          @default("")
+  path                 String                          @default("")
+  helmValuesFiles      String                          @default("")
+  repository           Repository                      @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+  deployment           Deployment                      @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
+  internalValueSources DeploymentInternalValueSource[]
+  externalValueSource  DeploymentExternalValueSource?
+}
+
+model DeploymentInternalValueSource {
+  id                 String           @id @unique @default(uuid()) @db.Uuid
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+  deploymentSourceId String           @db.Uuid
+  order              Int
+  path               String           @default("")
+  deploymentSource   DeploymentSource @relation(fields: [deploymentSourceId], references: [id], onDelete: Cascade)
+}
+
+model DeploymentExternalValueSource {
+  id                 String           @id @unique @default(uuid()) @db.Uuid
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+  deploymentSourceId String           @unique @db.Uuid
+  order              Int
+  path               String           @default("")
+  ref                String
+  targetRevision     String           @default("")
+  repositoryId       String           @db.Uuid
+  deploymentSource   DeploymentSource @relation(fields: [deploymentSourceId], references: [id], onDelete: Cascade)
+  repository         Repository       @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
 }
 
 model Environment {
@@ -46,20 +72,21 @@ model Environment {
 }
 
 model Repository {
-  id                String             @id @default(uuid()) @db.Uuid
-  projectId         String             @db.Uuid
-  internalRepoName  String
-  externalRepoUrl   String             @default("")
-  externalUserName  String             @default("")
-  isInfra           Boolean            @default(false)
-  isPrivate         Boolean            @default(false)
-  deployRevision    String             @default("")
-  deployPath        String             @default("")
-  helmValuesFiles   String             @default("")
-  createdAt         DateTime           @default(now())
-  updatedAt         DateTime           @updatedAt
-  project           Project            @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  deploymentSources DeploymentSource[]
+  id                             String                          @id @default(uuid()) @db.Uuid
+  projectId                      String                          @db.Uuid
+  internalRepoName               String
+  externalRepoUrl                String                          @default("")
+  externalUserName               String                          @default("")
+  isInfra                        Boolean                         @default(false)
+  isPrivate                      Boolean                         @default(false)
+  deployRevision                 String                          @default("")
+  deployPath                     String                          @default("")
+  helmValuesFiles                String                          @default("")
+  createdAt                      DateTime                        @default(now())
+  updatedAt                      DateTime                        @updatedAt
+  project                        Project                         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  deploymentSources              DeploymentSource[]
+  deploymentExternalValueSources DeploymentExternalValueSource[]
 }
 
 model ProjectClusterHistory {

--- a/packages/test-utils/src/imports/data.ts
+++ b/packages/test-utils/src/imports/data.ts
@@ -2302,4 +2302,6 @@ export const data = {
   ],
   deployment: [],
   deploymentSource: [],
+  deploymentExternalValueSource: [],
+  deploymentInternalValueSource: [],
 }


### PR DESCRIPTION
## Issues liées

Issues numéro: #2247

---------

## Quel est le comportement actuel ?

Une source de déploiement (`DeploymentSource`) ne permet pas de déclarer de
sources de valeurs (value sources) supplémentaires — internes ou externes —
pour surcharger les valeurs du chart.

## Quel est le nouveau comportement ?

- Ajout de deux modèles reliés à `DeploymentSource` :
  - `DeploymentInternalValueSource` (relation « many ») : `order` + `path`,
    pour référencer des fichiers de valeurs internes à la source de déploiement.
  - `DeploymentExternalValueSource` (relation optionnelle « one », contrainte
    d'unicité sur `deploymentSourceId`) : `order`, `path`, `ref`,
    `targetRevision` et un `repositoryId` **obligatoire** (relation vers
    `Repository`), pour référencer des valeurs externes.
- Les deux tables sont supprimées en cascade avec leur `DeploymentSource`
  parent (et l'externe également avec son `Repository`).
- `Repository` expose désormais `deploymentExternalValueSources`.
- Migrations Prisma correspondantes ajoutées sur les schémas `server-nestjs`
  et `server` (legacy).
- Jeux de données de test (`test-utils`) complétés avec les nouvelles
  collections `deploymentInternalValueSource` / `deploymentExternalValueSource`.

## Cette PR introduit-elle un breaking change ?

Non. Ajout de nouvelles tables uniquement, aucune modification destructive du
schéma existant.

## Autres informations

Ce changement s'adapte au nouveau helm-chart
(https://github.com/cloud-pi-native/helm-charts) afin de pouvoir ajouter des
valeurs externes (external values) au chart `dso-env`.

Cette PR ne couvre que la partie backend (schéma / migration). L'exploitation
par l'API (service, contrôleur, schéma partagé) fait l'objet de la PR #2372
(empilée sur celle-ci) ; les composants client suivront.
