### PR TITLE
Refactor to data driven http mocking using msw/data

### DIFF
--- a/apps/server-nestjs/package.json
+++ b/apps/server-nestjs/package.json
@@ -96,6 +96,7 @@
     "eslint": "catalog:tools",
     "globals": "catalog:test",
     "msw": "catalog:test",
+    "@mswjs/data": "catalog:test",
     "pino-pretty": "catalog:tools",
     "rimraf": "catalog:tools",
     "ts-patch": "catalog:build",

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube-client.service.spec.ts
@@ -2,6 +2,7 @@ import type { ConfigType } from '@nestjs/config'
 import type { AddPermissionGroupParams, CreateUserParams, DeactivateUserParams, RevokeUserTokenParams } from './sonarqube-client.service'
 import { faker } from '@faker-js/faker'
 import { Test } from '@nestjs/testing'
+import { factory, primaryKey } from '@mswjs/data'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -16,7 +17,62 @@ const sonarUrl = 'https://sonarqube.internal'
 const sonarToken = 'my-token'
 const sonarAuthHeader = `Bearer ${sonarToken}`
 
-const server = setupServer()
+const db = factory({
+  group: { ...makeSonarqubeGroup(), id: primaryKey(String) },
+  user: { ...makeSonarqubeUser(), login: primaryKey(String) },
+  project: { ...makeSonarqubeProject(), key: primaryKey(String) },
+  token: { ...makeSonarqubeGeneratedToken(), token: primaryKey(String) },
+})
+
+const server = setupServer(
+  http.get(`${sonarUrl}/api/user_groups/search`, ({ request }) => {
+    expect(request.headers.get('authorization')).toBe(sonarAuthHeader)
+    const q = new URL(request.url).searchParams.get('q')
+    const groups = q ? db.group.findMany({ where: { name: { equals: q } } }) : db.group.getAll()
+    return HttpResponse.json({ paging: makeSonarqubePaging({ total: groups.length }), groups })
+  }),
+  http.post(`${sonarUrl}/api/user_groups/create`, async ({ request }) => {
+    const params = new URL(request.url).searchParams
+    expect(params.get('name')).toBe('new-group')
+    db.group.create(makeSonarqubeGroup({ id: faker.string.uuid(), name: params.get('name') as string }))
+    return HttpResponse.json({})
+  }),
+  http.get(`${sonarUrl}/api/users/search`, () => {
+    const users = db.user.getAll()
+    return HttpResponse.json({ paging: makeSonarqubePaging({ total: users.length }), users })
+  }),
+  http.post(`${sonarUrl}/api/users/create`, async ({ request }) => {
+    const params = new URL(request.url).searchParams
+    db.user.create(makeSonarqubeUser({ id: faker.string.uuid(), login: params.get('login') as string }))
+    return HttpResponse.json({})
+  }),
+  http.post(`${sonarUrl}/api/users/deactivate`, async ({ request }) => {
+    const params = new URL(request.url).searchParams
+    db.user.deleteMany({ where: { login: { equals: params.get('login') as string } } })
+    return HttpResponse.json({})
+  }),
+  http.post(`${sonarUrl}/api/user_tokens/revoke`, async ({ request }) => {
+    const params = new URL(request.url).searchParams
+    db.token.deleteMany({ where: { login: { equals: params.get('login') as string } } })
+    return HttpResponse.json({})
+  }),
+  http.post(`${sonarUrl}/api/user_tokens/generate`, async ({ request }) => {
+    const params = new URL(request.url).searchParams
+    const generated = makeSonarqubeGeneratedToken({ login: params.get('login') as string, name: params.get('name') as string })
+    db.token.create(generated)
+    return HttpResponse.json(generated)
+  }),
+  http.get(`${sonarUrl}/api/projects/search`, () => {
+    const projects = db.project.getAll()
+    return HttpResponse.json({ paging: makeSonarqubePaging({ total: projects.length }), components: projects })
+  }),
+  http.post(`${sonarUrl}/api/projects/delete`, async ({ request }) => {
+    const params = new URL(request.url).searchParams
+    db.project.deleteMany({ where: { key: { equals: params.get('project') as string } } })
+    return HttpResponse.json({})
+  }),
+  http.post(`${sonarUrl}/api/permissions/add_group`, () => HttpResponse.json({})),
+)
 
 describe('sonarqubeClientService', () => {
   let service: SonarqubeClientService
@@ -50,13 +106,8 @@ describe('sonarqubeClientService', () => {
   describe('userGroupsSearch', () => {
     it('should GET user_groups/search with auth', async () => {
       const group = makeSonarqubeGroup({ name: 'my-group' })
-      server.use(
-        http.get(`${sonarUrl}/api/user_groups/search`, ({ request }) => {
-          expect(request.headers.get('authorization')).toBe(sonarAuthHeader)
-          expect(new URL(request.url).searchParams.get('q')).toBe('my-group')
-          return HttpResponse.json({ paging: makeSonarqubePaging({ total: 1 }), groups: [group] })
-        }),
-      )
+      db.group.create(group)
+
       const result = await service.searchUserGroup({ q: 'my-group' })
       expect(result.groups).toEqual([group])
     })
@@ -64,26 +115,18 @@ describe('sonarqubeClientService', () => {
 
   describe('userGroupsCreate', () => {
     it('should POST user_groups/create', async () => {
-      server.use(
-        http.post(`${sonarUrl}/api/user_groups/create`, ({ request }) => {
-          expect(new URL(request.url).searchParams.get('name')).toBe('new-group')
-          return HttpResponse.json({})
-        }),
-      )
       await expect(service.createUserGroup({ name: 'new-group' })).resolves.not.toThrow()
+      expect(db.group.count({ where: { name: { equals: 'new-group' } } })).toBe(1)
     })
   })
 
   describe('usersSearch', () => {
     it('should GET users/search', async () => {
       const user = makeSonarqubeUser({ login: 'my-user' })
-      server.use(
-        http.get(`${sonarUrl}/api/users/search`, () =>
-          HttpResponse.json({ paging: makeSonarqubePaging({ total: 1 }), users: [user] })),
-      )
+      db.user.create(user)
+
       const result = await getAll(service.searchUsers({ q: 'my-user' }))
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual(user)
+      expect(result).toEqual([user])
     })
   })
 
@@ -96,16 +139,8 @@ describe('sonarqubeClientService', () => {
         name: faker.internet.username(),
         password: faker.internet.password(),
       } satisfies CreateUserParams
-      server.use(
-        http.post(`${sonarUrl}/api/users/create`, ({ request }) => {
-          const params = new URL(request.url).searchParams
-          expect(params.get('login')).toBe(user.login)
-          expect(params.get('email')).toBe(user.email)
-          expect(params.get('local')).toBe(user.local)
-          return HttpResponse.json({})
-        }),
-      )
       await service.createUser(user)
+      expect(db.user.count({ where: { login: { equals: user.login } } })).toBe(1)
     })
   })
 
@@ -115,15 +150,9 @@ describe('sonarqubeClientService', () => {
         login: faker.internet.username(),
         anonymize: true,
       } satisfies DeactivateUserParams
-      server.use(
-        http.post(`${sonarUrl}/api/users/deactivate`, ({ request }) => {
-          const params = new URL(request.url).searchParams
-          expect(params.get('login')).toBe(user.login)
-          expect(params.get('anonymize')).toBe(String(user.anonymize))
-          return HttpResponse.json({})
-        }),
-      )
+      db.user.create(makeSonarqubeUser({ login: user.login }))
       await service.deactivateUser(user)
+      expect(db.user.count({ where: { login: { equals: user.login } } })).toBe(0)
     })
   })
 
@@ -134,45 +163,35 @@ describe('sonarqubeClientService', () => {
         login: token.login,
         name: token.name,
       } satisfies RevokeUserTokenParams
-      server.use(
-        http.post(`${sonarUrl}/api/user_tokens/revoke`, () => HttpResponse.json({})),
-      )
+      db.token.create(token)
       await expect(service.revokeUserToken(revoke)).resolves.not.toThrow()
+      expect(db.token.count()).toBe(0)
     })
 
     it('should POST user_tokens/generate and return the token', async () => {
       const generated = makeSonarqubeGeneratedToken()
-      server.use(
-        http.post(`${sonarUrl}/api/user_tokens/generate`, () => HttpResponse.json(generated)),
-      )
       const result = await service.generateUserToken({ login: generated.login, name: generated.name })
-      expect(result.token).toBe(generated.token)
+      expect(result.token).toBeDefined()
+      expect(db.token.count({ where: { login: { equals: generated.login } } })).toBe(1)
     })
   })
 
   describe('projectsSearch', () => {
     it('should GET projects/search', async () => {
       const project = makeSonarqubeProject()
-      server.use(
-        http.get(`${sonarUrl}/api/projects/search`, () =>
-          HttpResponse.json({ paging: makeSonarqubePaging({ total: 1 }), components: [project] })),
-      )
+      db.project.create(project)
+
       const result = await getAll(service.searchProject({ q: project.name }))
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual(project)
+      expect(result).toEqual([project])
     })
   })
 
   describe('projectsDelete', () => {
     it('should POST projects/delete with project key as query param', async () => {
       const project = makeSonarqubeProject()
-      server.use(
-        http.post(`${sonarUrl}/api/projects/delete`, ({ request }) => {
-          expect(new URL(request.url).searchParams.get('project')).toBe(project.key)
-          return HttpResponse.json({})
-        }),
-      )
+      db.project.create(project)
       await service.deleteProject({ project: project.key })
+      expect(db.project.count({ where: { key: { equals: project.key } } })).toBe(0)
     })
   })
 
@@ -182,25 +201,10 @@ describe('sonarqubeClientService', () => {
         groupName: '/admin',
         permission: 'admin',
       } satisfies AddPermissionGroupParams
-      server.use(
-        http.post(`${sonarUrl}/api/permissions/add_group`, ({ request }) => {
-          const params = new URL(request.url).searchParams
-          expect(params.get('groupName')).toBe(group.groupName)
-          expect(params.get('permission')).toBe(group.permission)
-          expect(params.has('projectKey')).toBe(false)
-          return HttpResponse.json({})
-        }),
-      )
       await service.addPermissionGroup(group)
     })
 
     it('should POST permissions/add_group with projectKey for project-scoped call', async () => {
-      server.use(
-        http.post(`${sonarUrl}/api/permissions/add_group`, ({ request }) => {
-          expect(new URL(request.url).searchParams.get('projectKey')).toBe('proj-key')
-          return HttpResponse.json({})
-        }),
-      )
       await service.addPermissionGroup({ groupName: '/proj', permission: 'scan', projectKey: 'proj-key' })
     })
   })

--- a/apps/server-nestjs/src/modules/vault/vault-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/vault/vault-client.service.spec.ts
@@ -1,6 +1,7 @@
 import type { ConfigType } from '@nestjs/config'
 import { HttpStatus } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
+import { factory, primaryKey } from '@mswjs/data'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -12,17 +13,32 @@ import { VaultError, VaultHttpClientService } from './vault-http-client.service'
 
 const vaultUrl = 'https://vault.internal'
 
+const db = factory({
+  token: { id: primaryKey(() => 'created'), client_token: String },
+  secret: { path: primaryKey(String), data: Object, metadata: Object },
+})
+
 const server = setupServer(
   http.post(`${vaultUrl}/v1/auth/token/create`, () => {
-    return HttpResponse.json({ auth: { client_token: 'token' } })
+    const token = db.token.create({ client_token: 'token' })
+    return HttpResponse.json({ auth: { client_token: token.client_token } })
   }),
-  http.get(`${vaultUrl}/v1/kv/data/:path`, () => {
-    return HttpResponse.json({ data: { data: { secret: 'value' }, metadata: { created_time: '2023-01-01T00:00:00.000Z', version: 1 } } })
+  http.get(`${vaultUrl}/v1/kv/data/:path`, ({ params }) => {
+    const secret = db.secret.findFirst({ where: { path: { equals: params.path as string } } })
+    if (!secret) return HttpResponse.json({}, { status: HttpStatus.NOT_FOUND })
+    return HttpResponse.json({ data: { data: secret.data, metadata: secret.metadata } })
   }),
-  http.post(`${vaultUrl}/v1/kv/data/:path`, () => {
+  http.post(`${vaultUrl}/v1/kv/data/:path`, async ({ request, params }) => {
+    const body = await request.json() as { data: Record<string, unknown> }
+    db.secret.create({
+      path: params.path as string,
+      data: body.data,
+      metadata: { created_time: '2023-01-01T00:00:00.000Z', version: 1 },
+    })
     return HttpResponse.json({})
   }),
-  http.delete(`${vaultUrl}/v1/kv/metadata/:path`, () => {
+  http.delete(`${vaultUrl}/v1/kv/metadata/:path`, ({ params }) => {
+    db.secret.deleteMany({ where: { path: { equals: params.path as string } } })
     return new HttpResponse(null, { status: HttpStatus.NO_CONTENT })
   }),
 )
@@ -58,6 +74,12 @@ describe('vault', () => {
 
   describe('read', () => {
     it('should read secret', async () => {
+      db.secret.create({
+        path: 'path',
+        data: { secret: 'value' },
+        metadata: { created_time: '2023-01-01T00:00:00.000Z', version: 1 },
+      })
+
       const result = await service.read('path')
       expect(result).toEqual({
         data: { secret: 'value' },
@@ -66,11 +88,7 @@ describe('vault', () => {
     })
 
     it('should throw if 404', async () => {
-      server.use(
-        http.get(`${vaultUrl}/v1/kv/data/:path`, () => {
-          return HttpResponse.json({}, { status: HttpStatus.NOT_FOUND })
-        }),
-      )
+      db.secret.deleteMany({ where: { path: { equals: 'path' } } })
 
       await expect(service.read('path')).rejects.toBeInstanceOf(VaultError)
       await expect(service.read('path')).rejects.toMatchObject({ kind: 'NotFound', status: HttpStatus.NOT_FOUND })
@@ -106,13 +124,13 @@ describe('vault', () => {
   describe('write', () => {
     it('should write secret', async () => {
       await expect(service.write({ secret: 'value' }, 'path')).resolves.toBeUndefined()
+      expect(db.secret.count({ where: { path: { equals: 'path' } } })).toBe(1)
     })
 
     it('should expose reasons on error', async () => {
       server.use(
-        http.post(`${vaultUrl}/v1/kv/data/:path`, () => {
-          return HttpResponse.json({ errors: ['No secret engine mount at test-project/'] }, { status: HttpStatus.BAD_REQUEST })
-        }),
+        http.post(`${vaultUrl}/v1/kv/data/:path`, () =>
+          HttpResponse.json({ errors: ['No secret engine mount at test-project/'] }, { status: HttpStatus.BAD_REQUEST })),
       )
 
       await expect(service.write({ secret: 'value' }, 'path')).rejects.toBeInstanceOf(VaultError)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ catalogs:
     '@faker-js/faker':
       specifier: ^9.9.0
       version: 9.9.0
+    '@mswjs/data':
+      specifier: ^0.16.2
+      version: 0.16.2
     '@playwright/test':
       specifier: ^1.59.1
       version: 1.59.1
@@ -803,34 +806,34 @@ importers:
         version: 2.7.2
       '@nestjs/cache-manager':
         specifier: catalog:runtime
-        version: 3.1.3(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)
+        version: 3.1.3(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: catalog:runtime
-        version: 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
       '@nestjs/config':
         specifier: catalog:runtime
-        version: 4.0.3(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 4.0.3(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: catalog:runtime
-        version: 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/event-emitter':
         specifier: catalog:runtime
-        version: 3.0.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
+        version: 3.0.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)
       '@nestjs/jwt':
         specifier: catalog:runtime
-        version: 11.0.2(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))
+        version: 11.0.2(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))
       '@nestjs/platform-fastify':
         specifier: catalog:runtime
-        version: 11.1.27(@fastify/static@10.1.2)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
+        version: 11.1.27(@fastify/static@10.1.2)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)
       '@nestjs/schedule':
         specifier: catalog:runtime
-        version: 6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
+        version: 6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)
       '@nestjs/swagger':
         specifier: catalog:runtime
-        version: 11.4.1(@fastify/static@10.1.2)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)
+        version: 11.4.1(@fastify/static@10.1.2)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)
       '@nestjs/terminus':
         specifier: catalog:runtime
-        version: 11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@opentelemetry/api':
         specifier: catalog:otel
         version: 1.9.1
@@ -887,7 +890,7 @@ importers:
         version: 4.2.0
       nestjs-pino:
         specifier: catalog:runtime
-        version: 4.6.0(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2)
+        version: 4.6.0(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2)
       prisma:
         specifier: catalog:runtime
         version: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
@@ -928,6 +931,9 @@ importers:
       '@faker-js/faker':
         specifier: catalog:test
         version: 9.9.0
+      '@mswjs/data':
+        specifier: catalog:test
+        version: 0.16.2(@types/node@26.1.2)(typescript@5.9.3)
       '@nestjs/cli':
         specifier: catalog:build
         version: 11.0.16(@types/node@26.1.2)(esbuild@0.28.1)(lightningcss@1.33.0)
@@ -936,7 +942,7 @@ importers:
         version: 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: catalog:build
-        version: 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.16)
+        version: 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.16)
       '@types/node':
         specifier: catalog:types
         version: 26.1.2
@@ -2972,6 +2978,10 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@mswjs/data@0.16.2':
+    resolution: {integrity: sha512-/C0d/PBcJyQJokUhcjO4HiZPc67hzllKlRtD1XELygl2t991/ATAAQJVcStn4YtVALsNodruzOHT0JIvgr0hnA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
@@ -4558,8 +4568,14 @@ packages:
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
+  '@types/lodash@4.17.25':
+    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
+
   '@types/luxon@3.7.1':
     resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
+
+  '@types/md5@2.3.6':
+    resolution: {integrity: sha512-WD69gNXtRBnpknfZcb4TRQ0XJQbUPZcai/Qdhmka3sxUR3Et8NrXoeAoknG/LghYHTf4ve795rInVYHBTQdNVA==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -4585,6 +4601,9 @@ packages:
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
+  '@types/pluralize@0.0.29':
+    resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
@@ -4605,6 +4624,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/uuid@8.3.4':
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
 
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
@@ -5378,6 +5400,9 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
   check-disk-space@3.4.0:
     resolution: {integrity: sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==}
     engines: {node: '>=16'}
@@ -5627,6 +5652,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
@@ -5670,6 +5698,10 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -6778,6 +6810,9 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
@@ -7324,6 +7359,9 @@ packages:
 
   mathml-tag-names@4.0.0:
     resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
+
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -11285,6 +11323,28 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@mswjs/data@0.16.2(@types/node@26.1.2)(typescript@5.9.3)':
+    dependencies:
+      '@types/lodash': 4.17.25
+      '@types/md5': 2.3.6
+      '@types/pluralize': 0.0.29
+      '@types/uuid': 8.3.4
+      date-fns: 2.30.0
+      debug: 4.4.3(supports-color@5.5.0)
+      graphql: 16.14.2
+      lodash: 4.18.1
+      md5: 2.3.0
+      outvariant: 1.4.3
+      pluralize: 8.0.0
+      strict-event-emitter: 0.5.1
+      uuid: 11.1.1
+    optionalDependencies:
+      msw: 2.12.10(@types/node@26.1.2)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - typescript
+
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -11301,10 +11361,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@nestjs/cache-manager@3.1.3(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)':
+  '@nestjs/cache-manager@3.1.3(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cache-manager: 7.2.8
       keyv: 5.6.0
       rxjs: 7.8.2
@@ -11344,9 +11404,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)':
     dependencies:
-      file-type: 21.3.4
+      file-type: 21.3.4(supports-color@5.5.0)
       iterare: 1.2.1
       load-esm: 1.0.3
       reflect-metadata: 0.2.2
@@ -11356,17 +11416,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/config@4.0.3(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@nestjs/config@4.0.3(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
       dotenv: 17.2.3
       dotenv-expand: 12.0.3
       lodash: 4.18.1
       rxjs: 7.8.2
 
-  '@nestjs/core@11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
       path-to-regexp: 8.4.2
@@ -11375,29 +11435,29 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
+      '@nestjs/platform-express': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)
 
-  '@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)':
+  '@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       eventemitter2: 6.4.9
 
-  '@nestjs/jwt@11.0.2(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+  '@nestjs/jwt@11.0.2(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
       '@types/jsonwebtoken': 9.0.10
       jsonwebtoken: 9.0.3
 
-  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(reflect-metadata@0.2.2)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
       reflect-metadata: 0.2.2
 
-  '@nestjs/platform-express@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)':
+  '@nestjs/platform-express@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.6
       express: 5.2.1
       multer: 2.2.0
@@ -11407,12 +11467,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@nestjs/platform-fastify@11.1.27(@fastify/static@10.1.2)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)':
+  '@nestjs/platform-fastify@11.1.27(@fastify/static@10.1.2)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)':
     dependencies:
       '@fastify/cors': 11.2.0
       '@fastify/formbody': 8.0.2
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       fast-querystring: 1.1.2
       fastify: 5.8.5
       fastify-plugin: 6.0.0
@@ -11424,10 +11484,10 @@ snapshots:
     optionalDependencies:
       '@fastify/static': 10.1.2
 
-  '@nestjs/schedule@6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)':
+  '@nestjs/schedule@6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
 
   '@nestjs/schematics@11.0.9(chokidar@4.0.3)(typescript@5.9.3)':
@@ -11441,12 +11501,12 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@11.4.1(@fastify/static@10.1.2)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@11.4.1(@fastify/static@10.1.2)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(reflect-metadata@0.2.2)
       js-yaml: 4.3.1
       lodash: 4.18.1
       path-to-regexp: 8.4.2
@@ -11455,10 +11515,10 @@ snapshots:
     optionalDependencies:
       '@fastify/static': 10.1.2
 
-  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       boxen: 5.1.2
       check-disk-space: 3.4.0
       reflect-metadata: 0.2.2
@@ -11468,13 +11528,13 @@ snapshots:
       '@grpc/proto-loader': 0.8.0
       '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
 
-  '@nestjs/testing@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.16)':
+  '@nestjs/testing@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.16)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
+      '@nestjs/core': 11.1.28(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)
+      '@nestjs/platform-express': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(@nestjs/core@11.1.28)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -12875,7 +12935,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -12888,7 +12948,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@5.5.0)':
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       token-types: 6.1.2
@@ -13004,7 +13064,11 @@ snapshots:
 
   '@types/katex@0.16.8': {}
 
+  '@types/lodash@4.17.25': {}
+
   '@types/luxon@3.7.1': {}
+
+  '@types/md5@2.3.6': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -13038,6 +13102,8 @@ snapshots:
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
+  '@types/pluralize@0.0.29': {}
+
   '@types/resolve@1.20.2': {}
 
   '@types/statuses@2.0.6': {}
@@ -13053,6 +13119,8 @@ snapshots:
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/uuid@8.3.4': {}
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.5.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.5.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -14162,6 +14230,8 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  charenc@0.0.2: {}
+
   check-disk-space@3.4.0: {}
 
   chokidar@3.6.0:
@@ -14390,6 +14460,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  crypt@0.0.2: {}
+
   crypto-random-string@2.0.0: {}
 
   css-functions-list@3.3.3: {}
@@ -14432,6 +14504,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
 
   date-fns@4.1.0: {}
 
@@ -15264,9 +15340,9 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-type@21.3.4:
+  file-type@21.3.4(supports-color@5.5.0):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@5.5.0)
       strtok3: 10.3.4
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -15797,6 +15873,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@1.1.6: {}
 
   is-builtin-module@5.0.0:
     dependencies:
@@ -16329,6 +16407,12 @@ snapshots:
 
   mathml-tag-names@4.0.0: {}
 
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+
   mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -16843,9 +16927,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nestjs-pino@4.6.0(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2):
+  nestjs-pino@4.6.0(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2):
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@5.5.0)
       pino: 10.3.1
       pino-http: 11.0.0
       rxjs: 7.8.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -156,6 +156,7 @@ catalogs:
     globals: ^16.5.0
     jsdom: ^25.0.1
     msw: ^2.12.10
+    "@mswjs/data": ^0.16.2
     vitest: ^4.1.5
   types:
     "@types/jsdom": ^21.1.7


### PR DESCRIPTION
## Issues liées

Aucune issue liée (refactor interne).

## Quel est le comportement actuel ?

Le mock HTTP des tests utilise des handlers MSW déclaratifs par endpoint, dupliqués entre les fichiers de test.

## Quel est le nouveau comportement ?

Refactor des mocks HTTP vers une approche data-driven reposant sur `@mswjs/data` : un modèle de données unique alimente les handlers MSW, réduisant la duplication et centralisant la simulation des réponses API dans les tests.

## Cette PR introduit-elle un breaking change ?

Non.