### PR TITLE
fix(argocd): revert DSO chart versions to env vars

### DIFF
--- a/plugins/argocd/src/functions.spec.ts
+++ b/plugins/argocd/src/functions.spec.ts
@@ -3,6 +3,10 @@ import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { stringify } from 'yaml'
 import { deleteProject, upsertProject } from './functions.js'
+import {
+  DEFAULT_DSO_ENV_CHART_VERSION,
+  DEFAULT_DSO_NS_CHART_VERSION,
+} from './infos.js'
 
 vi.mock('./utils.js', () => ({
   generateAppProjectName: vi.fn(() => 'app-project-name'),
@@ -130,8 +134,8 @@ describe('argocd functions', () => {
         cluster: 'in-cluster',
         namespace: 'argocd',
         project: 'app-project-name',
-        envChartVersion: 'dso-env-1.6.0',
-        nsChartVersion: 'dso-ns-1.1.5',
+        envChartVersion: DEFAULT_DSO_ENV_CHART_VERSION,
+        nsChartVersion: DEFAULT_DSO_NS_CHART_VERSION,
       },
       environment: {
         valueFileRepository: infraProjectUrl,

--- a/plugins/argocd/src/functions.ts
+++ b/plugins/argocd/src/functions.ts
@@ -27,15 +27,21 @@ function splitExtraRepositories(repos?: string): string[] {
   return repos ? repos.split(',').map(repo => repo.trim()) : []
 }
 
+const DSO_NS_CHART_VERSION = process.env.DSO_NS_CHART_VERSION ?? DEFAULT_DSO_NS_CHART_VERSION
+const DSO_ENV_CHART_VERSION
+  = process.env.DSO_ENV_CHART_VERSION ?? DEFAULT_DSO_ENV_CHART_VERSION
+
 function getValueFilePath(p: Project, c: ClusterObject, e: Environment): string {
   return `${p.name}/${c.label}/${e.name}/values.yaml`
 }
 
 export const upsertProject: StepCall<Project> = async (payload) => {
   const project = payload.args
-  const gitlabApi = payload.apis.gitlab as unknown as GitlabProjectApi
-  const keycloakApi = payload.apis.keycloak as any
-  const vaultApi = payload.apis.vault as unknown as VaultProjectApi
+  const {
+    gitlab: gitlabApi,
+    keycloak: keycloakApi,
+    vault: vaultApi,
+  } = payload.apis
 
   try {
     const infraRepositories = project.repositories.filter(
@@ -123,8 +129,6 @@ async function ensureInfraEnvValues(
   const projectDevopsGroupSuffix = config.argocd?.projectDevopsGroupPathSuffix ?? DEFAULT_PROJECT_DEVOPS_GROUP_PATH_SUFFIX
   const projectDevelopperGroupSuffix = config.argocd?.projectDevelopperGroupPathSuffix ?? DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX
   const projectReadonlyGroupSuffix = config.argocd?.projectReadonlyGroupPathSuffix ?? DEFAULT_PROJECT_READONLY_GROUP_PATH_SUFFIX
-  const dsoEnvChartVersion = config.argocd?.dsoEnvChartVersion ?? DEFAULT_DSO_ENV_CHART_VERSION
-  const dsoNsChartVersion = config.argocd?.dsoNsChartVersion ?? DEFAULT_DSO_NS_CHART_VERSION
   const cluster = getCluster(project, environment)
   const infraProject = await gitlabApi.getProjectById(repoId)
   const valueFilePath = getValueFilePath(project, cluster, environment)
@@ -162,8 +166,8 @@ async function ensureInfraEnvValues(
       cluster: inClusterLabel,
       namespace: getConfig().namespace,
       project: appProjectName,
-      envChartVersion: dsoEnvChartVersion,
-      nsChartVersion: dsoNsChartVersion,
+      envChartVersion: DSO_ENV_CHART_VERSION,
+      nsChartVersion: DSO_NS_CHART_VERSION,
     },
     environment: {
       valueFileRepository: infraProject.http_url_to_repo,

--- a/plugins/argocd/src/infos.ts
+++ b/plugins/argocd/src/infos.ts
@@ -8,6 +8,7 @@ export const DEFAULT_PROJECT_ADMIN_GROUP_PATH_SUFFIX = '/console/admin'
 export const DEFAULT_PROJECT_DEVOPS_GROUP_PATH_SUFFIX = '/console/devops'
 export const DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX = '/console/developer'
 export const DEFAULT_PROJECT_READONLY_GROUP_PATH_SUFFIX = '/console/readonly'
+
 export const DEFAULT_DSO_ENV_CHART_VERSION = 'dso-env-1.6.0'
 export const DEFAULT_DSO_NS_CHART_VERSION = 'dso-ns-1.1.5'
 
@@ -92,28 +93,6 @@ const infos = {
       title: 'Project Readonly Group Path Suffix',
       value: DEFAULT_PROJECT_READONLY_GROUP_PATH_SUFFIX,
       description: 'Suffixe du chemin du groupe lecture seule de projet',
-    }, {
-      key: 'dsoEnvChartVersion',
-      kind: 'text',
-      permissions: {
-        admin: { read: true, write: true },
-        user: { read: false, write: false },
-      },
-      title: 'DSO Env Chart Version',
-      value: DEFAULT_DSO_ENV_CHART_VERSION,
-      description: 'Version du chart Helm dso-env',
-      placeholder: DEFAULT_DSO_ENV_CHART_VERSION,
-    }, {
-      key: 'dsoNsChartVersion',
-      kind: 'text',
-      permissions: {
-        admin: { read: true, write: true },
-        user: { read: false, write: false },
-      },
-      title: 'DSO Namespace Chart Version',
-      value: DEFAULT_DSO_NS_CHART_VERSION,
-      description: 'Version du chart Helm dso-ns',
-      placeholder: DEFAULT_DSO_NS_CHART_VERSION,
     }],
     project: [{
       key: 'extraRepositories',


### PR DESCRIPTION
## Issues liées

Fixes #2393

---------

## Quel est le comportement actuel ?

Les versions de chart DSO (`DSO_ENV_CHART_VERSION`, `DSO_NS_CHART_VERSION`) étaient lues depuis la configuration plugin (`config.argocd?.dsoEnvChartVersion`) au lieu d'être lues depuis les variables d'environnement via `process.env`.

## Quel est le nouveau comportement ?

Les versions de chart DSO sont à nouveau lues depuis les variables d'environnement (`process.env.DSO_ENV_CHART_VERSION` / `process.env.DSO_NS_CHART_VERSION`) avec des valeurs par défaut en dur dans `configuration.service.ts`.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Revert du commit `chore: upstream static env var to infos` qui avait introduit la régression.