### PR TITLE
feat(server-nestjs): add repository service and mapping utils

### DIFF
--- a/apps/server-nestjs/src/modules/events/app-events.service.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.service.ts
@@ -25,6 +25,7 @@ export type EventLogAction
     | 'Create Deployment' | 'Update Deployment' | 'Delete Deployment'
     | 'Delete all project deployments'
     | 'Create Environment' | 'Update Environment' | 'Delete Environment'
+    | 'Create Repository' | 'Update Repository' | 'Delete Repository'
     | 'Add Project Member' | 'Update Project Member' | 'Remove Project Member'
 
 export interface EventContext {

--- a/apps/server-nestjs/src/modules/repository/repository.service.spec.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.service.spec.ts
@@ -1,0 +1,239 @@
+import type { CreateRepository, UpdateRepository } from '@cpn-console/shared'
+import type { TestingModule } from '@nestjs/testing'
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { faker } from '@faker-js/faker'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { AppEventsService } from '../events/app-events.service'
+import { VaultClientService } from '../vault/vault-client.service'
+import { RepositoryDatastoreService } from './repository-datastore.service'
+import { makeRepository } from './repository-testing.utils'
+import { RepositoryService } from './repository.service'
+
+describe('repositoryService', () => {
+  let module: TestingModule
+  let service: RepositoryService
+  let datastore: DeepMockProxy<RepositoryDatastoreService>
+  let appEvents: DeepMockProxy<AppEventsService>
+  let vault: DeepMockProxy<VaultClientService>
+
+  let projectId: string
+  let projectSlug: string
+  let repositoryId: string
+  let userId: string
+  let requestId: string
+  let validCreateRepository: CreateRepository
+  let validUpdateRepository: UpdateRepository
+
+  beforeEach(async () => {
+    projectId = faker.string.uuid()
+    projectSlug = faker.string.alphanumeric(8).toLowerCase()
+    repositoryId = faker.string.uuid()
+    userId = faker.string.uuid()
+    requestId = faker.string.uuid()
+    validCreateRepository = {
+      internalRepoName: faker.string.alphanumeric(8).toLowerCase(),
+      externalRepoUrl: `https://${faker.internet.domainName()}/repo.git`,
+      externalUserName: faker.internet.username(),
+      externalToken: faker.string.alphanumeric(16),
+      isInfra: false,
+      isPrivate: true,
+      deployRevision: 'HEAD',
+      deployPath: '.',
+      helmValuesFiles: '',
+    }
+    validUpdateRepository = {
+      isPrivate: false,
+      deployRevision: faker.git.branch(),
+    }
+
+    datastore = mockDeep<RepositoryDatastoreService>()
+    appEvents = mockDeep<AppEventsService>()
+    vault = mockDeep<VaultClientService>()
+
+    module = await Test.createTestingModule({
+      providers: [
+        RepositoryService,
+        { provide: RepositoryDatastoreService, useValue: datastore },
+        { provide: AppEventsService, useValue: appEvents },
+        { provide: VaultClientService, useValue: vault },
+      ],
+    }).compile()
+
+    service = module.get<RepositoryService>(RepositoryService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  describe('listByProjectId', () => {
+    it('returns the repositories of the project', async () => {
+      const repositories = [
+        makeRepository({ projectId, internalRepoName: 'alpha' }),
+        makeRepository({ projectId, internalRepoName: 'bravo' }),
+        makeRepository({ projectId, internalRepoName: 'charlie' }),
+      ]
+      datastore.getRepositoriesByProjectId.mockResolvedValue(repositories)
+
+      const result = await service.listByProjectId(projectId)
+
+      expect(datastore.getRepositoriesByProjectId).toHaveBeenCalledWith(projectId)
+      expect(result).toEqual(repositories)
+    })
+  })
+
+  describe('createRepository', () => {
+    it('creates a private repository, seeds the mirror token in Vault before reconciling', async () => {
+      const repository = makeRepository({ id: repositoryId, projectId, internalRepoName: validCreateRepository.internalRepoName, isPrivate: true })
+      datastore.hasRepositoryWithName.mockResolvedValue(false)
+      datastore.createRepository.mockResolvedValue(repository)
+      vault.writeGitlabMirrorCreds.mockResolvedValue(undefined)
+      appEvents.emitProjectEvent.mockResolvedValue({})
+
+      const result = await service.createRepository(projectId, projectSlug, validCreateRepository, userId, requestId)
+
+      expect(datastore.hasRepositoryWithName).toHaveBeenCalledWith(projectId, validCreateRepository.internalRepoName)
+      expect(datastore.createRepository).toHaveBeenCalledWith(expect.objectContaining({
+        projectId,
+        internalRepoName: validCreateRepository.internalRepoName,
+        isPrivate: true,
+      }))
+      expect(vault.writeGitlabMirrorCreds).toHaveBeenCalledWith(projectSlug, repository.internalRepoName, {
+        GIT_INPUT_USER: validCreateRepository.isPrivate ? validCreateRepository.externalUserName : undefined,
+        GIT_INPUT_PASSWORD: validCreateRepository.isPrivate ? validCreateRepository.externalToken : undefined,
+      })
+      // The token must reach Vault before the (fire-and-forget) reconciliation reads it.
+      expect(vault.writeGitlabMirrorCreds.mock.invocationCallOrder[0])
+        .toBeLessThan(appEvents.emitProjectEvent.mock.invocationCallOrder[0])
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, {
+        action: 'Create Repository',
+        userId,
+        requestId,
+      })
+      expect(result).toEqual(repository)
+    })
+
+    it('does not touch Vault when creating a public repository', async () => {
+      const publicRepository = {
+        internalRepoName: faker.string.alphanumeric(8).toLowerCase(),
+        externalRepoUrl: '',
+        isInfra: false,
+        isPrivate: false,
+        deployRevision: 'HEAD',
+        deployPath: '.',
+        helmValuesFiles: '',
+      } satisfies CreateRepository
+      datastore.hasRepositoryWithName.mockResolvedValue(false)
+      datastore.createRepository.mockResolvedValue(makeRepository({ projectId, internalRepoName: publicRepository.internalRepoName, isPrivate: false }))
+      appEvents.emitProjectEvent.mockResolvedValue({})
+
+      await service.createRepository(projectId, projectSlug, publicRepository, userId, requestId)
+
+      expect(vault.writeGitlabMirrorCreds).not.toHaveBeenCalled()
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, expect.objectContaining({ action: 'Create Repository' }))
+    })
+
+    it('rejects when a repository with the same internal name already exists', async () => {
+      datastore.hasRepositoryWithName.mockResolvedValue(true)
+
+      await expect(service.createRepository(projectId, projectSlug, validCreateRepository, userId, requestId))
+        .rejects.toThrow(BadRequestException)
+      expect(datastore.createRepository).not.toHaveBeenCalled()
+      expect(vault.writeGitlabMirrorCreds).not.toHaveBeenCalled()
+      expect(appEvents.emitProjectEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateRepository', () => {
+    it('writes a new token to Vault before reconciling, using the updated row username', async () => {
+      const externalToken = faker.string.alphanumeric(16)
+      const updated = makeRepository({ id: repositoryId, projectId, isPrivate: true, externalUserName: faker.internet.username() })
+      datastore.getRepositoryById.mockResolvedValue(makeRepository({ id: repositoryId, projectId }))
+      datastore.updateRepository.mockResolvedValue(updated)
+      vault.writeGitlabMirrorCreds.mockResolvedValue(undefined)
+      appEvents.emitProjectEvent.mockResolvedValue({})
+
+      const result = await service.updateRepository(projectId, projectSlug, repositoryId, { isPrivate: true, externalToken }, userId, requestId)
+
+      expect(vault.writeGitlabMirrorCreds).toHaveBeenCalledWith(projectSlug, updated.internalRepoName, {
+        GIT_INPUT_USER: updated.externalUserName,
+        GIT_INPUT_PASSWORD: externalToken,
+      })
+      expect(vault.writeGitlabMirrorCreds.mock.invocationCallOrder[0])
+        .toBeLessThan(appEvents.emitProjectEvent.mock.invocationCallOrder[0])
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, {
+        action: 'Update Repository',
+        userId,
+        requestId,
+      })
+      expect(result).toEqual(updated)
+    })
+
+    it('clears the Vault credentials when the repository is turned public', async () => {
+      const updated = makeRepository({ id: repositoryId, projectId, isPrivate: false })
+      datastore.getRepositoryById.mockResolvedValue(makeRepository({ id: repositoryId, projectId }))
+      datastore.updateRepository.mockResolvedValue(updated)
+      vault.deleteGitlabMirrorCreds.mockResolvedValue(undefined)
+      appEvents.emitProjectEvent.mockResolvedValue({})
+
+      await service.updateRepository(projectId, projectSlug, repositoryId, { isPrivate: false }, userId, requestId)
+
+      expect(vault.deleteGitlabMirrorCreds).toHaveBeenCalledWith(projectSlug, updated.internalRepoName)
+      expect(vault.writeGitlabMirrorCreds).not.toHaveBeenCalled()
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, expect.objectContaining({ action: 'Update Repository' }))
+    })
+
+    it('leaves Vault untouched when the update carries no credential change', async () => {
+      const updated = makeRepository({ id: repositoryId, projectId })
+      datastore.getRepositoryById.mockResolvedValue(updated)
+      datastore.updateRepository.mockResolvedValue(updated)
+      appEvents.emitProjectEvent.mockResolvedValue({})
+
+      await service.updateRepository(projectId, projectSlug, repositoryId, { deployRevision: faker.git.branch() }, userId, requestId)
+
+      expect(vault.writeGitlabMirrorCreds).not.toHaveBeenCalled()
+      expect(vault.deleteGitlabMirrorCreds).not.toHaveBeenCalled()
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, expect.objectContaining({ action: 'Update Repository' }))
+    })
+
+    it('rejects when the repository belongs to another project', async () => {
+      datastore.getRepositoryById.mockResolvedValue(makeRepository({ id: repositoryId, projectId: faker.string.uuid() }))
+
+      await expect(service.updateRepository(projectId, projectSlug, repositoryId, validUpdateRepository, userId, requestId))
+        .rejects.toThrow(NotFoundException)
+      expect(datastore.updateRepository).not.toHaveBeenCalled()
+      expect(vault.writeGitlabMirrorCreds).not.toHaveBeenCalled()
+      expect(vault.deleteGitlabMirrorCreds).not.toHaveBeenCalled()
+      expect(appEvents.emitProjectEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteRepository', () => {
+    it('deletes the repository and triggers the project reconciliation', async () => {
+      datastore.getRepositoryById.mockResolvedValue(makeRepository({ id: repositoryId, projectId }))
+      datastore.deleteRepository.mockResolvedValue(makeRepository({ id: repositoryId, projectId }))
+      appEvents.emitProjectEvent.mockResolvedValue({})
+
+      await service.deleteRepository(projectId, repositoryId, userId, requestId)
+
+      expect(datastore.deleteRepository).toHaveBeenCalledWith(repositoryId)
+      expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, {
+        action: 'Delete Repository',
+        userId,
+        requestId,
+      })
+    })
+
+    it('rejects when the repository belongs to another project', async () => {
+      datastore.getRepositoryById.mockResolvedValue(makeRepository({ id: repositoryId, projectId: faker.string.uuid() }))
+
+      await expect(service.deleteRepository(projectId, repositoryId, userId, requestId))
+        .rejects.toThrow(NotFoundException)
+      expect(datastore.deleteRepository).not.toHaveBeenCalled()
+      expect(appEvents.emitProjectEvent).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/server-nestjs/src/modules/repository/repository.service.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.service.ts
@@ -1,0 +1,116 @@
+import type { CreateRepository, UpdateRepository } from '@cpn-console/shared'
+import type { Repository } from '@prisma/client'
+import type { EventLogAction } from '../events/app-events.service'
+import type { RepositoryMirrorCredentialUpdate } from './repository.utils'
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { AppEventsService } from '../events/app-events.service'
+import { VaultClientService } from '../vault/vault-client.service'
+import { RepositoryDatastoreService } from './repository-datastore.service'
+import { buildRepositoryCreateData, buildRepositoryUpdateData, parseRepositoryCredentialUpdate } from './repository.utils'
+
+@Injectable()
+export class RepositoryService {
+  private readonly logger = new Logger(RepositoryService.name)
+
+  constructor(
+    @Inject(RepositoryDatastoreService) private readonly repositoryDatastoreService: RepositoryDatastoreService,
+    @Inject(AppEventsService) private readonly appEvents: AppEventsService,
+    @Inject(VaultClientService) private readonly vault: VaultClientService,
+  ) {}
+
+  listByProjectId(projectId: string): Promise<Repository[]> {
+    return this.repositoryDatastoreService.getRepositoriesByProjectId(projectId)
+  }
+
+  async createRepository(projectId: string, projectSlug: string, repositoryToCreate: CreateRepository, userId: string, requestId: string): Promise<Repository> {
+    if (await this.repositoryDatastoreService.hasRepositoryWithName(projectId, repositoryToCreate.internalRepoName)) {
+      throw new BadRequestException(`Le nom du dépôt interne ${repositoryToCreate.internalRepoName} existe déjà en base pour ce projet`)
+    }
+
+    const repository = await this.repositoryDatastoreService.createRepository(
+      buildRepositoryCreateData(projectId, repositoryToCreate),
+    )
+
+    if (repositoryToCreate.isPrivate) {
+      // The external token is never persisted in the database — it only lives in Vault
+      // as the mirror input credentials. We must write it BEFORE emitting the
+      // reconciliation: the GitLab reconciler only reads and *preserves* the existing
+      // GIT_INPUT_PASSWORD from Vault (it never receives the token), and the reconcile
+      // runs fire-and-forget. A token written after — or racing — the reconcile would
+      // be lost, since it exists nowhere else once this request returns.
+      await this.vault.writeGitlabMirrorCreds(projectSlug, repository.internalRepoName, {
+        GIT_INPUT_USER: repositoryToCreate.externalUserName,
+        GIT_INPUT_PASSWORD: repositoryToCreate.externalToken,
+      })
+    }
+
+    this.reconcileProject(projectId, 'Create Repository', userId, requestId)
+    return repository
+  }
+
+  async updateRepository(projectId: string, projectSlug: string, repositoryId: string, repositoryToUpdate: UpdateRepository, userId: string, requestId: string): Promise<Repository> {
+    await this.getProjectRepositoryOrThrow(projectId, repositoryId)
+
+    const repository = await this.repositoryDatastoreService.updateRepository(
+      repositoryId,
+      buildRepositoryUpdateData(repositoryToUpdate),
+    )
+
+    // Apply the credential intent to Vault BEFORE emitting the reconciliation, for the
+    // same reason as on create: the token lives nowhere but Vault, the reconciler only
+    // preserves the GIT_INPUT_PASSWORD already stored there, and the reconcile is
+    // fire-and-forget — so the new token (or its removal) must be persisted first.
+    await this.applyMirrorCredentialUpdate(projectSlug, repository, parseRepositoryCredentialUpdate(repositoryToUpdate))
+
+    this.reconcileProject(projectId, 'Update Repository', userId, requestId)
+    return repository
+  }
+
+  private async applyMirrorCredentialUpdate(
+    projectSlug: string,
+    repository: Repository,
+    credentialUpdate: RepositoryMirrorCredentialUpdate,
+  ): Promise<void> {
+    switch (credentialUpdate.kind) {
+      case 'set':
+        // The mirror username comes from the just-updated row (legacy reads it from the
+        // DB, not the request); only the token is ephemeral to this call.
+        await this.vault.writeGitlabMirrorCreds(projectSlug, repository.internalRepoName, {
+          GIT_INPUT_USER: repository.externalUserName,
+          GIT_INPUT_PASSWORD: credentialUpdate.externalToken,
+        })
+        break
+      case 'clear':
+        await this.vault.deleteGitlabMirrorCreds(projectSlug, repository.internalRepoName)
+        break
+      case 'keep':
+        break
+    }
+  }
+
+  async deleteRepository(projectId: string, repositoryId: string, userId: string, requestId: string): Promise<void> {
+    await this.getProjectRepositoryOrThrow(projectId, repositoryId)
+    await this.repositoryDatastoreService.deleteRepository(repositoryId)
+    this.reconcileProject(projectId, 'Delete Repository', userId, requestId)
+  }
+
+  /** Ensures the repository exists and belongs to the project addressed in the route. */
+  private async getProjectRepositoryOrThrow(projectId: string, repositoryId: string): Promise<Repository> {
+    const repository = await this.repositoryDatastoreService.getRepositoryById(repositoryId)
+    if (repository.projectId !== projectId) {
+      throw new NotFoundException('Dépôt introuvable')
+    }
+    return repository
+  }
+
+  /**
+   * Triggers the project reconciliation without blocking the response: listener
+   * outcomes (including failures) are persisted in the admin log by AppEventsService.
+   */
+  private reconcileProject(projectId: string, action: EventLogAction, userId: string, requestId: string): void {
+    this.appEvents.emitProjectEvent('project.upsert', projectId, { action, userId, requestId })
+      .catch((error: unknown) => {
+        this.logger.error(`project.upsert reconciliation failed (projectId=${projectId})`, error instanceof Error ? error.stack : String(error))
+      })
+  }
+}

--- a/apps/server-nestjs/src/modules/repository/repository.utils.spec.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.utils.spec.ts
@@ -1,0 +1,138 @@
+import type { CreateRepository, UpdateRepository } from '@cpn-console/shared'
+import { faker } from '@faker-js/faker'
+import { describe, expect, it } from 'vitest'
+import { buildRepositoryCreateData, buildRepositoryUpdateData, parseRepositoryCredentialUpdate } from './repository.utils'
+
+describe('buildRepositoryCreateData', () => {
+  it('maps a private repository, keeping the username and never persisting the token', () => {
+    const projectId = faker.string.uuid()
+    const data = {
+      internalRepoName: faker.string.alphanumeric(8).toLowerCase(),
+      externalRepoUrl: `https://${faker.internet.domainName()}/repo.git`,
+      externalUserName: faker.internet.username(),
+      externalToken: faker.string.alphanumeric(16),
+      isInfra: true,
+      isPrivate: true,
+      deployRevision: faker.git.branch(),
+      deployPath: faker.system.directoryPath(),
+      helmValuesFiles: `${faker.word.noun()}.yaml`,
+    } satisfies CreateRepository
+
+    const result = buildRepositoryCreateData(projectId, data)
+
+    expect(result).toEqual({
+      projectId,
+      internalRepoName: data.internalRepoName,
+      externalRepoUrl: data.externalRepoUrl,
+      externalUserName: data.externalUserName,
+      isInfra: true,
+      isPrivate: true,
+      deployRevision: data.deployRevision,
+      deployPath: data.deployPath,
+      helmValuesFiles: data.helmValuesFiles,
+    })
+    expect(result).not.toHaveProperty('externalToken')
+  })
+
+  it('maps a public repository, falling back to empty strings for the absent url and username', () => {
+    const projectId = faker.string.uuid()
+    // Already-parsed body: the schema has defaulted the deployment fields at the boundary.
+    const data = {
+      internalRepoName: faker.string.alphanumeric(8).toLowerCase(),
+      externalRepoUrl: '',
+      isInfra: false,
+      isPrivate: false,
+      deployRevision: 'HEAD',
+      deployPath: '.',
+      helmValuesFiles: '',
+    } satisfies CreateRepository
+
+    const result = buildRepositoryCreateData(projectId, data)
+
+    expect(result).toEqual({
+      projectId,
+      internalRepoName: data.internalRepoName,
+      externalRepoUrl: '',
+      externalUserName: '',
+      isInfra: false,
+      isPrivate: false,
+      deployRevision: 'HEAD',
+      deployPath: '.',
+      helmValuesFiles: '',
+    })
+    expect(result).not.toHaveProperty('externalToken')
+  })
+})
+
+describe('buildRepositoryUpdateData', () => {
+  it('never persists the external token', () => {
+    const data = { externalToken: faker.string.alphanumeric(16), isPrivate: true } satisfies UpdateRepository
+
+    const result = buildRepositoryUpdateData(data)
+
+    expect(result).not.toHaveProperty('externalToken')
+    expect(result).toEqual({ isPrivate: true })
+  })
+
+  it('keeps the stored external username when the repository becomes public', () => {
+    const data = { isPrivate: false, externalUserName: faker.internet.username() } satisfies UpdateRepository
+
+    const result = buildRepositoryUpdateData(data)
+
+    expect(result).toEqual({ isPrivate: false })
+    expect(result).not.toHaveProperty('externalUserName')
+  })
+
+  it('updates the external username when the repository stays private', () => {
+    const externalUserName = faker.internet.username()
+    const data = { isPrivate: true, externalUserName } satisfies UpdateRepository
+
+    const result = buildRepositoryUpdateData(data)
+
+    expect(result).toEqual({ isPrivate: true, externalUserName })
+  })
+
+  it('passes through the other updatable fields', () => {
+    const data = {
+      externalRepoUrl: `https://${faker.internet.domainName()}/repo.git`,
+      isInfra: true,
+      deployRevision: faker.git.branch(),
+      deployPath: faker.system.directoryPath(),
+      helmValuesFiles: `${faker.word.noun()}.yaml`,
+    } satisfies UpdateRepository
+
+    const result = buildRepositoryUpdateData(data)
+
+    expect(result).toEqual({
+      externalRepoUrl: data.externalRepoUrl,
+      isInfra: true,
+      deployRevision: data.deployRevision,
+      deployPath: data.deployPath,
+      helmValuesFiles: data.helmValuesFiles,
+    })
+  })
+})
+
+describe('parseRepositoryCredentialUpdate', () => {
+  it('returns "set" when a new token is supplied', () => {
+    const externalToken = faker.string.alphanumeric(16)
+
+    expect(parseRepositoryCredentialUpdate({ isPrivate: true, externalToken }))
+      .toEqual({ kind: 'set', externalToken })
+  })
+
+  it('returns "clear" when the repository is turned public', () => {
+    expect(parseRepositoryCredentialUpdate({ isPrivate: false, externalToken: faker.string.alphanumeric(16) }))
+      .toEqual({ kind: 'clear' })
+  })
+
+  it('returns "keep" when the body carries no token', () => {
+    expect(parseRepositoryCredentialUpdate({ deployRevision: faker.git.branch() }))
+      .toEqual({ kind: 'keep' })
+  })
+
+  it('treats an empty token as "keep" (unchanged), never a write', () => {
+    expect(parseRepositoryCredentialUpdate({ isPrivate: true, externalToken: '' }))
+      .toEqual({ kind: 'keep' })
+  })
+})

--- a/apps/server-nestjs/src/modules/repository/repository.utils.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.utils.ts
@@ -1,0 +1,88 @@
+import type { CreateRepository, UpdateRepository } from '@cpn-console/shared'
+import type { Prisma } from '@prisma/client'
+
+/**
+ * Builds the row persisted on creation from the already-parsed body. The
+ * discriminated union guarantees a public repository carries no credentials, and
+ * `externalToken` is never a database column — the external credential is written to
+ * Vault by the GitLab mirroring reconciliation (handled with the sync route, a
+ * separate change). `externalRepoUrl` and the deployment fields are already parsed to
+ * exact strings upstream, so the row is a straight mapping.
+ */
+export function buildRepositoryCreateData(
+  projectId: string,
+  createRepositoryInfos: CreateRepository,
+): Prisma.RepositoryUncheckedCreateInput {
+  return {
+    projectId,
+    internalRepoName: createRepositoryInfos.internalRepoName,
+    externalRepoUrl: createRepositoryInfos.externalRepoUrl,
+    externalUserName: createRepositoryInfos.isPrivate ? createRepositoryInfos.externalUserName : '',
+    isInfra: createRepositoryInfos.isInfra,
+    isPrivate: createRepositoryInfos.isPrivate,
+    deployRevision: createRepositoryInfos.deployRevision,
+    deployPath: createRepositoryInfos.deployPath,
+    helmValuesFiles: createRepositoryInfos.helmValuesFiles,
+  }
+}
+
+/**
+ * Builds the partial update applied to the row. Mirrors the legacy sanitization:
+ * `externalToken` is never persisted, and turning a repository public
+ * (`isPrivate === false`) leaves its stored `externalUserName` untouched.
+ */
+export function buildRepositoryUpdateData(
+  updateRepositoryInfos: UpdateRepository,
+): Prisma.RepositoryUncheckedUpdateInput {
+  const { externalToken: _externalToken, externalUserName, isPrivate, ...rest } = updateRepositoryInfos
+
+  const updateData: Prisma.RepositoryUncheckedUpdateInput = { ...rest }
+
+  if (isPrivate !== undefined) {
+    updateData.isPrivate = isPrivate
+  }
+
+  if (isPrivate !== false && externalUserName !== undefined) {
+    updateData.externalUserName = externalUserName
+  }
+
+  return updateData
+}
+
+/**
+ * What a PUT body asks to do with the repository's Vault mirror credentials.
+ *
+ * The external token is never stored in the database (it only lives in Vault), so a
+ * partial update expresses one of three intents:
+ * - `set`   : the body carries a new token → overwrite it in Vault.
+ * - `clear` : the body sets `isPrivate: false` (repo made public) → remove the creds.
+ * - `keep`  : the body carries no token → leave the stored secret unchanged.
+ *
+ * How "keep" is signalled differs from the legacy server: legacy sent a placeholder
+ * string ('fakeToken') as the token value to mean "unchanged" — dropped in
+ * `apps/server/src/resources/repository/router.ts` (`updateRepository`), then the empty
+ * token falls back to the stored password in the GitLab plugin
+ * (`plugins/gitlab/src/repositories.ts`, `ensureRepositoryExists`). Here the client
+ * simply omits the field, so an absent (or empty) token is what selects `keep`.
+ */
+export type RepositoryMirrorCredentialUpdate
+  = | { kind: 'set', externalToken: string }
+    | { kind: 'clear' }
+    | { kind: 'keep' }
+
+/**
+ * Parses the credential intent out of a partial update body. An absent or empty token
+ * means "unchanged" (the legacy `token || existing` fallback), so it never triggers a
+ * write. `isPrivate === false` wins: making a repository public clears its creds.
+ */
+export function parseRepositoryCredentialUpdate(
+  updateRepositoryInfos: UpdateRepository,
+): RepositoryMirrorCredentialUpdate {
+  if (updateRepositoryInfos.isPrivate === false) {
+    return { kind: 'clear' }
+  }
+  if (updateRepositoryInfos.externalToken) {
+    return { kind: 'set', externalToken: updateRepositoryInfos.externalToken }
+  }
+  return { kind: 'keep' }
+}

--- a/apps/server-nestjs/src/modules/vault/vault-client.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault-client.service.ts
@@ -81,6 +81,15 @@ export interface MirrorUserSecret {
   MIRROR_TOKEN: string
 }
 
+export interface GitlabMirrorSecret {
+  GIT_INPUT_URL: string
+  GIT_INPUT_USER: string
+  GIT_INPUT_PASSWORD: string
+  GIT_OUTPUT_URL: string
+  GIT_OUTPUT_USER: string
+  GIT_OUTPUT_PASSWORD: string
+}
+
 export interface VaultMetadata {
   created_time: string
   custom_metadata: Record<string, any> | null
@@ -170,28 +179,28 @@ export class VaultClientService {
   }
 
   @StartActiveSpan()
-  async readGitlabMirrorCreds(projectSlug: string, repoName: string): Promise<VaultSecret | null> {
+  async readGitlabMirrorCreds(projectSlug: string, repoName: string): Promise<VaultSecret<Partial<GitlabMirrorSecret>> | null> {
     const vaultCredsPath = generateGitlabMirrorCredPath(this.baseConfig.projectsRootDir, projectSlug, repoName)
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', projectSlug)
     span?.setAttribute('repo.name', repoName)
     span?.setAttribute('vault.kv.path', vaultCredsPath)
     this.logger.verbose(`Reading Vault GitLab mirror credentials (projectSlug=${projectSlug}, repoName=${repoName})`)
-    return await this.read(vaultCredsPath).catch((error) => {
+    return await this.read<Partial<GitlabMirrorSecret>>(vaultCredsPath).catch((error) => {
       if (error instanceof VaultError && error.kind === 'NotFound') return null
       throw error
     })
   }
 
   @StartActiveSpan()
-  async writeGitlabMirrorCreds(projectSlug: string, repoName: string, data: Record<string, any>): Promise<void> {
+  async writeGitlabMirrorCreds(projectSlug: string, repoName: string, creds: Partial<GitlabMirrorSecret>): Promise<void> {
     const vaultCredsPath = generateGitlabMirrorCredPath(this.baseConfig.projectsRootDir, projectSlug, repoName)
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', projectSlug)
     span?.setAttribute('repo.name', repoName)
     span?.setAttribute('vault.kv.path', vaultCredsPath)
     this.logger.verbose(`Writing Vault GitLab mirror credentials (projectSlug=${projectSlug}, repoName=${repoName})`)
-    await this.write(data, vaultCredsPath)
+    await this.write(creds, vaultCredsPath)
   }
 
   @StartActiveSpan()


### PR DESCRIPTION
## Issues liées

Issues numéro: #2423 

---------

> PR 4/5 de la pile « repository API v2 ». Base : `feat/repository-v2-datastore`.

## Quel est le comportement actuel ?

La logique métier des dépôts (unicité du nom interne, nettoyage des identifiants de
miroir, journalisation des événements) n'existe que dans le serveur legacy.

## Quel est le nouveau comportement ?

Ajout de `RepositoryService` et des utilitaires de mapping :

- `repository.utils.ts` :
  - `buildRepositoryCreateData` / `buildRepositoryUpdateData` — construction des entrées
    Prisma ; `externalToken` n'est jamais une colonne DB, et rendre un dépôt public laisse
    l'`externalUserName` stocké intact (comportement legacy conservé).
  - `parseRepositoryCredentialUpdate` — explicite le tri-état des identifiants Vault
    (`set` / `clear` / `keep`). Le legacy signalait « inchangé » via un jeton factice
    (`fakeToken`) ; ici le client omet simplement le champ.
- `RepositoryService` : création (avec contrôle d'unicité), mise à jour, suppression et
  listing, avec émission des événements applicatifs correspondants.
- Ajout des actions `Create/Update/Delete Repository` à `EventLogAction`.

Couverture unitaire du service et des utilitaires.

## Cette PR introduit-elle un breaking change ?

Non. Aucune route n'expose encore ce service.

## Autres informations

À faire dans une PR de suivi (hors pile) :
- route de synchronisation (`sync`)
- migration `externalToken` vers Vault
- gestion tri-state de l'`update` de bout en bout
