### PR TITLE
fix(server-nestjs/argocd): purge des fichiers de valeurs quand un projet n'a plus d'environnement

### DIFF
--- a/apps/server-nestjs/src/modules/argocd/argocd-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd-datastore.service.ts
@@ -101,4 +101,11 @@ export class ArgoCDDatastoreService {
       select: projectSelect,
     })
   }
+
+  async getAllZoneSlugs(): Promise<string[]> {
+    const zones = await this.prisma.zone.findMany({
+      select: { slug: true },
+    })
+    return zones.map(zone => zone.slug)
+  }
 }

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
@@ -34,6 +34,8 @@ describe('argoCDService', () => {
       deployVaultConnectionInNamespaces: false,
     })
 
+    datastore.getAllZoneSlugs.mockResolvedValue(['zone-1'])
+
     const module = await Test.createTestingModule({
       providers: [
         ArgoCDService,
@@ -350,6 +352,53 @@ describe('argoCDService', () => {
     )
 
     expect(gitlab.generateCreateOrUpdateAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('should delete leftover values files when the project has no environments', async () => {
+    const mockProject = makeProjectWithDetails({
+      slug: 'project-1',
+      name: 'Project 1',
+      environments: [],
+      repositories: [makeProjectRepository({ internalRepoName: 'infra-repo', isInfra: true })],
+      deployments: [],
+    })
+
+    const infraProject = makeProjectSchema({ id: 100, http_url_to_repo: 'https://gitlab.internal/infra' })
+    datastore.getAllProjects.mockResolvedValue([mockProject])
+    // The project no longer has any environment, so the zone must be discovered
+    // from the platform zone list rather than from the project's environments.
+    datastore.getAllZoneSlugs.mockResolvedValue(['zone-1'])
+    gitlab.getOrCreateInfraGroupRepo.mockResolvedValue(infraProject)
+    gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
+    gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
+    gitlab.listFiles.mockResolvedValue([
+      makeRepositoryTreeSchema(
+        { name: 'values.yaml', path: 'Project 1/cluster-1/dev/values.yaml' },
+      ),
+      makeRepositoryTreeSchema(
+        { name: 'values.yaml', path: 'Project 1/cluster-1/prod/values.yaml' },
+      ),
+    ])
+
+    await expect(service.handleCron()).resolves.not.toThrow()
+
+    expect(gitlab.maybeCreateCommit).toHaveBeenCalledTimes(1)
+    expect(gitlab.maybeCreateCommit).toHaveBeenCalledWith(
+      infraProject,
+      'ci: :robot_face: Sync project-1',
+      expect.arrayContaining([
+        {
+          action: 'delete',
+          filePath: 'Project 1/cluster-1/dev/values.yaml',
+        },
+        {
+          action: 'delete',
+          filePath: 'Project 1/cluster-1/prod/values.yaml',
+        },
+      ]),
+    )
+
+    expect(gitlab.generateCreateOrUpdateAction).not.toHaveBeenCalled()
   })
 
   it('should not commit when there is no diff', async () => {

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -101,7 +101,9 @@ export class ArgoCDService {
   ): Promise<void> {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
-    const zones = getDistinctZones(project)
+    // Visit every zone, not only those with a current environment, so leftover
+    // values files are purged from zones the project no longer deploys to.
+    const zones = await this.argoCDDatastore.getAllZoneSlugs()
     span?.setAttribute('argocd.zones.count', zones.length)
     this.logger.verbose(`Reconciling ArgoCD zones for project ${project.slug} (count=${zones.length})`)
     await Promise.all(zones.map(zoneSlug => this.ensureZone(project, zoneSlug)))
@@ -167,11 +169,6 @@ export class ArgoCDService {
     zoneSlug: string,
   ): Promise<CommitAction[]> {
     const neededFiles = new Set<string>()
-    const clusterLabelsInZone = new Set(
-      project.environments
-        .filter(e => e.cluster.zone.slug === zoneSlug)
-        .map(e => e.cluster.label),
-    )
 
     project.environments.forEach((env) => {
       if (env.cluster?.zone.slug !== zoneSlug) return
@@ -188,10 +185,6 @@ export class ArgoCDService {
       .filter((existingFile) => {
         if (existingFile.name !== 'values.yaml') return false
         if (!existingFile.path.startsWith(projectPrefix)) return false
-
-        const remaining = existingFile.path.slice(projectPrefix.length)
-        const clusterLabel = remaining.split('/')[0]
-        if (!clusterLabel || !clusterLabelsInZone.has(clusterLabel)) return false
 
         return !neededFiles.has(existingFile.path)
       })
@@ -443,12 +436,6 @@ function formatAppProjectName(projectSlug: string, env: string) {
 
 function formatEnvironmentValuesFilePath(project: { name: string }, cluster: { label: string }, env: { name: string }): string {
   return `${project.name}/${cluster.label}/${env.name}/values.yaml`
-}
-
-function getDistinctZones(project: ProjectWithDetails) {
-  const zones = new Set<string>()
-  project.environments.forEach(e => zones.add(e.cluster.zone.slug))
-  return [...zones]
 }
 
 function splitExtraRepositories(extraRepositories: string | undefined): string[] {


### PR DESCRIPTION
## Issues liées

Issues numéro: #2387

---------

## Quel est le comportement actuel ?

Quand on rejoue le hook d'un projet qui ne possède plus aucun environnement, les fichiers `values.yaml` générés précédemment dans le dépôt `infra` ne sont pas supprimés. Ils restent orphelins et des applications ArgoCD peuvent rester actives pour des environnements qui n'existent plus côté console.

La cause : la reconciliation ne parcourait que les zones déduites des environnements *actuels* du projet. Sans environnement, aucune zone n'était visitée, donc aucun nettoyage n'était effectué. De plus, la suppression des fichiers était restreinte aux clusters encore référencés par un environnement, ce qui empêchait de purger le fichier d'un cluster dont le dernier environnement venait d'être retiré.

## Quel est le nouveau comportement ?

La reconciliation parcourt désormais **toutes les zones de la plateforme** au lieu des seules zones déduites des environnements du projet. Ainsi, même un projet vidé de ses environnements visite ses dépôts `infra` et supprime les fichiers de valeurs devenus orphelins.

La restriction basée sur les clusters encore référencés a été retirée : tout fichier `values.yaml` sous le préfixe du projet qui ne correspond plus à un environnement existant est maintenant supprimé. Comme la console est seule responsable de ces fichiers (gérés en GitOps), cela ne présente pas de risque pour des fichiers tiers.

Un test couvre le cas « projet sans aucun environnement » pour garantir la suppression des fichiers restants.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Les zones étant un ensemble restreint et contrôlé, parcourir l'ensemble des zones à chaque reconciliation a un coût négligeable.