### PR TITLE
fix(server-nestjs): harden gitlab token and user handling

### DIFF
--- a/apps/server-nestjs/src/config/gitlab.config.spec.ts
+++ b/apps/server-nestjs/src/config/gitlab.config.spec.ts
@@ -17,8 +17,7 @@ describe('gitlabConfig', () => {
       url: 'https://gitlab.internal',
       internalUrl: 'https://gitlab.internal:8080',
       secretExposeInternalUrl: true,
-      mirrorTokenExpirationDays: 180,
-      mirrorTokenRotationThresholdDays: 90,
+      mirrorTokenExpirationDays: 365,
       projectRootDir: 'forge-test/projects',
     })
   })

--- a/apps/server-nestjs/src/config/gitlab.config.ts
+++ b/apps/server-nestjs/src/config/gitlab.config.ts
@@ -6,8 +6,7 @@ const gitlabFeatureSchema = z.object({
   GITLAB_TOKEN: z.string().min(1),
   GITLAB_URL: z.string().url(),
   GITLAB_INTERNAL_URL: z.string().url().optional(),
-  GITLAB_MIRROR_TOKEN_EXPIRATION_DAYS: z.coerce.number().int().positive().default(180),
-  GITLAB_MIRROR_TOKEN_ROTATION_THRESHOLD_DAYS: z.coerce.number().int().positive().default(90),
+  GITLAB_MIRROR_TOKEN_EXPIRATION_DAYS: z.coerce.number().int().positive().default(365),
   GITLAB__SECRET_EXPOSE_INTERNAL_URL: truthySchema.default('false').transform(v => v === 'true' || v === '1'),
   PROJECTS_ROOT_DIR: z.string().min(1),
 }).transform(raw => ({
@@ -16,7 +15,6 @@ const gitlabFeatureSchema = z.object({
   internalUrl: raw.GITLAB_INTERNAL_URL,
   secretExposeInternalUrl: raw.GITLAB__SECRET_EXPOSE_INTERNAL_URL,
   mirrorTokenExpirationDays: raw.GITLAB_MIRROR_TOKEN_EXPIRATION_DAYS,
-  mirrorTokenRotationThresholdDays: raw.GITLAB_MIRROR_TOKEN_ROTATION_THRESHOLD_DAYS,
   projectRootDir: raw.PROJECTS_ROOT_DIR,
 }))
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
@@ -1,10 +1,12 @@
-import type { ExpandedGroupSchema, Gitlab as GitlabApi, ProjectSchema } from '@gitbeaker/core'
+import type { Gitlab as GitlabApi } from '@gitbeaker/core'
 import type { ConfigType } from '@nestjs/config'
 import type { TestingModule } from '@nestjs/testing'
 import type { MockedFunction } from 'vitest'
 import type { DeepMockProxy } from 'vitest-mock-extended'
 import { Test } from '@nestjs/testing'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { gitlabConfigFactory } from '../../config/gitlab.config'
 import { GITLAB_REST_CLIENT, GitlabClientService } from './gitlab-client.service'
@@ -54,6 +56,10 @@ describe('gitlab-client', () => {
     service = module.get(GitlabClientService)
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('should be defined', () => {
     expect(service).toBeDefined()
   })
@@ -71,14 +77,14 @@ describe('gitlab-client', () => {
         paginationInfo: { next: null },
       })
 
-      gitlabApi.Groups.show.mockResolvedValueOnce({ id: rootId, full_path: 'forge' } as ExpandedGroupSchema)
+      gitlabApi.Groups.show.mockResolvedValueOnce(makeExpandedGroupSchema({ id: rootId, full_path: 'forge' }))
 
       gitlabGroupsAllMock.mockResolvedValueOnce({
         data: [],
         paginationInfo: { next: null },
       })
 
-      gitlabApi.Groups.create.mockResolvedValue({ id: infraGroupId, full_path: 'forge/infra' } as ExpandedGroupSchema)
+      gitlabApi.Groups.create.mockResolvedValue(makeExpandedGroupSchema({ id: infraGroupId, full_path: 'forge/infra' }))
 
       const gitlabProjectsAllMock = gitlabApi.Projects.all as MockedFunction<typeof gitlabApi.Projects.all>
       gitlabProjectsAllMock.mockResolvedValueOnce({
@@ -86,19 +92,19 @@ describe('gitlab-client', () => {
         paginationInfo: { next: null },
       })
 
-      gitlabApi.Projects.create.mockResolvedValue({
+      gitlabApi.Projects.create.mockResolvedValue(makeProjectSchema({
         id: projectId,
         path_with_namespace: 'forge/infra/zone-1',
         http_url_to_repo: 'https://gitlab.internal/infra/zone-1.git',
-      } as ProjectSchema)
+      }))
 
       const result = await service.getOrCreateInfraGroupRepo(zoneSlug)
 
-      expect(result).toEqual({
+      expect(result).toEqual(expect.objectContaining({
         id: projectId,
         http_url_to_repo: 'https://gitlab.internal/infra/zone-1.git',
         path_with_namespace: 'forge/infra/zone-1',
-      })
+      }))
       expect(gitlabApi.Groups.create).toHaveBeenCalledWith('infra', 'infra', expect.any(Object))
       expect(gitlabApi.GroupCustomAttributes.set).toHaveBeenCalledWith(rootId, GROUP_ROOT_CUSTOM_ATTRIBUTE_KEY, 'true')
       expect(gitlabApi.GroupCustomAttributes.set).toHaveBeenCalledWith(infraGroupId, MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY, 'true')
@@ -257,11 +263,11 @@ describe('gitlab-client', () => {
         paginationInfo: { next: null },
       })
 
-      gitlabApi.Projects.edit.mockResolvedValue({ id: repoId, name: 'mirror' } as ProjectSchema)
+      gitlabApi.Projects.edit.mockResolvedValue(makeProjectSchema({ id: repoId, name: 'mirror' }))
 
       const result = await service.upsertProjectMirrorRepo(projectSlug)
 
-      expect(result).toEqual({ id: repoId, name: 'mirror' })
+      expect(result).toEqual(expect.objectContaining({ id: repoId, name: 'mirror' }))
       expect(gitlabApi.Projects.edit).toHaveBeenCalledWith(repoId, expect.objectContaining({
         name: 'mirror',
         path: 'mirror',
@@ -274,11 +280,11 @@ describe('gitlab-client', () => {
       const repoId = 101
 
       gitlabApi.Projects.show.mockResolvedValue(makeProjectSchema({ id: repoId }))
-      gitlabApi.Projects.edit.mockResolvedValue({ id: repoId, name: repoName } as ProjectSchema)
+      gitlabApi.Projects.edit.mockResolvedValue(makeProjectSchema({ id: repoId, name: repoName }))
 
       const result = await service.upsertProjectGroupRepo(projectSlug, repoName, 'desc')
 
-      expect(result).toEqual({ id: repoId, name: repoName })
+      expect(result).toEqual(expect.objectContaining({ id: repoId, name: repoName }))
       expect(gitlabApi.ProjectCustomAttributes.set).toHaveBeenCalledWith(repoId, MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY, 'true')
     })
 
@@ -407,7 +413,7 @@ describe('gitlab-client', () => {
         data: [{ id: repoId, path_with_namespace: 'forge/project-1/mirror' }],
         paginationInfo: { next: null },
       })
-      gitlabApi.Projects.edit.mockResolvedValue({ id: repoId, name: 'mirror' } as ProjectSchema)
+      gitlabApi.Projects.edit.mockResolvedValue(makeProjectSchema({ id: repoId, name: 'mirror' }))
 
       const gitlabPipelineTriggerTokensAllMock = gitlabApi.PipelineTriggerTokens.all as MockedFunction<typeof gitlabApi.PipelineTriggerTokens.all>
       gitlabPipelineTriggerTokensAllMock.mockResolvedValue({
@@ -471,7 +477,7 @@ describe('gitlab-client', () => {
         data: [{ id: 123, full_path: 'forge' }],
         paginationInfo: { next: null },
       })
-      gitlabApi.Groups.show.mockResolvedValueOnce({ id: 123, full_path: 'forge' } as ExpandedGroupSchema)
+      gitlabApi.Groups.show.mockResolvedValueOnce(makeExpandedGroupSchema({ id: 123, full_path: 'forge' }))
 
       const gitlabGroupsAllSubgroupsMock = gitlabApi.Groups.allSubgroups as MockedFunction<typeof gitlabApi.Groups.allSubgroups>
       gitlabGroupsAllSubgroupsMock.mockResolvedValueOnce({
@@ -538,7 +544,7 @@ describe('gitlab-client', () => {
         paginationInfo: { next: null },
       })
 
-      gitlabApi.Projects.create.mockResolvedValue({ id: projectId, name: repoName } as ProjectSchema)
+      gitlabApi.Projects.create.mockResolvedValue(makeProjectSchema({ id: projectId, name: repoName }))
 
       const result = await service.getOrCreateProjectGroupRepo(subGroupPath, fullPath)
 
@@ -621,6 +627,7 @@ describe('gitlab-client', () => {
     it('should return specific token', async () => {
       const projectSlug = 'project-1'
       const groupId = 456
+      const group = makeGroupSchema({ id: groupId })
       const tokenName = `${projectSlug}-bot`
       const token = makeAccessTokenSchema({ id: 1, name: tokenName })
 
@@ -629,7 +636,7 @@ describe('gitlab-client', () => {
         data: [{ id: 123, full_path: 'forge' }],
         paginationInfo: { next: null },
       })
-      gitlabApi.Groups.show.mockResolvedValueOnce({ id: 123, full_path: 'forge' } as ExpandedGroupSchema)
+      gitlabApi.Groups.show.mockResolvedValueOnce(makeExpandedGroupSchema({ id: 123, full_path: 'forge' }))
       const gitlabGroupsAllSubgroupsMock = gitlabApi.Groups.allSubgroups as MockedFunction<typeof gitlabApi.Groups.allSubgroups>
       gitlabGroupsAllSubgroupsMock.mockResolvedValueOnce({
         data: [{ id: groupId, name: projectSlug, parent_id: 123, full_path: `forge/${projectSlug}` }],
@@ -642,8 +649,95 @@ describe('gitlab-client', () => {
         paginationInfo: makeOffsetPagination({ next: null }),
       })
 
-      const result = await service.getProjectToken(projectSlug)
+      const result = await service.getProjectToken(group, projectSlug)
       expect(result).toEqual(token)
+    })
+  })
+
+  describe('revokeProjectToken', () => {
+    it('should revoke a project access token by group id and token id', async () => {
+      const projectSlug = 'project-1'
+      const groupId = 456
+      const tokenId = 789
+      const group = makeGroupSchema({ id: groupId, name: projectSlug, path: projectSlug, full_path: `forge/${projectSlug}`, full_name: `forge/${projectSlug}`, parent_id: 123 })
+
+      const gitlabGroupsAllMock = gitlabApi.Groups.all as MockedFunction<typeof gitlabApi.Groups.all>
+      gitlabGroupsAllMock.mockResolvedValueOnce({
+        data: [{ id: 123, full_path: 'forge' }],
+        paginationInfo: { next: null },
+      })
+      gitlabApi.Groups.show.mockResolvedValueOnce(makeExpandedGroupSchema({ id: 123, full_path: 'forge' }))
+      const gitlabGroupsAllSubgroupsMock = gitlabApi.Groups.allSubgroups as MockedFunction<typeof gitlabApi.Groups.allSubgroups>
+      gitlabGroupsAllSubgroupsMock.mockResolvedValueOnce({
+        data: [group],
+        paginationInfo: { next: null },
+      })
+
+      await service.revokeProjectToken(group, tokenId)
+
+      expect(gitlabApi.GroupAccessTokens.revoke).toHaveBeenCalledWith(groupId, tokenId)
+    })
+  })
+
+  describe('getProjectGroup', () => {
+    it('should return undefined when the project group is not found', async () => {
+      const projectSlug = 'missing'
+      const gitlabGroupsAllMock = gitlabApi.Groups.all as MockedFunction<typeof gitlabApi.Groups.all>
+      gitlabGroupsAllMock.mockResolvedValueOnce({ data: [{ id: 123, full_path: 'forge' }], paginationInfo: { next: null } })
+      gitlabApi.Groups.show.mockResolvedValueOnce(makeExpandedGroupSchema({ id: 123, full_path: 'forge' }))
+      const gitlabGroupsAllSubgroupsMock = gitlabApi.Groups.allSubgroups as MockedFunction<typeof gitlabApi.Groups.allSubgroups>
+      gitlabGroupsAllSubgroupsMock.mockResolvedValueOnce({ data: [], paginationInfo: { next: null } })
+
+      await expect(service.getProjectGroup(projectSlug)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('validateProjectToken', () => {
+    const server = setupServer()
+    beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+    afterEach(() => server.resetHandlers())
+    afterAll(() => server.close())
+
+    function stubPersonalAccessTokenSelf(body: object, status = 200) {
+      server.use(
+        http.get('https://gitlab.internal/api/v4/personal_access_tokens/self', () =>
+          HttpResponse.json(body, { status })),
+      )
+    }
+
+    it('should send the candidate token and not the integration token', async () => {
+      let capturedToken: string | null = null
+      server.use(
+        http.get('https://gitlab.internal/api/v4/personal_access_tokens/self', ({ request }) => {
+          capturedToken = request.headers.get('private-token')
+          return HttpResponse.json({ id: 1, active: true, revoked: false })
+        }),
+      )
+
+      await expect(service.validateProjectToken('valid-token')).resolves.toBe(true)
+
+      expect(capturedToken).toBe('valid-token')
+    })
+
+    it.each([
+      { active: false, revoked: false },
+      { active: true, revoked: true },
+    ])('should return false for an inactive or revoked token (%o)', async (state) => {
+      stubPersonalAccessTokenSelf({ id: 1, ...state })
+
+      await expect(service.validateProjectToken('stale-token')).resolves.toBe(false)
+    })
+
+    it('should return false when GitLab rejects the token', async () => {
+      stubPersonalAccessTokenSelf({ message: '401 Unauthorized' }, 401)
+
+      await expect(service.validateProjectToken('invalid-token')).resolves.toBe(false)
+    })
+
+    it('should throw on transient failures instead of reporting an invalid token', async () => {
+      stubPersonalAccessTokenSelf({ message: '502 Bad Gateway' }, 502)
+
+      await expect(service.validateProjectToken('valid-token')).rejects.toThrow()
     })
   })
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -17,6 +17,7 @@ import type {
 import type { ConfigType } from '@nestjs/config'
 import { join } from 'node:path'
 import { GitbeakerRequestError } from '@gitbeaker/requester-utils'
+import { Gitlab as GitlabRest } from '@gitbeaker/rest'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { gitlabConfigFactory } from '../../config/gitlab.config'
 import { find } from '../../utils/iterable.utils'
@@ -241,6 +242,7 @@ export class GitlabClientService {
         path: repoName,
         namespaceId: parentGroup.id,
         defaultBranch: 'main',
+        ciConfigPath: '.gitlab-ci-dso.yml',
       })
       this.logger.log(`Created a GitLab project repository (path=${fullPath}, repoId=${created.id})`)
       return created
@@ -334,7 +336,7 @@ export class GitlabClientService {
 
   async getProjectGroup(projectSlug: string): Promise<GroupSchema | undefined> {
     const parentGroup = await this.getOrCreateProjectGroup()
-    return find(
+    return await find(
       this.offsetPaginate(opts => this.client.Groups.allSubgroups(parentGroup.id, opts)),
       g => g.name === projectSlug,
     )
@@ -375,6 +377,9 @@ export class GitlabClientService {
     this.logger.log(`Creating a GitLab user (email=${user.email}, username=${user.username})`)
     return await this.client.Users.create({
       ...user,
+      canCreateGroup: false,
+      forceRandomPassword: true,
+      projectsLimit: 0,
       skipConfirmation: true,
     }) as UserSchema
   }
@@ -461,30 +466,43 @@ export class GitlabClientService {
     return this.upsertProjectGroupRepo(projectSlug, MIRROR_REPO_NAME)
   }
 
-  async getProjectToken(projectSlug: string) {
-    const group = await this.getProjectGroup(projectSlug)
-    if (!group) throw new Error('Unable to retrieve gitlab project group')
+  async getProjectToken(group: CondensedGroupSchemaWith<'id'>, projectSlug: string) {
     return find(
-      this.offsetPaginate<{ name: string }>(
-        opts => this.client.GroupAccessTokens.all(group.id, opts) as unknown as Promise<{ data: { name: string }[], paginationInfo: OffsetPagination }>,
+      this.offsetPaginate<{ name: string, id: number }>(
+        opts => this.client.GroupAccessTokens.all(group.id, opts) as unknown as Promise<{ data: { name: string, id: number }[], paginationInfo: OffsetPagination }>,
       ),
       token => token.name === `${projectSlug}-bot`,
     )
   }
 
-  async createProjectToken(projectSlug: string, tokenName: string, scopes: AccessTokenScopes[]) {
-    const group = await this.getProjectGroup(projectSlug)
-    if (!group) throw new Error('Unable to retrieve gitlab project group')
-    const expirationDays = Number(this.config.mirrorTokenExpirationDays)
-    const effectiveExpirationDays = Number.isFinite(expirationDays) && expirationDays > 0 ? expirationDays : 30
-    const expiryDate = new Date(Date.now() + effectiveExpirationDays * 24 * 60 * 60 * 1000)
-    this.logger.log(`Creating a GitLab group access token (projectSlug=${projectSlug}, tokenName=${tokenName}, expiry=${expiryDate.toISOString().slice(0, 10)})`)
+  async createProjectToken(group: CondensedGroupSchemaWith<'id'>, tokenName: string, scopes: AccessTokenScopes[]) {
+    const expiryDate = new Date(Date.now() + this.config.mirrorTokenExpirationDays * 24 * 60 * 60 * 1000)
+    this.logger.log(`Creating a GitLab group access token (groupId=${group.id}, tokenName=${tokenName}, expiry=${expiryDate.toISOString().slice(0, 10)})`)
     return this.client.GroupAccessTokens.create(group.id, tokenName, scopes, expiryDate.toISOString().slice(0, 10))
   }
 
   async createMirrorAccessToken(projectSlug: string) {
     const tokenName = `${projectSlug}-bot`
-    return this.createProjectToken(projectSlug, tokenName, ['write_repository', 'read_repository', 'read_api'])
+    const group = await this.getProjectGroup(projectSlug)
+    if (!group) throw new Error(`Unable to retrieve gitlab project group for ${projectSlug}`)
+    return this.createProjectToken(group, tokenName, ['write_repository', 'read_repository', 'read_api'])
+  }
+
+  async revokeProjectToken(group: CondensedGroupSchemaWith<'id'>, tokenId: number): Promise<void> {
+    this.logger.log(`Revoking a GitLab group access token (groupId=${group.id}, tokenId=${tokenId})`)
+    await this.client.GroupAccessTokens.revoke(group.id, tokenId)
+  }
+
+  async validateProjectToken(token: string): Promise<boolean> {
+    // gitbeaker has no per-call auth override, so validation needs a client bound to the candidate token
+    const client = new GitlabRest({ token, host: this.config.internalUrl ?? this.config.url })
+    try {
+      const self = await client.PersonalAccessTokens.show()
+      return self.active && !self.revoked
+    } catch (error) {
+      if (error instanceof GitbeakerRequestError && error.cause?.response.status === 401) return false
+      throw error
+    }
   }
 
   async getOrCreateMirrorPipelineTriggerToken(projectSlug: string): Promise<PipelineTriggerTokenSchema> {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
@@ -443,6 +443,8 @@ describe('gitlabService', () => {
 
       gitlab.getOrCreateProjectSubGroup.mockResolvedValue(group)
       gitlab.getGroupMembers.mockResolvedValue([])
+      gitlab.getProjectGroup.mockResolvedValue(group)
+      gitlab.getProjectToken.mockResolvedValue(undefined)
       gitlab.getRepos.mockReturnValue((async function* () { yield gitlabRepo })())
       gitlab.getOrCreateProjectGroupInternalRepoUrl.mockResolvedValue('https://gitlab.internal/group/repo-1.git')
       gitlab.createMirrorAccessToken.mockResolvedValue(accessToken)
@@ -487,6 +489,31 @@ describe('gitlabService', () => {
 
       expect(datastore.getAllProjects).toHaveBeenCalled()
       expect(gitlab.getOrCreateProjectSubGroup).toHaveBeenCalledWith('project-1')
+    })
+  })
+
+  describe('handleDelete', () => {
+    it('should delete project group from GitLab', async () => {
+      const project = makeProjectWithDetails({ slug: 'project-1' })
+      const group = makeGroupSchema({ id: 123, name: 'project-1', path: 'project-1', full_path: 'forge/console/project-1', full_name: 'forge/console/project-1', parent_id: 1 })
+
+      gitlab.getGroupByPath.mockResolvedValue(group)
+      gitlab.deleteGroup.mockResolvedValue(undefined)
+
+      await service.handleDelete(project)
+
+      expect(gitlab.getGroupByPath).toHaveBeenCalledWith('forge/project-1')
+      expect(gitlab.deleteGroup).toHaveBeenCalledWith(group)
+    })
+
+    it('should not throw when project group does not exist', async () => {
+      const project = makeProjectWithDetails({ slug: 'project-1' })
+
+      gitlab.getGroupByPath.mockResolvedValue(undefined)
+
+      await expect(service.handleDelete(project)).resolves.not.toThrow()
+
+      expect(gitlab.deleteGroup).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -1,7 +1,7 @@
 import type { CondensedGroupSchema, MemberSchema, ProjectSchema } from '@gitbeaker/core'
 import type { ConfigType } from '@nestjs/config'
 import type { RequiredPluginResult } from '../plugin/plugin.utils'
-import type { VaultSecret } from '../vault/vault-client.service'
+import type { MirrorUserSecret } from '../vault/vault-client.service'
 import type { ProjectWithDetails } from './gitlab-datastore.service'
 import { specificallyEnabled } from '@cpn-console/hooks'
 import { AccessLevel } from '@gitbeaker/core'
@@ -32,7 +32,6 @@ import {
 } from './gitlab.constants'
 import {
   adminRoleFlag,
-  daysAgoFromNow,
   generateAccessLevelMapping,
   generateAdminRoleMapping,
   generateName,
@@ -84,8 +83,12 @@ export class GitlabService {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project delete event for ${project.slug}`)
-    await this.ensureProjectGroup(project)
-    this.logger.log(`GitLab sync completed for project ${project.slug}`)
+    const projectGroupPath = `${this.gitlabConfig.projectRootDir}/${project.slug}`
+    const group = await this.gitlab.getGroupByPath(projectGroupPath)
+    if (group) {
+      await this.gitlab.deleteGroup(group)
+    }
+    this.logger.log(`GitLab cleanup completed for project ${project.slug}`)
   }
 
   // @Cron(CronExpression.EVERY_HOUR)
@@ -427,7 +430,7 @@ export class GitlabService {
     span?.setAttribute('repository.externalRepoUrn', externalRepoUrn)
     span?.setAttribute('repository.internalRepoUrn', internalRepoUrn)
 
-    const projectMirrorCreds = await this.getOrRotateMirrorCreds(project.slug)
+    const projectMirrorCreds = await this.getOrRotateMirrorCreds(project)
 
     const mirrorSecretData = {
       GIT_INPUT_URL: externalRepoUrn,
@@ -449,30 +452,30 @@ export class GitlabService {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     await Promise.all([
-      this.ensureInfraAppsRepo(project.slug),
-      this.ensureMirrorRepo(project.slug),
+      this.ensureInfraAppsRepo(project),
+      this.ensureMirrorRepo(project),
     ])
   }
 
-  private async ensureInfraAppsRepo(projectSlug: string) {
-    await this.gitlab.upsertProjectGroupRepo(projectSlug, INFRA_APPS_REPO_NAME)
+  private async ensureInfraAppsRepo(project: ProjectWithDetails) {
+    await this.gitlab.upsertProjectGroupRepo(project.slug, INFRA_APPS_REPO_NAME)
   }
 
-  private async ensureMirrorRepo(projectSlug: string) {
-    const mirrorRepo = await this.gitlab.upsertProjectMirrorRepo(projectSlug)
+  private async ensureMirrorRepo(project: ProjectWithDetails) {
+    const mirrorRepo = await this.gitlab.upsertProjectMirrorRepo(project.slug)
     if (mirrorRepo.empty_repo) {
       await this.gitlab.commitMirror(mirrorRepo.id)
     }
-    await this.ensureMirrorRepoTriggerToken(projectSlug)
+    await this.ensureMirrorRepoTriggerToken(project)
   }
 
   @StartActiveSpan()
-  private async ensureMirrorRepoTriggerToken(projectSlug: string) {
+  private async ensureMirrorRepoTriggerToken(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
-    span?.setAttribute('project.slug', projectSlug)
-    const triggerToken = await this.gitlab.getOrCreateMirrorPipelineTriggerToken(projectSlug)
+    span?.setAttribute('project.slug', project.slug)
+    const triggerToken = await this.gitlab.getOrCreateMirrorPipelineTriggerToken(project.slug)
     const gitlabSecret = {
-      PROJECT_SLUG: projectSlug,
+      PROJECT_SLUG: project.slug,
       GIT_MIRROR_PROJECT_ID: triggerToken.repoId,
       GIT_MIRROR_TOKEN: triggerToken.token,
     }
@@ -481,40 +484,52 @@ export class GitlabService {
   }
 
   @StartActiveSpan()
-  private async getOrRotateMirrorCreds(projectSlug: string) {
+  private async getOrRotateMirrorCreds(project: ProjectWithDetails): Promise<MirrorUserSecret> {
     const span = trace.getActiveSpan()
-    span?.setAttribute('project.slug', projectSlug)
-    const vaultSecret = await this.vault.readTechnReadOnlyCreds(projectSlug)
-    if (!vaultSecret) return this.createMirrorAccessToken(projectSlug)
-
-    const isExpiring = this.isMirrorCredsExpiring(vaultSecret)
-    span?.setAttribute('mirror.creds.expiring', isExpiring)
-    if (!isExpiring) {
-      span?.setAttribute('mirror.creds.rotated', false)
-      return vaultSecret.data as { MIRROR_USER: string, MIRROR_TOKEN: string }
+    span?.setAttribute('project.slug', project.slug)
+    const group = await this.gitlab.getProjectGroup(project.slug)
+    if (!group) throw new Error(`No group found for project ${project.slug}`)
+    const currentToken = await this.gitlab.getProjectToken(group, project.slug)
+    if (currentToken) {
+      const vaultSecret = await this.getMirrorTokenFromVault(project)
+      if (vaultSecret) {
+        span?.setAttribute('mirror.creds.rotated', false)
+        return vaultSecret
+      }
+      this.logger.warn(`Mirror token invalid or vault secret missing, revoking (projectSlug=${project.slug}, tokenId=${currentToken.id})`)
+      span?.setAttribute('mirror.creds.revoking', true)
+      await this.gitlab.revokeProjectToken(group, currentToken.id).catch((err) => {
+        this.logger.error(`Failed to revoke stale mirror token (projectSlug=${project.slug}, tokenId=${currentToken.id}): ${err}`)
+        span?.setAttribute('mirror.creds.revoke.failed', true)
+      })
     }
-    return this.createMirrorAccessToken(projectSlug)
+    return this.createMirrorAccessToken(project)
+  }
+
+  private async getMirrorTokenFromVault(project: ProjectWithDetails): Promise<MirrorUserSecret | undefined> {
+    const vaultSecret = await this.vault.readTechnReadOnlyCreds(project.slug)
+    const vaultToken = vaultSecret?.data?.MIRROR_TOKEN
+    if (vaultToken) {
+      const isValid = await this.gitlab.validateProjectToken(vaultToken)
+      if (isValid) {
+        return vaultSecret.data
+      }
+    }
   }
 
   @StartActiveSpan()
-  private async createMirrorAccessToken(projectSlug: string) {
+  private async createMirrorAccessToken(project: ProjectWithDetails) {
     const span = trace.getActiveSpan()
-    span?.setAttribute('project.slug', projectSlug)
+    span?.setAttribute('project.slug', project.slug)
     span?.setAttribute('mirror.creds.rotated', true)
-    const token = await this.gitlab.createMirrorAccessToken(projectSlug)
+    const token = await this.gitlab.createMirrorAccessToken(project.slug)
     const creds = {
       MIRROR_USER: token.name,
       MIRROR_TOKEN: token.token,
     }
-    await this.vault.writeTechReadOnlyCreds(projectSlug, creds)
+    await this.vault.writeTechReadOnlyCreds(project.slug, creds)
     span?.setAttribute('vault.secret.written', true)
     return creds
-  }
-
-  private isMirrorCredsExpiring(vaultSecret: VaultSecret): boolean {
-    if (!vaultSecret?.metadata?.created_time) return false
-    const createdTime = new Date(vaultSecret.metadata.created_time)
-    return daysAgoFromNow(createdTime) > this.gitlabConfig.mirrorTokenRotationThresholdDays
   }
 
   private getExternalRepoHost(externalRepoUrl: string | null | undefined): string | undefined {

--- a/apps/server-nestjs/src/modules/vault/vault-client.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault-client.service.ts
@@ -76,6 +76,11 @@ export interface SonarqubeUserSecret {
   SONAR_TOKEN: string
 }
 
+export interface MirrorUserSecret {
+  MIRROR_USER: string
+  MIRROR_TOKEN: string
+}
+
 export interface VaultMetadata {
   created_time: string
   custom_metadata: Record<string, any> | null


### PR DESCRIPTION
Revoke old mirror tokens on rotation, validate tokens via API call, restore 1-year token expiry, set ciConfigPath and user creation hardening (canCreateGroup, forceRandomPassword, projectsLimit).


Change-Id: I9dc52277970e58fc62f11363c4989c1d6a6a6964

## Issues liées

Extrait de: #2407

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
