### PR TITLE
feat(server-nestjs): add repository datastore service

### DIFF
--- a/apps/server-nestjs/src/modules/repository/repository-datastore.service.spec.ts
+++ b/apps/server-nestjs/src/modules/repository/repository-datastore.service.spec.ts
@@ -1,0 +1,150 @@
+import type { TestingModule } from '@nestjs/testing'
+import type { Repository } from '@prisma/client'
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { faker } from '@faker-js/faker'
+import { Test } from '@nestjs/testing'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { RepositoryDatastoreService } from './repository-datastore.service'
+import {
+  makeExternalRepository,
+  makeInternalRepository,
+  stubRepositoryTable,
+} from './repository-testing.utils'
+
+describe('repositoryDatastoreService', () => {
+  let module: TestingModule
+  let service: RepositoryDatastoreService
+  let prisma: DeepMockProxy<PrismaService>
+
+  let projectId: string
+  let rows: Repository[]
+
+  beforeEach(async () => {
+    projectId = faker.string.uuid()
+    rows = []
+    prisma = mockDeep<PrismaService>()
+    stubRepositoryTable(prisma, () => rows)
+
+    module = await Test.createTestingModule({
+      providers: [
+        RepositoryDatastoreService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile()
+
+    service = module.get(RepositoryDatastoreService)
+  })
+
+  describe('getRepositoriesByProjectId', () => {
+    it('returns only the repositories of the given project', async () => {
+      const mine = makeInternalRepository({ projectId })
+      rows = [mine, makeInternalRepository()]
+
+      const result = await service.getRepositoriesByProjectId(projectId)
+
+      expect(result).toEqual([mine])
+    })
+
+    it('returns the repositories from the oldest to the most recently created', async () => {
+      const oldest = makeInternalRepository({ projectId, createdAt: new Date('2024-01-01') })
+      const middle = makeExternalRepository({ projectId, createdAt: new Date('2024-06-01') })
+      const newest = makeInternalRepository({ projectId, createdAt: new Date('2025-02-01') })
+      rows = [newest, oldest, middle]
+
+      const result = await service.getRepositoriesByProjectId(projectId)
+
+      expect(result).toEqual([oldest, middle, newest])
+    })
+
+    it('returns an empty list when the project has no repository', async () => {
+      rows = [makeInternalRepository()]
+
+      const result = await service.getRepositoriesByProjectId(projectId)
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getRepositoryById', () => {
+    it('returns the repository matching the id', async () => {
+      const repository = makeExternalRepository()
+      prisma.repository.findUniqueOrThrow.mockResolvedValue(repository)
+
+      const result = await service.getRepositoryById(repository.id)
+
+      expect(result).toEqual(repository)
+    })
+
+    it('rejects when no repository matches the id', async () => {
+      prisma.repository.findUniqueOrThrow.mockRejectedValue(new Error('No Repository found'))
+
+      await expect(service.getRepositoryById(faker.string.uuid())).rejects.toThrow()
+    })
+  })
+
+  describe('hasRepositoryWithName', () => {
+    it('returns true when a repository with the internal name exists in the project', async () => {
+      const repository = makeInternalRepository({ projectId })
+      rows = [repository]
+
+      const result = await service.hasRepositoryWithName(projectId, repository.internalRepoName)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when no repository with the internal name exists in the project', async () => {
+      rows = [makeInternalRepository({ projectId })]
+
+      const result = await service.hasRepositoryWithName(projectId, faker.string.alphanumeric(8).toLowerCase())
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when the internal name is only taken in another project', async () => {
+      const repository = makeInternalRepository()
+      rows = [repository]
+
+      const result = await service.hasRepositoryWithName(projectId, repository.internalRepoName)
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('createRepository', () => {
+    it('returns the created repository', async () => {
+      const repository = makeInternalRepository({ projectId })
+      prisma.repository.create.mockResolvedValue(repository)
+
+      const result = await service.createRepository({
+        projectId,
+        internalRepoName: repository.internalRepoName,
+      })
+
+      expect(result).toEqual(repository)
+    })
+  })
+
+  describe('updateRepository', () => {
+    it('returns the updated repository', async () => {
+      const repository = makeExternalRepository({ isPrivate: false })
+      prisma.repository.update.mockResolvedValue(repository)
+
+      const result = await service.updateRepository(repository.id, { isPrivate: false })
+
+      expect(result).toEqual(repository)
+    })
+  })
+
+  describe('deleteRepository', () => {
+    it('returns the deleted repository', async () => {
+      const repository = makeInternalRepository()
+      prisma.repository.delete.mockResolvedValue(repository)
+
+      const result = await service.deleteRepository(repository.id)
+
+      expect(result).toEqual(repository)
+    })
+  })
+})

--- a/apps/server-nestjs/src/modules/repository/repository-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/repository/repository-datastore.service.ts
@@ -1,0 +1,45 @@
+import type { Prisma, Repository } from '@prisma/client'
+import { Inject, Injectable } from '@nestjs/common'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+
+@Injectable()
+export class RepositoryDatastoreService {
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  getRepositoriesByProjectId(projectId: string): Promise<Repository[]> {
+    return this.prisma.repository.findMany({
+      where: { projectId },
+      orderBy: { createdAt: 'asc' },
+    })
+  }
+
+  getRepositoryById(repositoryId: string): Promise<Repository> {
+    return this.prisma.repository.findUniqueOrThrow({
+      where: { id: repositoryId },
+    })
+  }
+
+  async hasRepositoryWithName(projectId: string, internalRepoName: string): Promise<boolean> {
+    const count = await this.prisma.repository.count({
+      where: { projectId, internalRepoName },
+    })
+    return count > 0
+  }
+
+  createRepository(data: Prisma.RepositoryUncheckedCreateInput): Promise<Repository> {
+    return this.prisma.repository.create({ data })
+  }
+
+  updateRepository(repositoryId: string, data: Prisma.RepositoryUncheckedUpdateInput): Promise<Repository> {
+    return this.prisma.repository.update({
+      where: { id: repositoryId },
+      data,
+    })
+  }
+
+  deleteRepository(repositoryId: string): Promise<Repository> {
+    return this.prisma.repository.delete({
+      where: { id: repositoryId },
+    })
+  }
+}

--- a/apps/server-nestjs/src/modules/repository/repository-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/repository/repository-testing.utils.ts
@@ -1,0 +1,82 @@
+import type { Prisma, Repository } from '@prisma/client'
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import type { PrismaService } from '../infrastructure/database/prisma.service'
+import { faker } from '@faker-js/faker'
+
+export function makeRepository(overrides: Partial<Repository> = {}): Repository {
+  return {
+    id: faker.string.uuid(),
+    projectId: faker.string.uuid(),
+    internalRepoName: faker.string.alphanumeric(8).toLowerCase(),
+    externalRepoUrl: '',
+    externalUserName: '',
+    isInfra: false,
+    isPrivate: false,
+    deployRevision: '',
+    deployPath: '',
+    helmValuesFiles: '',
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  }
+}
+
+// Repository without an external source: nothing is mirrored.
+export function makeInternalRepository(overrides: Partial<Repository> = {}): Repository {
+  return makeRepository({
+    externalRepoUrl: '',
+    externalUserName: '',
+    isPrivate: false,
+    ...overrides,
+  })
+}
+
+// Repository mirroring an external source, private by default (hence with credentials).
+export function makeExternalRepository(overrides: Partial<Repository> = {}): Repository {
+  return makeRepository({
+    externalRepoUrl: `https://github.com/${faker.string.alphanumeric(8).toLowerCase()}/${faker.string.alphanumeric(8).toLowerCase()}.git`,
+    externalUserName: faker.internet.username().toLowerCase(),
+    isPrivate: true,
+    ...overrides,
+  })
+}
+
+function matchesRepositoryWhere(repository: Repository, where?: Prisma.RepositoryWhereInput): boolean {
+  if (!where) return true
+  if (where.id !== undefined && repository.id !== where.id) return false
+  if (where.projectId !== undefined && repository.projectId !== where.projectId) return false
+  if (where.internalRepoName !== undefined && repository.internalRepoName !== where.internalRepoName) return false
+  return true
+}
+
+function sortRepositories(repositories: Repository[], orderBy: unknown): Repository[] {
+  if (typeof orderBy !== 'object' || orderBy === null || !('createdAt' in orderBy)) return repositories
+  const direction = orderBy.createdAt === 'desc' ? -1 : 1
+  return [...repositories].sort((a, b) => direction * (a.createdAt.getTime() - b.createdAt.getTime()))
+}
+
+// Prisma delegates return a branded promise, which mock implementations have to mimic.
+function prismaPromise<T>(value: T): Prisma.PrismaPromise<T> {
+  const promise = Promise.resolve(value)
+  return {
+    then: promise.then.bind(promise),
+    catch: promise.catch.bind(promise),
+    finally: promise.finally.bind(promise),
+    [Symbol.toStringTag]: 'PrismaPromise',
+  }
+}
+
+/**
+ * Backs the read queries of the repository table with an in-memory list, so tests can
+ * observe what a service returns instead of which arguments it forwards to Prisma.
+ * Only the filters and orderings the console actually issues are honoured.
+ */
+export function stubRepositoryTable(prisma: DeepMockProxy<PrismaService>, getRepositories: () => Repository[]): void {
+  prisma.repository.findMany.mockImplementation(args => prismaPromise(
+    sortRepositories(getRepositories().filter(repository => matchesRepositoryWhere(repository, args?.where)), args?.orderBy),
+  ))
+
+  prisma.repository.count.mockImplementation(args => prismaPromise(
+    getRepositories().filter(repository => matchesRepositoryWhere(repository, args?.where)).length,
+  ))
+}


### PR DESCRIPTION
## Issues liées

Issues numéro: #2423 

---------

> PR 3/5 de la pile « repository API v2 ». Base : `feat/repository-v2-contract`.

## Quel est le comportement actuel ?

`server-nestjs` n'a aucun accès aux dépôts : toutes les requêtes Prisma sur la table
`Repository` sont faites depuis le serveur legacy.

## Quel est le nouveau comportement ?

Ajout de `RepositoryDatastoreService`, la seule couche autorisée à parler à Prisma pour
les dépôts :

- `getRepositoriesByProjectId` (tri `createdAt asc`)
- `getRepositoryById` (`findUniqueOrThrow`)
- `hasRepositoryWithName` (unicité du nom interne dans un projet)
- `createRepository` / `updateRepository` / `deleteRepository`

Ajout de `repository-testing.utils.ts` (`makeRepository`, basé sur faker) partagé par les
tests des couches suivantes, et de la couverture unitaire du datastore.

## Cette PR introduit-elle un breaking change ?

Non. Aucun consommateur n'est encore branché sur ce service.

## Autres informations

Le service n'est volontairement enregistré dans aucun module à ce stade : le module Nest
arrive avec le controller, en fin de pile.
