### PR TITLE
feat(server-nestjs): await project reconciliation on repositories mutations

### DIFF
--- a/apps/server-nestjs/src/modules/repository/repository.service.spec.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.service.spec.ts
@@ -68,6 +68,10 @@ describe('repositoryService', () => {
     service = module.get<RepositoryService>(RepositoryService)
   })
 
+  const failedReconciliation = {
+    gitlab: { status: 'KO', message: 'Unable to provision repository', executionTime: 1, error: new Error('boom') },
+  } as const
+
   it('should be defined', () => {
     expect(service).toBeDefined()
   })
@@ -108,7 +112,7 @@ describe('repositoryService', () => {
         GIT_INPUT_USER: validCreateRepository.isPrivate ? validCreateRepository.externalUserName : undefined,
         GIT_INPUT_PASSWORD: validCreateRepository.isPrivate ? validCreateRepository.externalToken : undefined,
       })
-      // The token must reach Vault before the (fire-and-forget) reconciliation reads it.
+      // The token must reach Vault before the reconciliation reads it.
       expect(vault.writeGitlabMirrorCreds.mock.invocationCallOrder[0])
         .toBeLessThan(appEvents.emitProjectEvent.mock.invocationCallOrder[0])
       expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, {
@@ -166,6 +170,33 @@ describe('repositoryService', () => {
 
       expect(vault.writeGitlabMirrorCreds).not.toHaveBeenCalled()
       expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, expect.objectContaining({ action: 'Create Repository' }))
+    })
+
+    it('waits for the reconciliation and rejects with 422 when a plugin fails', async () => {
+      const repository = makeRepository({ id: repositoryId, projectId, internalRepoName: validCreateRepository.internalRepoName })
+      datastore.hasRepositoryWithName.mockResolvedValue(false)
+      datastore.createRepository.mockResolvedValue(repository)
+      vault.writeGitlabMirrorCreds.mockResolvedValue(undefined)
+      appEvents.emitProjectEvent.mockResolvedValue(failedReconciliation)
+
+      await expect(service.createRepository(projectId, projectSlug, validCreateRepository, userId, requestId))
+        .rejects.toThrow(UnprocessableEntityException)
+      expect(datastore.createRepository).toHaveBeenCalled()
+      // A failed reconciliation stops the request before the mirror sync, as in v1.
+      expect(appEvents.emitRepositoryEvent).not.toHaveBeenCalled()
+    })
+
+    it('still returns the repository when the post-creation mirror sync fails', async () => {
+      const repository = makeRepository({ id: repositoryId, projectId, internalRepoName: validCreateRepository.internalRepoName })
+      datastore.hasRepositoryWithName.mockResolvedValue(false)
+      datastore.createRepository.mockResolvedValue(repository)
+      vault.writeGitlabMirrorCreds.mockResolvedValue(undefined)
+      appEvents.emitProjectEvent.mockResolvedValue({})
+      appEvents.emitRepositoryEvent.mockRejectedValue(new Error('mirror unreachable'))
+
+      const result = await service.createRepository(projectId, projectSlug, validCreateRepository, userId, requestId)
+
+      expect(result).toEqual(repository)
     })
 
     it('rejects when a repository with the same internal name already exists', async () => {
@@ -229,6 +260,17 @@ describe('repositoryService', () => {
       expect(vault.writeGitlabMirrorCreds).not.toHaveBeenCalled()
       expect(vault.deleteGitlabMirrorCreds).not.toHaveBeenCalled()
       expect(appEvents.emitProjectEvent).toHaveBeenCalledWith('project.upsert', projectId, expect.objectContaining({ action: 'Update Repository' }))
+    })
+
+    it('waits for the reconciliation and rejects with 422 when a plugin fails', async () => {
+      const repository = makeRepository({ id: repositoryId, projectId })
+      datastore.getRepositoryById.mockResolvedValue(repository)
+      datastore.updateRepository.mockResolvedValue(repository)
+      appEvents.emitProjectEvent.mockResolvedValue(failedReconciliation)
+
+      await expect(service.updateRepository(projectId, projectSlug, repositoryId, validUpdateRepository, userId, requestId))
+        .rejects.toThrow(UnprocessableEntityException)
+      expect(datastore.updateRepository).toHaveBeenCalled()
     })
 
     it('rejects when the repository belongs to another project', async () => {
@@ -314,6 +356,16 @@ describe('repositoryService', () => {
         userId,
         requestId,
       })
+    })
+
+    it('waits for the reconciliation and rejects with 422 when a plugin fails', async () => {
+      datastore.getRepositoryById.mockResolvedValue(makeRepository({ id: repositoryId, projectId }))
+      datastore.deleteRepository.mockResolvedValue(makeRepository({ id: repositoryId, projectId }))
+      appEvents.emitProjectEvent.mockResolvedValue(failedReconciliation)
+
+      await expect(service.deleteRepository(projectId, repositoryId, userId, requestId))
+        .rejects.toThrow(UnprocessableEntityException)
+      expect(datastore.deleteRepository).toHaveBeenCalledWith(repositoryId)
     })
 
     it('rejects when the repository belongs to another project', async () => {

--- a/apps/server-nestjs/src/modules/repository/repository.service.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.service.ts
@@ -37,9 +37,8 @@ export class RepositoryService {
       // The external token is never persisted in the database — it only lives in Vault
       // as the mirror input credentials. We must write it BEFORE emitting the
       // reconciliation: the GitLab reconciler only reads and *preserves* the existing
-      // GIT_INPUT_PASSWORD from Vault (it never receives the token), and the reconcile
-      // runs fire-and-forget. A token written after — or racing — the reconcile would
-      // be lost, since it exists nowhere else once this request returns.
+      // GIT_INPUT_PASSWORD from Vault (it never receives the token), so a token written
+      // after the reconcile would never reach the mirror.
       if (this.vault) {
         await this.vault.writeGitlabMirrorCreds(projectSlug, repository.internalRepoName, {
           GIT_INPUT_USER: repositoryToCreate.externalUserName,
@@ -50,14 +49,20 @@ export class RepositoryService {
       }
     }
 
-    this.reconcileProject(projectId, 'Create Repository', userId, requestId)
+    await this.reconcileProjectAndThrowOnFailure(
+      projectId,
+      'Create Repository',
+      userId,
+      requestId,
+      'Echec des services lors de la création du dépôt',
+    )
 
     // Legacy parity: a repository declared with an external source is mirrored right
-    // away, so the first sync doesn't wait for a manual trigger. Fire-and-forget like
-    // the reconciliation above — the creation itself succeeded, and the mirror pipeline
-    // is a downstream effect whose failure is reported in the admin log.
+    // away, so the first sync doesn't wait for a manual trigger. v1 awaits this sync but
+    // discards its outcome — the creation itself succeeded, and the mirror pipeline is a
+    // downstream effect whose failure is reported in the admin log, not in the response.
     if (repositoryToCreate.externalRepoUrl) {
-      this.syncRepositoryMirror(
+      await this.syncRepositoryMirror(
         { projectId, projectSlug, internalRepoName: repository.internalRepoName, syncAllBranches: true },
         userId,
         requestId,
@@ -112,12 +117,18 @@ export class RepositoryService {
     )
 
     // Apply the credential intent to Vault BEFORE emitting the reconciliation, for the
-    // same reason as on create: the token lives nowhere but Vault, the reconciler only
-    // preserves the GIT_INPUT_PASSWORD already stored there, and the reconcile is
-    // fire-and-forget — so the new token (or its removal) must be persisted first.
+    // same reason as on create: the token lives nowhere but Vault and the reconciler only
+    // preserves the GIT_INPUT_PASSWORD already stored there, so the new token (or its
+    // removal) must be persisted first.
     await this.applyMirrorCredentialUpdate(projectSlug, repository, parseRepositoryCredentialUpdate(repositoryToUpdate))
 
-    this.reconcileProject(projectId, 'Update Repository', userId, requestId)
+    await this.reconcileProjectAndThrowOnFailure(
+      projectId,
+      'Update Repository',
+      userId,
+      requestId,
+      'Echec des services à la mise à jour du dépôt',
+    )
     return repository
   }
 
@@ -153,7 +164,13 @@ export class RepositoryService {
   async deleteRepository(projectId: string, repositoryId: string, userId: string, requestId: string): Promise<void> {
     await this.getProjectRepositoryOrThrow(projectId, repositoryId)
     await this.repositoryDatastoreService.deleteRepository(repositoryId)
-    this.reconcileProject(projectId, 'Delete Repository', userId, requestId)
+    await this.reconcileProjectAndThrowOnFailure(
+      projectId,
+      'Delete Repository',
+      userId,
+      requestId,
+      'Echec des services à la suppression du dépôt',
+    )
   }
 
   /** Ensures the repository exists and belongs to the project addressed in the route. */
@@ -166,13 +183,23 @@ export class RepositoryService {
   }
 
   /**
-   * Triggers the project reconciliation without blocking the response: listener
-   * outcomes (including failures) are persisted in the admin log by AppEventsService.
+   * Runs the project reconciliation and waits for it before answering: a repository
+   * change is only meaningful once the services have applied it, so a failing plugin
+   * must surface as a 422 (legacy v1 behavior) instead of leaving the caller with a
+   * success on a project that AppEventsService just marked `failed`. The row change
+   * stays committed — the reconciliation is replayable.
    */
-  private reconcileProject(projectId: string, action: EventLogAction, userId: string, requestId: string): void {
-    this.appEvents.emitProjectEvent('project.upsert', projectId, { action, userId, requestId })
-      .catch((error: unknown) => {
-        this.logger.error(`project.upsert reconciliation failed (projectId=${projectId})`, error instanceof Error ? error.stack : String(error))
-      })
+  private async reconcileProjectAndThrowOnFailure(
+    projectId: string,
+    action: EventLogAction,
+    userId: string,
+    requestId: string,
+    failureMessage: string,
+  ): Promise<void> {
+    const results = await this.appEvents.emitProjectEvent('project.upsert', projectId, { action, userId, requestId })
+
+    if (getFailedPlugins(results).length) {
+      throw new UnprocessableEntityException(failureMessage)
+    }
   }
 }


### PR DESCRIPTION
## Issues liées

Issues numéro: #2423

---------

## Quel est le comportement actuel ?

Sur l'API v2 (`/api/v2/projects/:projectId/repositories`), la création, la modification et la suppression d'un dépôt répondent immédiatement (201 / 200 / 204), puis déclenchent la réconciliation `project.upsert` en tâche de fond (fire-and-forget).

L'utilisateur reçoit donc un succès alors que les services (GitLab, ArgoCD, …) n'ont pas encore appliqué le changement. Si un plugin échoue, le projet est marqué `failed` juste après la réponse : l'échec n'apparaît que dans le journal d'administration, jamais dans la réponse de la requête. L'API v1, elle, attend le résultat des hooks et renvoie une erreur.

## Quel est le nouveau comportement ?

Les trois routes attendent la fin de la réconciliation avant de répondre :

| Route | Succès | Échec d'un service |
| --- | --- | --- |
| `POST /repositories` | 201 | 422 — `Echec des services lors de la création du dépôt` |
| `PUT /repositories/:id` | 200 | 422 — `Echec des services à la mise à jour du dépôt` |
| `DELETE /repositories/:id` | 204 | 422 — `Echec des services à la suppression du dépôt` |

Codes et messages identiques à l'API v1. En cas d'échec, l'écriture en base est conservée — comme en v1 : le projet est marqué `failed` et la réconciliation reste rejouable.

La synchronisation initiale du miroir (dépôt créé avec une source externe) est désormais attendue elle aussi, mais son résultat reste ignoré : v1 fait de même, la création a réussi et le miroir est un effet aval dont l'échec est journalisé, pas renvoyé au client.

### Pourquoi ce changement est nécessaire

L'UX actuelle du client est construite sur le comportement **synchrone** de la v1 : à la fin de l'appel, l'utilisateur voit l'état réel du dépôt et l'erreur du service fautif s'affiche directement dans l'interface. Avec la v2 en fire-and-forget, l'écran affiche un succès sur un projet qui vient de basculer en `failed`, sans aucun retour d'erreur. Aligner la v2 sur la v1 est donc un prérequis au basculement du client sur les routes v2 : sinon il faudrait d'abord reconstruire tout le suivi asynchrone (polling de statut, notifications) côté interface.

## Cette PR introduit-elle un breaking change ?

Pas sur le contrat d'API : mêmes codes de succès, mêmes payloads.

Changement de comportement observable : les trois routes v2 sont désormais synchrones, leur temps de réponse correspond à la durée du round-trip des plugins (comportement v1). Les clients dont les timeouts auraient été calibrés sur les réponses rapides de la v2 sont à vérifier.

## Autres informations

- Quatre tests ajoutés : un par verbe pour le 422 quand un plugin renvoie `KO`, plus un vérifiant que la création renvoie bien le dépôt quand la synchronisation du miroir échoue.
- Suite complète `server-nestjs` : 538 tests passés, 57 ignorés.
- L'intention de mise à jour des credentials de dépôt reste suivie séparément dans #2422.
