### PR TITLE
feat(server-nestjs): await project reconciliation on environment mutations

### DIFF
--- a/apps/server-nestjs/src/modules/environment/environment.module.ts
+++ b/apps/server-nestjs/src/modules/environment/environment.module.ts
@@ -1,13 +1,20 @@
 import { Module } from '@nestjs/common'
 import { AppEventsModule } from '../events/app-events.module'
-import { InfrastructureModule } from '../infrastructure/infrastructure.module'
+import { AuthModule } from '../infrastructure/auth/auth.module'
+import { DatabaseModule } from '../infrastructure/database/database.module'
+import { ProjectPermissionModule } from '../infrastructure/permission/project/project.module'
 import { EnvironmentDatastoreService } from './environment-datastore.service'
 import { EnvironmentValidationService } from './environment-validation.service'
 import { EnvironmentController } from './environment.controller'
 import { EnvironmentService } from './environment.service'
 
 @Module({
-  imports: [AppEventsModule, InfrastructureModule],
+  imports: [
+    AppEventsModule,
+    AuthModule,
+    DatabaseModule,
+    ProjectPermissionModule,
+  ],
   controllers: [EnvironmentController],
   providers: [
     EnvironmentDatastoreService,

--- a/apps/server-nestjs/src/modules/environment/environment.service.spec.ts
+++ b/apps/server-nestjs/src/modules/environment/environment.service.spec.ts
@@ -1,13 +1,21 @@
 import type { CreateEnvironment, UpdateEnvironment } from '@cpn-console/shared'
 import type { TestingModule } from '@nestjs/testing'
 import type { DeepMockProxy } from 'vitest-mock-extended'
-import { BadRequestException, NotFoundException } from '@nestjs/common'
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { AppEventsService } from '../events/app-events.service'
 import { EnvironmentDatastoreService } from './environment-datastore.service'
-import { makeEnvironment, makeEnvironmentWithCluster, makeEnvironmentWithStage } from './environment-testing.utils'
+import {
+  makeEnvironment,
+  makeEnvironmentWithCluster,
+  makeEnvironmentWithStage,
+} from './environment-testing.utils'
 import { EnvironmentValidationService } from './environment-validation.service'
 import { EnvironmentService } from './environment.service'
 
@@ -34,6 +42,10 @@ describe('environmentService', () => {
     memory: 4,
     autosync: true,
   } satisfies CreateEnvironment
+
+  const failedReconciliation = {
+    gitlab: { status: 'KO', message: 'Unable to provision environment', executionTime: 1, error: new Error('boom') },
+  } as const
 
   const validUpdateEnvironment = {
     cpu: 4,
@@ -103,6 +115,17 @@ describe('environmentService', () => {
       expect(result).toEqual(environment)
     })
 
+    it('should wait for the reconciliation and reject when a service fails', async () => {
+      const environment = makeEnvironment({ id: environmentId, projectId, clusterId, stageId })
+      validation.validateCreate.mockResolvedValue(undefined)
+      datastore.createEnvironment.mockResolvedValue(environment)
+      appEvents.emitProjectEvent.mockResolvedValue(failedReconciliation)
+
+      await expect(service.createEnvironment(projectId, validCreateEnvironment, userId, requestId))
+        .rejects.toThrow(InternalServerErrorException)
+      expect(datastore.createEnvironment).toHaveBeenCalled()
+    })
+
     it('should not create the environment when the validation fails', async () => {
       validation.validateCreate.mockRejectedValue(new BadRequestException('Cluster invalide.'))
 
@@ -132,6 +155,18 @@ describe('environmentService', () => {
         requestId,
       })
       expect(result).toEqual(updated)
+    })
+
+    it('should wait for the reconciliation and reject when a service fails', async () => {
+      const existing = makeEnvironmentWithCluster({ id: environmentId, projectId })
+      datastore.getProjectEnvironment.mockResolvedValue(existing)
+      validation.validateUpdate.mockResolvedValue(undefined)
+      datastore.updateEnvironment.mockResolvedValue(makeEnvironment({ id: environmentId, projectId, ...validUpdateEnvironment }))
+      appEvents.emitProjectEvent.mockResolvedValue(failedReconciliation)
+
+      await expect(service.updateEnvironment(projectId, environmentId, validUpdateEnvironment, userId, requestId))
+        .rejects.toThrow(InternalServerErrorException)
+      expect(datastore.updateEnvironment).toHaveBeenCalled()
     })
 
     it('should reject when the environment is not found in the project', async () => {
@@ -169,6 +204,16 @@ describe('environmentService', () => {
         userId,
         requestId,
       })
+    })
+
+    it('should wait for the reconciliation and reject when a service fails', async () => {
+      datastore.getProjectEnvironment.mockResolvedValue(makeEnvironmentWithCluster({ id: environmentId, projectId }))
+      datastore.deleteEnvironment.mockResolvedValue(makeEnvironment({ id: environmentId, projectId }))
+      appEvents.emitProjectEvent.mockResolvedValue(failedReconciliation)
+
+      await expect(service.deleteEnvironment(projectId, environmentId, userId, requestId))
+        .rejects.toThrow(InternalServerErrorException)
+      expect(datastore.deleteEnvironment).toHaveBeenCalledWith(environmentId)
     })
 
     it('should reject when the environment is not found in the project', async () => {

--- a/apps/server-nestjs/src/modules/environment/environment.service.ts
+++ b/apps/server-nestjs/src/modules/environment/environment.service.ts
@@ -2,15 +2,19 @@ import type { CreateEnvironment, UpdateEnvironment } from '@cpn-console/shared'
 import type { Environment } from '@prisma/client'
 import type { EventLogAction } from '../events/app-events.service'
 import type { EnvironmentWithCluster, EnvironmentWithStage } from './environment-datastore.service'
-import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common'
 import { AppEventsService } from '../events/app-events.service'
+import { getFailedPlugins } from '../plugin/plugin.utils'
 import { EnvironmentDatastoreService } from './environment-datastore.service'
 import { EnvironmentValidationService } from './environment-validation.service'
 
 @Injectable()
 export class EnvironmentService {
-  private readonly logger = new Logger(EnvironmentService.name)
-
   constructor(
     @Inject(EnvironmentDatastoreService) private readonly environmentDatastoreService: EnvironmentDatastoreService,
     @Inject(EnvironmentValidationService) private readonly environmentValidationService: EnvironmentValidationService,
@@ -35,7 +39,13 @@ export class EnvironmentService {
       autosync: environmentToCreate.autosync,
     })
 
-    this.reconcileProject(projectId, 'Create Environment', userId, requestId)
+    await this.reconcileProjectAndThrowOnFailure(
+      projectId,
+      'Create Environment',
+      userId,
+      requestId,
+      'Echec des services à la création de l\'environnement',
+    )
     return environment
   }
 
@@ -50,14 +60,26 @@ export class EnvironmentService {
       autosync: environmentToUpdate.autosync,
     })
 
-    this.reconcileProject(projectId, 'Update Environment', userId, requestId)
+    await this.reconcileProjectAndThrowOnFailure(
+      projectId,
+      'Update Environment',
+      userId,
+      requestId,
+      'Echec des services à la mise à jour de l\'environnement',
+    )
     return environment
   }
 
   async deleteEnvironment(projectId: string, environmentId: string, userId: string, requestId: string): Promise<void> {
     await this.getProjectEnvironmentOrThrow(projectId, environmentId)
     await this.environmentDatastoreService.deleteEnvironment(environmentId)
-    this.reconcileProject(projectId, 'Delete Environment', userId, requestId)
+    await this.reconcileProjectAndThrowOnFailure(
+      projectId,
+      'Delete Environment',
+      userId,
+      requestId,
+      'Echec des services à la suppression de l\'environnement',
+    )
   }
 
   private async getProjectEnvironmentOrThrow(projectId: string, environmentId: string): Promise<EnvironmentWithCluster> {
@@ -69,13 +91,23 @@ export class EnvironmentService {
   }
 
   /**
-   * Triggers the project reconciliation without blocking the response: listener
-   * outcomes (including failures) are persisted in the admin log by AppEventsService.
+   * Runs the project reconciliation and waits for it before answering: an environment
+   * change is only meaningful once the services have applied it, so a failing plugin
+   * must surface in the response (legacy v1 behavior) instead of leaving the caller
+   * with a success on a project that AppEventsService just marked `failed`. The row
+   * change stays committed — the reconciliation is replayable.
    */
-  private reconcileProject(projectId: string, action: EventLogAction, userId: string, requestId: string): void {
-    this.appEvents.emitProjectEvent('project.upsert', projectId, { action, userId, requestId })
-      .catch((error: unknown) => {
-        this.logger.error(`project.upsert reconciliation failed (projectId=${projectId})`, error instanceof Error ? error.stack : String(error))
-      })
+  private async reconcileProjectAndThrowOnFailure(
+    projectId: string,
+    action: EventLogAction,
+    userId: string,
+    requestId: string,
+    failureMessage: string,
+  ): Promise<void> {
+    const results = await this.appEvents.emitProjectEvent('project.upsert', projectId, { action, userId, requestId })
+
+    if (getFailedPlugins(results).length) {
+      throw new InternalServerErrorException(failureMessage)
+    }
   }
 }

--- a/apps/server-nestjs/src/modules/events/app-events.module.ts
+++ b/apps/server-nestjs/src/modules/events/app-events.module.ts
@@ -1,10 +1,15 @@
 import { Module } from '@nestjs/common'
-import { InfrastructureModule } from '../infrastructure/infrastructure.module'
+import { DatabaseModule } from '../infrastructure/database/database.module'
+import { EventsModule } from '../infrastructure/events/events.module'
 import { LogModule } from '../log/log.module'
 import { AppEventsService } from './app-events.service'
 
 @Module({
-  imports: [InfrastructureModule, LogModule],
+  imports: [
+    DatabaseModule,
+    EventsModule,
+    LogModule,
+  ],
   providers: [AppEventsService],
   exports: [AppEventsService],
 })


### PR DESCRIPTION
## Issues liées

Issues numéro: #1911, #2322

---------

## Quel est le comportement actuel ?

Sur l'API v2 (`/api/v2/projects/:projectId/environments`), la création, la modification et la suppression d'un environnement répondent immédiatement (201 / 200 / 204), puis déclenchent la réconciliation `project.upsert` en tâche de fond.

L'utilisateur reçoit donc un succès alors que les services (GitLab, ArgoCD, …) n'ont pas encore appliqué le changement. Si un plugin échoue, le projet est marqué `failed` juste après la réponse : l'échec n'apparaît que dans le journal d'administration, jamais dans la réponse de la requête. L'API v1, elle, attend le résultat des hooks et renvoie une erreur.

## Quel est le nouveau comportement ?

Les trois routes attendent la fin de la réconciliation avant de répondre :

| Route | Succès | Échec d'un service |
| --- | --- | --- |
| `POST /environments` | 201 | 500 — `Echec des services à la création de l'environnement` |
| `PUT /environments/:id` | 200 | 500 — `Echec des services à la mise à jour de l'environnement` |
| `DELETE /environments/:id` | 204 | 500 — `Echec des services à la suppression de l'environnement` |

Codes et messages identiques à l'API v1. En cas d'échec, l'écriture en base est conservée — comme en v1 : le projet est marqué `failed` et la réconciliation reste rejouable.

## Cette PR introduit-elle un breaking change ?

Pas sur le contrat d'API : mêmes codes de succès, mêmes payloads.

Changement de comportement observable : les trois routes v2 sont désormais synchrones, leur temps de réponse correspond à la durée du round-trip des plugins (comportement v1). Les clients dont les timeouts auraient été calibrés sur les réponses rapides de la v2 sont à vérifier.

## Autres informations

- Trois tests ajoutés (un par verbe) couvrant le retour 500 quand un plugin renvoie `KO`. Suite complète : 537 tests passés, 50 ignorés.
- Nettoyage annexe : `EnvironmentModule` et `AppEventsModule` importaient le barrel `InfrastructureModule`, qui réexporte les modules racine `EventEmitter` et Pino (`forRoot`), réservés à `MainModule`. Ils importent maintenant directement `AuthModule`, `DatabaseModule` et `ProjectPermissionModule`, comme tous les autres modules fonctionnels — ce qui rend explicite la dépendance de `ProjectGuard` à `AuthService`.
