### PR TITLE
feat(server-nestjs): migrate repository sync route to API v2

### DIFF
--- a/apps/server-nestjs/src/modules/events/app-events.service.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.service.ts
@@ -12,11 +12,21 @@ import { formatEventLogData, isPluginResults } from './app-events.utils'
 
 export type ProjectEventName = 'project.upsert' | 'project.delete'
 export type ProjectMemberEventName = 'projectMember.upsert' | 'projectMember.delete'
+export type RepositoryEventName = 'repository.sync'
 
 export interface ProjectMemberEventPayload {
   projectId: string
   userId: string
 }
+
+export type RepositorySyncEventPayload = {
+  projectId: string
+  projectSlug: string
+  internalRepoName: string
+} & (
+  { syncAllBranches: true }
+  | { syncAllBranches: false, branchName: string }
+)
 
 /** Admin-log action labels (legacy hooks wording). */
 export type EventLogAction
@@ -25,7 +35,7 @@ export type EventLogAction
     | 'Create Deployment' | 'Update Deployment' | 'Delete Deployment'
     | 'Delete all project deployments'
     | 'Create Environment' | 'Update Environment' | 'Delete Environment'
-    | 'Create Repository' | 'Update Repository' | 'Delete Repository'
+    | 'Create Repository' | 'Update Repository' | 'Delete Repository' | 'Sync Repository'
     | 'Add Project Member' | 'Update Project Member' | 'Remove Project Member'
 
 export interface EventContext {
@@ -81,6 +91,19 @@ export class AppEventsService {
   async emitProjectMemberEvent(
     event: ProjectMemberEventName,
     payload: ProjectMemberEventPayload,
+    context: EventContext,
+  ): Promise<PluginResults> {
+    return this.emitAndLog(event, payload, payload.projectId, context)
+  }
+
+  /**
+   * Emits a repository event. Unlike `project.upsert`, the caller awaits the merged
+   * results and decides what to do with a failure — a sync is a user-triggered action
+   * whose outcome belongs in the response, not only in the admin log.
+   */
+  async emitRepositoryEvent(
+    event: RepositoryEventName,
+    payload: RepositorySyncEventPayload,
     context: EventContext,
   ): Promise<PluginResults> {
     return this.emitAndLog(event, payload, payload.projectId, context)

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
@@ -19,6 +19,7 @@ import {
   makeGroupSchema,
   makeMemberSchema,
   makeOffsetPagination,
+  makePipeline,
   makePipelineTriggerToken,
   makeProjectSchema,
   makeRepositoryFileExpandedSchema,
@@ -29,6 +30,7 @@ import {
   INFRA_GROUP_CUSTOM_ATTRIBUTE_KEY,
   MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY,
   PROJECT_GROUP_CUSTOM_ATTRIBUTE_KEY,
+  SPECIAL_REPO_NAMES,
   USER_ID_CUSTOM_ATTRIBUTE_KEY,
 } from './gitlab.constants'
 
@@ -286,6 +288,89 @@ describe('gitlab-client', () => {
 
       expect(result).toEqual(expect.objectContaining({ id: repoId, name: repoName }))
       expect(gitlabApi.ProjectCustomAttributes.set).toHaveBeenCalledWith(repoId, MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY, 'true')
+    })
+
+    describe('triggerMirror', () => {
+      const projectSlug = 'project-1'
+      const mirrorId = 10
+
+      function mockProjectGroupRepos(repos: { id: number, name: string }[]) {
+        const gitlabGroupsAllMock = gitlabApi.Groups.all as MockedFunction<typeof gitlabApi.Groups.all>
+        gitlabGroupsAllMock.mockResolvedValueOnce({
+          data: [{ id: 123, full_path: 'forge' }],
+          paginationInfo: { next: null },
+        })
+        gitlabGroupsAllMock.mockResolvedValueOnce({
+          data: [{ id: 1, full_path: `forge/${projectSlug}` }],
+          paginationInfo: { next: null },
+        })
+        const gitlabGroupsAllProjectsMock = gitlabApi.Groups.allProjects as MockedFunction<typeof gitlabApi.Groups.allProjects>
+        gitlabGroupsAllProjectsMock.mockResolvedValue({
+          data: repos,
+          paginationInfo: { next: null },
+        })
+      }
+
+      const populatedGroup = [
+        { id: 9, name: 'infra-apps' },
+        { id: mirrorId, name: 'mirror' },
+        { id: 11, name: 'repo-1' },
+        { id: 12, name: 'repo-2' },
+      ]
+
+      it('should start the pipeline on the mirror repo with the target as variable', async () => {
+        mockProjectGroupRepos(populatedGroup)
+        gitlabApi.Pipelines.create.mockResolvedValue(makePipeline({ id: 42 }))
+
+        const pipeline = await service.triggerMirror(projectSlug, 'repo-1', false, 'feat/x')
+
+        expect(pipeline.id).toBe(42)
+        // The pipeline runs on the *mirror* repo, never on the target itself.
+        expect(gitlabApi.Pipelines.create).toHaveBeenCalledWith(mirrorId, 'main', {
+          variables: [
+            { key: 'SYNC_ALL', value: 'false' },
+            { key: 'GIT_BRANCH_DEPLOY', value: 'feat/x' },
+            { key: 'PROJECT_NAME', value: 'repo-1' },
+          ],
+        })
+      })
+
+      it('should send an empty branch when syncing every branch', async () => {
+        mockProjectGroupRepos(populatedGroup)
+        gitlabApi.Pipelines.create.mockResolvedValue(makePipeline())
+
+        await service.triggerMirror(projectSlug, 'repo-1', true)
+
+        expect(gitlabApi.Pipelines.create).toHaveBeenCalledWith(mirrorId, 'main', {
+          variables: [
+            { key: 'SYNC_ALL', value: 'true' },
+            { key: 'GIT_BRANCH_DEPLOY', value: '' },
+            { key: 'PROJECT_NAME', value: 'repo-1' },
+          ],
+        })
+      })
+
+      it.each(SPECIAL_REPO_NAMES)('should refuse to mirror the special repository %s', async (specialRepo) => {
+        await expect(service.triggerMirror(projectSlug, specialRepo, true))
+          .rejects.toThrow('User requested for invalid mirroring')
+        expect(gitlabApi.Pipelines.create).not.toHaveBeenCalled()
+      })
+
+      it('should fail when the target repository is absent from the group', async () => {
+        mockProjectGroupRepos([{ id: mirrorId, name: 'mirror' }, { id: 12, name: 'repo-2' }])
+
+        await expect(service.triggerMirror(projectSlug, 'repo-1', true))
+          .rejects.toThrow('Unable to find target repository')
+        expect(gitlabApi.Pipelines.create).not.toHaveBeenCalled()
+      })
+
+      it('should fail when the project group has no mirror repository', async () => {
+        mockProjectGroupRepos([{ id: 11, name: 'repo-1' }, { id: 12, name: 'repo-2' }])
+
+        await expect(service.triggerMirror(projectSlug, 'repo-1', true))
+          .rejects.toThrow('Unable to find mirror repository')
+        expect(gitlabApi.Pipelines.create).not.toHaveBeenCalled()
+      })
     })
 
     describe('upsertUser', () => {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -29,6 +29,7 @@ import {
   MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY,
   MIRROR_REPO_NAME,
   PROJECT_GROUP_CUSTOM_ATTRIBUTE_KEY,
+  SPECIAL_REPO_NAMES,
   TOKEN_DESCRIPTION,
   TOPIC_PLUGIN_MANAGED,
   USER_ID_CUSTOM_ATTRIBUTE_KEY,
@@ -551,6 +552,40 @@ export class GitlabClientService {
     const created = await this.client.PipelineTriggerTokens.create(mirrorRepo.id, TOKEN_DESCRIPTION)
     this.logger.log(`GitLab pipeline trigger token created (projectSlug=${projectSlug}, repoId=${mirrorRepo.id})`)
     return created
+  }
+
+  /**
+   * Triggers the mirroring pipeline for one repository of a project.
+   *
+   * The mirroring is not performed against the target repo directly: the project's
+   * `mirror` repo carries the pipeline, which is started with the target designated by the `PROJECT_NAME` variable.
+   * `SPECIAL_REPO_NAMES` are the console's own plumbing repositories — mirroring one of
+   * them would have the pipeline act on itself or on the infra repo, so it is refused.
+   */
+  async triggerMirror(projectSlug: string, targetRepo: string, syncAllBranches: boolean, branchName?: string) {
+    if (SPECIAL_REPO_NAMES.includes(targetRepo)) {
+      throw new Error('User requested for invalid mirroring')
+    }
+    this.logger.log(`Triggering a GitLab mirror pipeline (projectSlug=${projectSlug}, targetRepo=${targetRepo}, syncAllBranches=${syncAllBranches})`)
+
+    let mirror: CondensedProjectSchemaWith<'id'> | undefined
+    let target: CondensedProjectSchemaWith<'id'> | undefined
+    for await (const repo of this.getRepos(projectSlug)) {
+      if (repo.name === MIRROR_REPO_NAME) mirror = repo
+      if (repo.name === targetRepo) target = repo
+    }
+    if (!mirror) throw new Error('Unable to find mirror repository')
+    if (!target) throw new Error('Unable to find target repository')
+
+    const pipeline = await this.client.Pipelines.create(mirror.id, 'main', {
+      variables: [
+        { key: 'SYNC_ALL', value: syncAllBranches.toString() },
+        { key: 'GIT_BRANCH_DEPLOY', value: branchName ?? '' },
+        { key: 'PROJECT_NAME', value: targetRepo },
+      ],
+    })
+    this.logger.verbose(`GitLab mirror pipeline created (projectSlug=${projectSlug}, targetRepo=${targetRepo}, pipelineId=${pipeline.id})`)
+    return pipeline
   }
 
   private async* offsetPaginate<T>(

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-testing.utils.ts
@@ -3,6 +3,7 @@ import type {
   AccessTokenSchema,
   CommitAction,
   ExpandedGroupSchema,
+  ExpandedPipelineSchema,
   ExpandedUserSchema,
   GroupSchema,
   MemberSchema,
@@ -313,6 +314,46 @@ export function makePipelineTriggerToken(overrides: Partial<PipelineTriggerToken
     repoId: 1,
     ...overrides,
   } satisfies PipelineTriggerTokenSchema
+}
+
+export function makePipeline(overrides: Partial<ExpandedPipelineSchema> = {}) {
+  const createdAt = faker.date.past().toISOString()
+  return {
+    id: 42,
+    iid: 1,
+    project_id: 1,
+    sha: faker.git.commitSha(),
+    before_sha: faker.git.commitSha(),
+    ref: 'main',
+    tag: false,
+    status: 'created',
+    source: 'api',
+    user: {
+      id: 1,
+      name: 'Console',
+      username: 'console',
+      state: 'active',
+      avatar_url: 'https://gitlab.internal/uploads/-/system/user/avatar/1/avatar.png',
+      web_url: 'https://gitlab.internal/console',
+    },
+    created_at: createdAt,
+    updated_at: createdAt,
+    started_at: createdAt,
+    finished_at: createdAt,
+    duration: 0,
+    detailed_status: {
+      icon: 'status_created',
+      text: 'created',
+      label: 'created',
+      group: 'created',
+      tooltip: 'created',
+      has_details: false,
+      details_path: '/forge/project-1/mirror/-/pipelines/42',
+      favicon: 'favicon_status_created',
+    },
+    web_url: 'https://gitlab.internal/forge/project-1/mirror/-/pipelines/42',
+    ...overrides,
+  } satisfies ExpandedPipelineSchema
 }
 
 export function makeOffsetPagination(overrides: Partial<OffsetPagination> = {}) {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
@@ -7,6 +7,9 @@ export const INFRA_GROUP_PATH = 'infra'
 export const INFRA_APPS_REPO_NAME = 'infra-apps'
 export const MIRROR_REPO_NAME = 'mirror'
 
+/** Console-managed plumbing repositories, never a valid mirroring target. */
+export const SPECIAL_REPO_NAMES: string[] = [INFRA_APPS_REPO_NAME, MIRROR_REPO_NAME]
+
 // Managed resources sentinel
 export const TOPIC_PLUGIN_MANAGED = 'plugin-managed'
 export const TOKEN_DESCRIPTION = 'mirroring-from-external-repo'

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
@@ -10,7 +10,7 @@ import { gitlabConfigFactory } from '../../config/gitlab.config'
 import { VaultClientService } from '../vault/vault-client.service'
 import { GitlabClientService } from './gitlab-client.service'
 import { GitlabDatastoreService } from './gitlab-datastore.service'
-import { makeAccessTokenExposedSchema, makeExpandedUserSchema, makeGroupSchema, makeMemberSchema, makePipelineTriggerToken, makeProjectSchema, makeProjectWithDetails } from './gitlab-testing.utils'
+import { makeAccessTokenExposedSchema, makeExpandedUserSchema, makeGroupSchema, makeMemberSchema, makePipeline, makePipelineTriggerToken, makeProjectSchema, makeProjectWithDetails } from './gitlab-testing.utils'
 import { PLUGIN_NAME, TOPIC_PLUGIN_MANAGED } from './gitlab.constants'
 import { GitlabService } from './gitlab.service'
 
@@ -470,6 +470,36 @@ describe('gitlabService', () => {
         MIRROR_USER: 'bot',
         MIRROR_TOKEN: accessToken.token,
       })
+    })
+  })
+
+  describe('handleRepositorySync', () => {
+    const payload = {
+      projectId: 'p1',
+      projectSlug: 'project-1',
+      internalRepoName: 'repo-1',
+      syncAllBranches: false,
+      branchName: 'main',
+    }
+
+    it('should trigger the mirror and report an OK plugin result', async () => {
+      gitlab.triggerMirror.mockResolvedValue(makePipeline())
+
+      const result = await service.handleRepositorySync(payload)
+
+      expect(gitlab.triggerMirror).toHaveBeenCalledWith('project-1', 'repo-1', false, 'main')
+      expect(result.gitlab.status).toBe('OK')
+    })
+
+    // capturePluginResult swallows the throw so the emitter can merge every listener's
+    // outcome; the failure has to surface as a KO result, not as a rejected promise.
+    it('should report a KO plugin result when the mirror cannot be triggered', async () => {
+      gitlab.triggerMirror.mockRejectedValue(new Error('Unable to find mirror repository'))
+
+      const result = await service.handleRepositorySync(payload)
+
+      expect(result.gitlab.status).toBe('KO')
+      expect(result.gitlab.message).toBe('Unable to find mirror repository')
     })
   })
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -1,5 +1,6 @@
 import type { CondensedGroupSchema, MemberSchema, ProjectSchema } from '@gitbeaker/core'
 import type { ConfigType } from '@nestjs/config'
+import type { RepositorySyncEventPayload } from '../events/app-events.service'
 import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { MirrorUserSecret } from '../vault/vault-client.service'
 import type { ProjectWithDetails } from './gitlab-datastore.service'
@@ -76,6 +77,29 @@ export class GitlabService {
   @OnEvent('project.delete')
   async handleDelete(project: ProjectWithDetails): Promise<RequiredPluginResult<'gitlab'>> {
     return capturePluginResult('gitlab', () => this.cleanupProject(project))
+  }
+
+  @OnEvent('repository.sync')
+  async handleRepositorySync(payload: RepositorySyncEventPayload): Promise<RequiredPluginResult<'gitlab'>> {
+    return capturePluginResult('gitlab', () => this.syncRepositoryMirror(payload))
+  }
+
+  @StartActiveSpan()
+  private async syncRepositoryMirror(payload: RepositorySyncEventPayload) {
+    const { projectSlug, internalRepoName, syncAllBranches } = payload
+    const span = trace.getActiveSpan()
+    span?.setAttribute('project.slug', projectSlug)
+    span?.setAttribute('repository.name', internalRepoName)
+    this.logger.log(`Handling a repository sync event for ${projectSlug}/${internalRepoName}`)
+    // A full sync has no branch to designate; the client turns that into an empty
+    // GIT_BRANCH_DEPLOY, which is what the mirror pipeline expects.
+    await this.gitlab.triggerMirror(
+      projectSlug,
+      internalRepoName,
+      syncAllBranches,
+      payload.syncAllBranches ? undefined : payload.branchName,
+    )
+    this.logger.log(`GitLab mirror pipeline triggered for ${projectSlug}/${internalRepoName}`)
   }
 
   @StartActiveSpan()

--- a/apps/server-nestjs/src/modules/repository/repository.controller.spec.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.controller.spec.ts
@@ -107,6 +107,18 @@ describe('repositoryController', () => {
     })
   })
 
+  describe('sync', () => {
+    it('calls repositoryService.syncRepository with the body and request context', async () => {
+      const syncRequest = { syncAllBranches: false, branchName: faker.git.branch() }
+      service.syncRepository.mockResolvedValue(undefined)
+
+      const result = await controller.sync(repositoryId, syncRequest, project, user, request)
+
+      expect(service.syncRepository).toHaveBeenCalledWith(projectId, projectSlug, repositoryId, syncRequest, userId, requestId)
+      expect(result).toBeUndefined()
+    })
+  })
+
   describe('delete', () => {
     it('calls repositoryService.deleteRepository with the repository id and request context', async () => {
       service.deleteRepository.mockResolvedValue(undefined)

--- a/apps/server-nestjs/src/modules/repository/repository.controller.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.controller.ts
@@ -1,9 +1,9 @@
-import type { CreateRepository, UpdateRepository } from '@cpn-console/shared'
+import type { CreateRepository, SyncRepository, UpdateRepository } from '@cpn-console/shared'
 import type { Repository } from '@prisma/client'
 import type { FastifyRequest } from 'fastify'
 import type { UserContext } from '../infrastructure/auth/auth-user.decorator'
 import type { ProjectContext } from '../infrastructure/permission/project/project.guard'
-import { CreateRepositorySchema, UpdateRepositorySchema } from '@cpn-console/shared'
+import { CreateRepositorySchema, SyncRepositorySchema, UpdateRepositorySchema } from '@cpn-console/shared'
 import {
   Body,
   Controller,
@@ -49,12 +49,12 @@ export class RepositoryController {
   @RequireUserType('human')
   @HttpCode(HttpStatus.CREATED)
   create(
-    @Body(new ZodValidationPipe(CreateRepositorySchema)) data: CreateRepository,
+    @Body(new ZodValidationPipe(CreateRepositorySchema)) repositoryToCreate: CreateRepository,
     @Project() project: ProjectContext,
     @AuthUser() user: UserContext,
     @Req() request: FastifyRequest,
   ): Promise<Repository> {
-    return this.repositoryService.createRepository(project.id, project.slug, data, user.userId, request.id)
+    return this.repositoryService.createRepository(project.id, project.slug, repositoryToCreate, user.userId, request.id)
   }
 
   @Put(':repositoryId')
@@ -65,12 +65,28 @@ export class RepositoryController {
   @HttpCode(HttpStatus.OK)
   update(
     @Param('repositoryId', ParseUUIDPipe) repositoryId: string,
-    @Body(new ZodValidationPipe(UpdateRepositorySchema)) data: UpdateRepository,
+    @Body(new ZodValidationPipe(UpdateRepositorySchema)) repositoryToUpdate: UpdateRepository,
     @Project() project: ProjectContext,
     @AuthUser() user: UserContext,
     @Req() request: FastifyRequest,
   ): Promise<Repository> {
-    return this.repositoryService.updateRepository(project.id, project.slug, repositoryId, data, user.userId, request.id)
+    return this.repositoryService.updateRepository(project.id, project.slug, repositoryId, repositoryToUpdate, user.userId, request.id)
+  }
+
+  @Post(':repositoryId/sync')
+  @RequireProjectPermission('ManageRepositories')
+  @RequireProjectStatus('initializing', 'created', 'failed', 'warning')
+  @RequireProjectLocked(false)
+  @RequireUserType('human')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  sync(
+    @Param('repositoryId', ParseUUIDPipe) repositoryId: string,
+    @Body(new ZodValidationPipe(SyncRepositorySchema)) syncRequest: SyncRepository,
+    @Project() project: ProjectContext,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
+  ): Promise<void> {
+    return this.repositoryService.syncRepository(project.id, project.slug, repositoryId, syncRequest, user.userId, request.id)
   }
 
   @Delete(':repositoryId')

--- a/apps/server-nestjs/src/modules/repository/repository.service.spec.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.service.spec.ts
@@ -2,7 +2,7 @@ import type { CreateRepository, UpdateRepository } from '@cpn-console/shared'
 import type { TestingModule } from '@nestjs/testing'
 import type { DeepMockProxy } from 'vitest-mock-extended'
 import { faker } from '@faker-js/faker'
-import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { BadRequestException, NotFoundException, UnprocessableEntityException } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
@@ -52,6 +52,9 @@ describe('repositoryService', () => {
     datastore = mockDeep<RepositoryDatastoreService>()
     appEvents = mockDeep<AppEventsService>()
     vault = mockDeep<VaultClientService>()
+    // Creating a repository with an external source fires a sync; give every test a
+    // resolving default so only the tests that assert on it have to care.
+    appEvents.emitRepositoryEvent.mockResolvedValue({})
 
     module = await Test.createTestingModule({
       providers: [
@@ -114,6 +117,35 @@ describe('repositoryService', () => {
         requestId,
       })
       expect(result).toEqual(repository)
+    })
+
+    it('triggers a full mirror sync when the repository declares an external source', async () => {
+      const repository = makeRepository({ id: repositoryId, projectId, internalRepoName: validCreateRepository.internalRepoName })
+      datastore.hasRepositoryWithName.mockResolvedValue(false)
+      datastore.createRepository.mockResolvedValue(repository)
+      vault.writeGitlabMirrorCreds.mockResolvedValue(undefined)
+      appEvents.emitProjectEvent.mockResolvedValue({})
+
+      await service.createRepository(projectId, projectSlug, validCreateRepository, userId, requestId)
+
+      expect(appEvents.emitRepositoryEvent).toHaveBeenCalledWith(
+        'repository.sync',
+        expect.objectContaining({ internalRepoName: repository.internalRepoName, syncAllBranches: true }),
+        expect.objectContaining({ action: 'Sync Repository' }),
+      )
+    })
+
+    it('does not trigger a sync when no external source is declared', async () => {
+      const withoutExternalSource = { ...validCreateRepository, externalRepoUrl: '' }
+      const repository = makeRepository({ id: repositoryId, projectId, internalRepoName: withoutExternalSource.internalRepoName })
+      datastore.hasRepositoryWithName.mockResolvedValue(false)
+      datastore.createRepository.mockResolvedValue(repository)
+      vault.writeGitlabMirrorCreds.mockResolvedValue(undefined)
+      appEvents.emitProjectEvent.mockResolvedValue({})
+
+      await service.createRepository(projectId, projectSlug, withoutExternalSource, userId, requestId)
+
+      expect(appEvents.emitRepositoryEvent).not.toHaveBeenCalled()
     })
 
     it('does not touch Vault when creating a public repository', async () => {
@@ -208,6 +240,63 @@ describe('repositoryService', () => {
       expect(vault.writeGitlabMirrorCreds).not.toHaveBeenCalled()
       expect(vault.deleteGitlabMirrorCreds).not.toHaveBeenCalled()
       expect(appEvents.emitProjectEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('syncRepository', () => {
+    const syncRequest = { syncAllBranches: true } as const
+
+    it('emits the sync event with the repository addressed by slug and name', async () => {
+      const repository = makeRepository({ id: repositoryId, projectId })
+      datastore.getRepositoryById.mockResolvedValue(repository)
+      appEvents.emitRepositoryEvent.mockResolvedValue({ gitlab: { status: 'OK', message: 'Up to date', executionTime: 1 } })
+
+      await service.syncRepository(projectId, projectSlug, repositoryId, syncRequest, userId, requestId)
+
+      // A full sync carries no branch key at all — not an undefined one.
+      expect(appEvents.emitRepositoryEvent).toHaveBeenCalledWith(
+        'repository.sync',
+        {
+          projectId,
+          projectSlug,
+          internalRepoName: repository.internalRepoName,
+          syncAllBranches: true,
+        },
+        { action: 'Sync Repository', userId, requestId },
+      )
+    })
+
+    it('forwards the requested branch when not syncing every branch', async () => {
+      const repository = makeRepository({ id: repositoryId, projectId })
+      const branchName = faker.git.branch()
+      datastore.getRepositoryById.mockResolvedValue(repository)
+      appEvents.emitRepositoryEvent.mockResolvedValue({})
+
+      await service.syncRepository(projectId, projectSlug, repositoryId, { syncAllBranches: false, branchName }, userId, requestId)
+
+      expect(appEvents.emitRepositoryEvent).toHaveBeenCalledWith(
+        'repository.sync',
+        expect.objectContaining({ syncAllBranches: false, branchName }),
+        expect.objectContaining({ action: 'Sync Repository' }),
+      )
+    })
+
+    it('rejects with 422 when a plugin fails the synchronization', async () => {
+      datastore.getRepositoryById.mockResolvedValue(makeRepository({ id: repositoryId, projectId }))
+      appEvents.emitRepositoryEvent.mockResolvedValue({
+        gitlab: { status: 'KO', message: 'Unable to find mirror repository', executionTime: 1, error: new Error('boom') },
+      })
+
+      await expect(service.syncRepository(projectId, projectSlug, repositoryId, syncRequest, userId, requestId))
+        .rejects.toThrow(UnprocessableEntityException)
+    })
+
+    it('rejects when the repository belongs to another project', async () => {
+      datastore.getRepositoryById.mockResolvedValue(makeRepository({ id: repositoryId, projectId: faker.string.uuid() }))
+
+      await expect(service.syncRepository(projectId, projectSlug, repositoryId, syncRequest, userId, requestId))
+        .rejects.toThrow(NotFoundException)
+      expect(appEvents.emitRepositoryEvent).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/server-nestjs/src/modules/repository/repository.service.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.service.ts
@@ -1,9 +1,11 @@
-import type { CreateRepository, UpdateRepository } from '@cpn-console/shared'
+import type { CreateRepository, SyncRepository, UpdateRepository } from '@cpn-console/shared'
 import type { Repository } from '@prisma/client'
-import type { EventLogAction } from '../events/app-events.service'
+import type { EventLogAction, RepositorySyncEventPayload } from '../events/app-events.service'
+import type { PluginResults } from '../plugin/plugin.utils'
 import type { RepositoryMirrorCredentialUpdate } from './repository.utils'
-import { BadRequestException, Inject, Injectable, Logger, NotFoundException, Optional } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException, Optional, UnprocessableEntityException } from '@nestjs/common'
 import { AppEventsService } from '../events/app-events.service'
+import { getFailedPlugins } from '../plugin/plugin.utils'
 import { VaultClientService } from '../vault/vault-client.service'
 import { RepositoryDatastoreService } from './repository-datastore.service'
 import { buildRepositoryCreateData, buildRepositoryUpdateData, parseRepositoryCredentialUpdate } from './repository.utils'
@@ -49,7 +51,56 @@ export class RepositoryService {
     }
 
     this.reconcileProject(projectId, 'Create Repository', userId, requestId)
+
+    // Legacy parity: a repository declared with an external source is mirrored right
+    // away, so the first sync doesn't wait for a manual trigger. Fire-and-forget like
+    // the reconciliation above — the creation itself succeeded, and the mirror pipeline
+    // is a downstream effect whose failure is reported in the admin log.
+    if (repositoryToCreate.externalRepoUrl) {
+      this.syncRepositoryMirror(
+        { projectId, projectSlug, internalRepoName: repository.internalRepoName, syncAllBranches: true },
+        userId,
+        requestId,
+      ).catch((error: unknown) => {
+        this.logger.error(`repository.sync after creation failed (repositoryId=${repository.id})`, error instanceof Error ? error.stack : String(error))
+      })
+    }
+
     return repository
+  }
+
+  /**
+   * Triggers the GitLab mirror for one repository and waits for the outcome: unlike the
+   * project reconciliation, this is the user's whole intent for the request, so a
+   * failing plugin must surface as a 422 rather than a silent log entry.
+   */
+  async syncRepository(projectId: string, projectSlug: string, repositoryId: string, syncRequest: SyncRepository, userId: string, requestId: string): Promise<void> {
+    const repository = await this.getProjectRepositoryOrThrow(projectId, repositoryId)
+
+    const results = await this.syncRepositoryMirror(
+      {
+        projectId,
+        projectSlug,
+        internalRepoName: repository.internalRepoName,
+        ...(syncRequest.syncAllBranches
+          ? { syncAllBranches: true }
+          : { syncAllBranches: false, branchName: syncRequest.branchName }),
+      },
+      userId,
+      requestId,
+    )
+
+    if (getFailedPlugins(results).length) {
+      throw new UnprocessableEntityException('Echec des services à la synchronisation du dépôt')
+    }
+  }
+
+  private syncRepositoryMirror(payload: RepositorySyncEventPayload, userId: string, requestId: string): Promise<PluginResults> {
+    return this.appEvents.emitRepositoryEvent('repository.sync', payload, {
+      action: 'Sync Repository',
+      userId,
+      requestId,
+    })
   }
 
   async updateRepository(projectId: string, projectSlug: string, repositoryId: string, repositoryToUpdate: UpdateRepository, userId: string, requestId: string): Promise<Repository> {

--- a/packages/shared/src/contracts/v2/repository.ts
+++ b/packages/shared/src/contracts/v2/repository.ts
@@ -2,13 +2,12 @@ import { ContractNoBody } from '@ts-rest/core'
 import { z } from 'zod'
 import { apiPrefixV2, contractInstance } from '../../api-client.js'
 import { RepoSchema } from '../../schemas/repository.js'
-import { CreateRepositorySchema, UpdateRepositorySchema } from '../../schemas/v2/repository.js'
+import { CreateRepositorySchema, SyncRepositorySchema, UpdateRepositorySchema } from '../../schemas/v2/repository.js'
 import { baseHeaders, ErrorSchema } from '../_utils.js'
 
 // Contrat des dépôts pour l'API v2 (server-nestjs). projectId est porté par le chemin.
 // NB: les clés de routes servent d'operationId OpenAPI (setOperationId: true) et
 // doivent être uniques sur l'ensemble du contrat, d'où le suffixe V2.
-// La route de synchronisation reste servie par le serveur legacy pour l'instant.
 export const repositoryContractV2 = contractInstance.router({
   createRepositoryV2: {
     method: 'POST',
@@ -58,6 +57,28 @@ export const repositoryContractV2 = contractInstance.router({
       401: ErrorSchema,
       403: ErrorSchema,
       404: ErrorSchema,
+      500: ErrorSchema,
+    },
+  },
+
+  syncRepositoryV2: {
+    method: 'POST',
+    path: '/:repositoryId/sync',
+    contentType: 'application/json',
+    summary: 'Sync repository',
+    description: 'Trigger a GitLab mirror synchronization for a repository.',
+    pathParams: z.object({
+      repositoryId: z.string()
+        .uuid(),
+    }),
+    body: SyncRepositorySchema,
+    responses: {
+      204: null,
+      400: ErrorSchema,
+      401: ErrorSchema,
+      403: ErrorSchema,
+      404: ErrorSchema,
+      422: ErrorSchema,
       500: ErrorSchema,
     },
   },

--- a/packages/shared/src/schemas/v2/repository.spec.ts
+++ b/packages/shared/src/schemas/v2/repository.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { describe, expect, it } from 'vitest'
-import { CreateRepositorySchema } from './repository.js'
+import { CreateRepositorySchema, SyncRepositorySchema } from './repository.js'
 
 describe('createRepositorySchema', () => {
   const gitUrl = `https://${faker.internet.domainName()}/repo.git`
@@ -127,6 +127,43 @@ describe('createRepositorySchema', () => {
       isPrivate: true,
       externalToken: faker.string.alphanumeric(16),
     })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('syncRepositorySchema', () => {
+  it('accepts a full sync without a branch', () => {
+    const result = SyncRepositorySchema.safeParse({ syncAllBranches: true })
+
+    expect(result.success).toBe(true)
+  })
+
+  // The discriminated union makes a full sync incapable of carrying a branch: the key is
+  // stripped at the boundary rather than reaching the mirror pipeline.
+  it('strips a branch smuggled into a full sync', () => {
+    const result = SyncRepositorySchema.safeParse({ syncAllBranches: true, branchName: 'main' })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({ syncAllBranches: true })
+  })
+
+  it('accepts a partial sync naming its branch', () => {
+    const result = SyncRepositorySchema.safeParse({ syncAllBranches: false, branchName: 'main' })
+
+    expect(result.success).toBe(true)
+  })
+
+  // A partial sync with no branch designates nothing to mirror: rejected at the boundary
+  // rather than reaching GitLab as an empty GIT_BRANCH_DEPLOY.
+  it('rejects a partial sync without a branch', () => {
+    const result = SyncRepositorySchema.safeParse({ syncAllBranches: false })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a missing syncAllBranches', () => {
+    const result = SyncRepositorySchema.safeParse({ branchName: 'main' })
 
     expect(result.success).toBe(false)
   })

--- a/packages/shared/src/schemas/v2/repository.ts
+++ b/packages/shared/src/schemas/v2/repository.ts
@@ -55,5 +55,16 @@ export const UpdateRepositorySchema = RepoSchema.pick({
   helmValuesFiles: true,
 }).partial()
 
+export const SyncRepositorySchema = z.discriminatedUnion('syncAllBranches', [
+  z.object({
+    syncAllBranches: z.literal(true),
+  }),
+  z.object({
+    syncAllBranches: z.literal(false),
+    branchName: z.string().min(1, { message: 'branchName est requis lorsque syncAllBranches vaut false' }),
+  }),
+])
+
 export type CreateRepository = Zod.infer<typeof CreateRepositorySchema>
 export type UpdateRepository = Zod.infer<typeof UpdateRepositorySchema>
+export type SyncRepository = Zod.infer<typeof SyncRepositorySchema>


### PR DESCRIPTION
## Issues liées

Issues numéro: #2423

---------

> Suite de la pile « repository API v2 » (#2408) : dernière route restée sur le serveur legacy.

## Quel est le comportement actuel ?

La synchronisation d'un dépôt (déclenchement du miroir GitLab) est uniquement servie par
l'API v1 (legacy). L'API v2 des repositories expose le CRUD mais pas le `sync`, et
`server-nestjs` ne sait pas déclencher de pipeline de mirroring.

## Quel est le nouveau comportement ?

Ajout de `POST /api/v2/projects/:projectId/repositories/:repositoryId/sync` (`204`),
permission `ManageRepositories`, mêmes contraintes que les autres mutations
(`@RequireProjectStatus`, `@RequireProjectLocked(false)`, `@RequireUserType('human')`).

**Contrat / schémas (`shared`)**
- `SyncRepositorySchema` : union discriminée sur `syncAllBranches`. Une synchro complète
  ne peut pas porter de `branchName` (la clé est retirée au parsing), une synchro
  partielle ne peut pas l'omettre (`400`).
- Route `syncRepositoryV2` dans le contrat ts-rest v2.

**Événement (`events`)**
- Événement `repository.sync` avec `RepositorySyncEventPayload` et l'action de log admin
  `Sync Repository`.
- `emitRepositoryEvent` renvoie les `PluginResults` fusionnés : contrairement à
  `project.upsert` (non bloquant), l'appelant attend le résultat, car la synchro est
  l'intention même de la requête et son échec doit être visible dans la réponse.

**GitLab**
- `GitlabClientService.triggerMirror` : le pipeline de mirroring est porté par le dépôt
  `mirror` du projet et cible le dépôt via la variable `PROJECT_NAME` (+ `SYNC_ALL` et
  `GIT_BRANCH_DEPLOY`). Les dépôts de plomberie de la console (`SPECIAL_REPO_NAMES` :
  `infra-apps`, `mirror`) sont refusés comme cible.
- `GitlabService.handleRepositorySync` écoute `repository.sync` et remonte un
  `RequiredPluginResult<'gitlab'>`.

**Service repository**
- `syncRepository` vérifie que le dépôt appartient bien au projet du chemin (`404`
  sinon), attend les résultats des plugins et transforme un plugin en échec en `422`.
- Parité legacy : la création d'un dépôt avec `externalRepoUrl` déclenche un premier
  miroir en *fire-and-forget* (l'échec est tracé dans le log admin, la création reste
  `201`).

Tests : couverture du schéma, du client GitLab, du service GitLab, du service et du
controller repository.

## Cette PR introduit-elle un breaking change ?

Non. La route v1 reste inchangée et continue d'être servie par le serveur legacy ; la v2
est ajoutée en parallèle. Aucun changement côté client.

## Autres informations

Avec cette PR, l'API v2 des repositories couvre l'intégralité des routes v1. Reste à
faire hors de cette PR : la bascule du client sur les routes v2.
