### PR TITLE
feat(client): switch environments to API v2

### DIFF
--- a/apps/client/src/components/EnvironmentForm.vue
+++ b/apps/client/src/components/EnvironmentForm.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type {
   CleanedCluster,
-  CreateEnvironmentBody,
+  CreateEnvironment,
   Environment,
 } from '@cpn-console/shared'
 import {
@@ -46,7 +46,7 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{
-  addEnvironment: [environment: Omit<CreateEnvironmentBody, 'projectId'>]
+  addEnvironment: [environment: CreateEnvironment]
   putEnvironment: [environment: Pick<Environment, 'cpu' | 'gpu' | 'memory' | 'autosync'>]
   deleteEnvironment: [environmentId: Environment['id']]
   cancel: []

--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CleanedCluster, Cluster, CreateEnvironmentBody, Environment, Repo, Stage, UpdateEnvironmentBody, Zone } from '@cpn-console/shared'
+import type { CleanedCluster, Cluster, CreateEnvironment, Environment, Repo, Stage, UpdateEnvironment, Zone } from '@cpn-console/shared'
 import type { Project } from '@/utils/project-utils.js'
 import { logger } from '@cpn-console/logger/browser'
 import { AdminAuthorized, defaultBranchName, ProjectAuthorized, projectIsLockedInfo } from '@cpn-console/shared'
@@ -67,7 +67,7 @@ watch(selectedRepo, async () => {
   branchName.value = defaultBranchName
 })
 
-async function putEnvironment(environment: UpdateEnvironmentBody, envId: Environment['id']) {
+async function putEnvironment(environment: UpdateEnvironment, envId: Environment['id']) {
   selectedEnv.value = undefined
   if (!props.project.locked) {
     props.project.Environments.update(envId, environment)
@@ -85,7 +85,7 @@ async function deleteEnvironment(environmentId: Environment['id']) {
   }
 }
 
-async function addEnvironment(environment: Omit<CreateEnvironmentBody, 'id' | 'projectId'>) {
+async function addEnvironment(environment: CreateEnvironment) {
   newResource.value = undefined
   if (!props.project.locked) {
     props.project.Environments.create(environment)
@@ -395,7 +395,7 @@ async function copyToClipboard(text: string) {
       :is-editable="false"
       :is-project-locked="project.locked"
       :can-manage="canManageEnvs || (AdminAuthorized.Manage(userStore.adminPerms) && asProfile === 'admin')"
-      @put-environment="(environmentUpdate: UpdateEnvironmentBody) => putEnvironment(environmentUpdate, selectedEnv!.id)"
+      @put-environment="(environmentUpdate: UpdateEnvironment) => putEnvironment(environmentUpdate, selectedEnv!.id)"
       @delete-environment="() => deleteEnvironment(selectedEnv!.id)"
       @cancel="selectedEnv = undefined"
     />
@@ -405,7 +405,7 @@ async function copyToClipboard(text: string) {
       :available-clusters="projectClusters"
       :can-manage="canManageEnvs"
       is-editable
-      @add-environment="(environment: Omit<CreateEnvironmentBody, 'id' | 'projectId'>) => addEnvironment(environment)"
+      @add-environment="(environment: CreateEnvironment) => addEnvironment(environment)"
       @cancel="newResource = undefined"
     />
     <template

--- a/apps/client/src/stores/project.spec.ts
+++ b/apps/client/src/stores/project.spec.ts
@@ -1,12 +1,12 @@
 import { createRandomDbSetup, getRandomMember, getRandomProject } from '@cpn-console/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { apiClient } from '../api/xhr-client'
-import { useProjectStore } from './project'
+import { apiClient } from '../api/xhr-client.js'
+import { useProjectStore } from './project.js'
 
 const getProject = vi.spyOn(apiClient.Projects, 'getProject')
 const listProjects = vi.spyOn(apiClient.Projects, 'listProjects')
-const listEnvironments = vi.spyOn(apiClient.Environments, 'listEnvironments')
+const listEnvironments = vi.spyOn(apiClient.EnvironmentsV2, 'listEnvironmentsV2')
 const listRepositories = vi.spyOn(apiClient.Repositories, 'listRepositories')
 const apiClientPost = vi.spyOn(apiClient.Projects, 'createProject')
 

--- a/apps/client/src/utils/project-utils.ts
+++ b/apps/client/src/utils/project-utils.ts
@@ -1,6 +1,6 @@
 import type {
   CreateDeploymentBody,
-  CreateEnvironmentBody,
+  CreateEnvironment,
   CreateRepositoryBody,
   Deployment,
   Environment,
@@ -16,7 +16,7 @@ import type {
   RepositoryParams,
   Role,
   UpdateDeploymentBody,
-  UpdateEnvironmentBody,
+  UpdateEnvironment,
   UpdateRepositoryBody,
   User,
 } from '@cpn-console/shared'
@@ -274,22 +274,22 @@ export class Project implements ProjectV2 {
 
   Environments = {
     list: async () => {
-      this.environments.value = await apiClient.Environments.listEnvironments({ query: { projectId: this.id } })
+      this.environments.value = await apiClient.EnvironmentsV2.listEnvironmentsV2({ params: { projectId: this.id } })
         .then((response: any) => extractData(response, 200))
       return this.environments.value
     },
-    create: async (envData: Omit<CreateEnvironmentBody, 'projectId'>) => {
+    create: async (envData: CreateEnvironment) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.Environments.createEnvironment({ body: { ...envData, projectId: this.id } })
+        await apiClient.EnvironmentsV2.createEnvironmentV2({ params: { projectId: this.id }, body: envData })
           .then((response: any) => extractData(response, 201))
         return this.Environments.list()
       } finally { callback() }
     },
-    update: async (id: Environment['id'], environment: UpdateEnvironmentBody) => {
+    update: async (id: Environment['id'], environment: UpdateEnvironment) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.Environments.updateEnvironment({ body: environment, params: { environmentId: id } })
+        await apiClient.EnvironmentsV2.updateEnvironmentV2({ body: environment, params: { projectId: this.id, environmentId: id } })
           .then((response: any) => extractData(response, 200))
         await this.Environments.list()
         return this.environments
@@ -298,7 +298,7 @@ export class Project implements ProjectV2 {
     delete: async (environmentId: Environment['id']) => {
       const callback = this.addOperation('envManagement')
       try {
-        await apiClient.Environments.deleteEnvironment({ params: { environmentId } })
+        await apiClient.EnvironmentsV2.deleteEnvironmentV2({ params: { projectId: this.id, environmentId } })
           .then((response: any) => extractData(response, 204))
         await this.Environments.list()
         return this.environments


### PR DESCRIPTION
## Issues liées

Issues numéro: #1911, #2322

---------

## Quel est le comportement actuel ?

Le client consomme les routes v1 des environnements via `apiClient.Environments` :

- `listEnvironments({ query: { projectId } })`
- `createEnvironment({ body: { ...envData, projectId } })`
- `updateEnvironment({ params: { environmentId } })`
- `deleteEnvironment({ params: { environmentId } })`

Le `projectId` transite donc dans la query string ou dans le body, et les
composants typent leurs événements avec `CreateEnvironmentBody` /
`UpdateEnvironmentBody` (d'où les `Omit<..., 'projectId'>` dans
`EnvironmentForm.vue` et `ProjectResources.vue`).

Cet état provient du revert 933977c8, qui avait remis le client sur la v1 en
attendant que le back-end v2 soit prêt.

## Quel est le nouveau comportement ?

Le client repasse sur `apiClient.EnvironmentsV2`, aligné sur les routes
`/api/v2/projects/:projectId/environments` :

- `listEnvironmentsV2({ params: { projectId } })`
- `createEnvironmentV2({ params: { projectId }, body })`
- `updateEnvironmentV2({ params: { projectId, environmentId }, body })`
- `deleteEnvironmentV2({ params: { projectId, environmentId } })`

`projectId` est désormais un paramètre de chemin, plus un champ de query/body.
Les types partagés `CreateEnvironment` / `UpdateEnvironment` remplacent
`CreateEnvironmentBody` / `UpdateEnvironmentBody`, ce qui supprime les `Omit`
sur `projectId` dans les signatures des composants.

Fichiers touchés :

- `apps/client/src/utils/project-utils.ts` — appels et types du gestionnaire `Environments`
- `apps/client/src/components/EnvironmentForm.vue` — type de l'émission `addEnvironment`
- `apps/client/src/components/ProjectResources.vue` — types des handlers `addEnvironment` / `putEnvironment`
- `apps/client/src/stores/project.spec.ts` — le spy cible `EnvironmentsV2.listEnvironmentsV2`

Vérifications : `pnpm run type-check` passe, `src/stores/project.spec.ts` passe (4 tests).

## Cette PR introduit-elle un breaking change ?

Non côté utilisateur : le comportement fonctionnel des écrans environnements est
inchangé (mêmes actions, mêmes formulaires). Le changement est interne au
transport HTTP.

Prérequis de déploiement : les routes `/api/v2/projects/:projectId/environments`
doivent être servies, ce qui suppose le bloc nginx générique `/api/v2` et le
back-end v2 en place. Sans cela, les écrans environnements retournent 404.

## Autres informations

- PR empilée sur #2437 (`feat/environment-v2-await-reconciliation`) : à merger après.
- Le diff est le revert exact de 933977c8.
