### PR TITLE
feat(client): switch repositories to API v2

### DIFF
--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { CleanedCluster, Cluster, CreateEnvironment, Environment, Repo, Stage, UpdateEnvironment, Zone } from '@cpn-console/shared'
 import type { Project } from '@/utils/project-utils.js'
+import type { RepoFormResult } from '@/utils/repository-utils.js'
 import { logger } from '@cpn-console/logger/browser'
 import { AdminAuthorized, defaultBranchName, ProjectAuthorized, projectIsLockedInfo } from '@cpn-console/shared'
 import TimeAgo from 'javascript-time-ago'
@@ -11,6 +12,7 @@ import { useStageStore } from '@/stores/stage.js'
 import { useUserStore } from '@/stores/user.js'
 import { useZoneStore } from '@/stores/zone.js'
 import { clickInDialog, getRandomId } from '@/utils/func.js'
+import { toCreateRepositoryBody, toUpdateRepositoryBody } from '@/utils/repository-utils.js'
 
 type Source = 'Privée extérieure' | 'Publique extérieure' | 'Interne'
 
@@ -96,15 +98,15 @@ async function addEnvironment(environment: CreateEnvironment) {
 
 const isAllSyncing = ref<boolean>(false)
 
-async function saveRepo(repo: Repo) {
+async function saveRepo(repo: RepoFormResult) {
   selectedRepo.value = undefined
   newResource.value = undefined
   if (repo.id) {
-    props.project.Repositories.update(repo.id, repo)
+    props.project.Repositories.update(repo.id, toUpdateRepositoryBody(repo))
       .catch(reason => snackbarStore.setMessage(reason, 'error'))
       .finally(reload)
   } else {
-    props.project.Repositories.create(repo)
+    props.project.Repositories.create(toCreateRepositoryBody(repo))
       .catch(reason => snackbarStore.setMessage(reason, 'error'))
       .finally(reload)
   }
@@ -120,7 +122,12 @@ async function deleteRepo(repoId: Repo['id']) {
 async function syncRepository() {
   if (!selectedRepo.value) return
   if (!isAllSyncing.value && !branchName.value) branchName.value = defaultBranchName
-  await props.project.Repositories.sync(selectedRepo.value.id, { syncAllBranches: isAllSyncing.value, branchName: branchName.value })
+  await props.project.Repositories.sync(
+    selectedRepo.value.id,
+    isAllSyncing.value
+      ? { syncAllBranches: true }
+      : { syncAllBranches: false, branchName: branchName.value },
+  )
   snackbarStore.setMessage(`Travail de synchronisation lancé pour le dépôt ${selectedRepo.value.internalRepoName}`)
 }
 

--- a/apps/client/src/stores/project.spec.ts
+++ b/apps/client/src/stores/project.spec.ts
@@ -7,7 +7,7 @@ import { useProjectStore } from './project.js'
 const getProject = vi.spyOn(apiClient.Projects, 'getProject')
 const listProjects = vi.spyOn(apiClient.Projects, 'listProjects')
 const listEnvironments = vi.spyOn(apiClient.EnvironmentsV2, 'listEnvironmentsV2')
-const listRepositories = vi.spyOn(apiClient.Repositories, 'listRepositories')
+const listRepositories = vi.spyOn(apiClient.RepositoriesV2, 'listRepositoriesV2')
 const apiClientPost = vi.spyOn(apiClient.Projects, 'createProject')
 
 describe('project Store', () => {

--- a/apps/client/src/utils/project-utils.ts
+++ b/apps/client/src/utils/project-utils.ts
@@ -1,7 +1,7 @@
 import type {
   CreateDeploymentBody,
   CreateEnvironment,
-  CreateRepositoryBody,
+  CreateRepositoryBodyV2,
   Deployment,
   Environment,
   GetLogsQuery,
@@ -13,11 +13,11 @@ import type {
   ProjectService,
   ProjectV2,
   Repo,
-  RepositoryParams,
   Role,
+  SyncRepositoryBodyV2,
   UpdateDeploymentBody,
   UpdateEnvironment,
-  UpdateRepositoryBody,
+  UpdateRepositoryBodyV2,
   User,
 } from '@cpn-console/shared'
 import type { Ref } from 'vue'
@@ -308,32 +308,32 @@ export class Project implements ProjectV2 {
 
   Repositories = {
     list: async () => {
-      this.repositories.value = await apiClient.Repositories.listRepositories({ query: { projectId: this.id } })
+      this.repositories.value = await apiClient.RepositoriesV2.listRepositoriesV2({ params: { projectId: this.id } })
         .then((response: any) => extractData(response, 200))
       return this.repositories.value
     },
-    sync: async (repositoryId: Repo['id'], { branchName, syncAllBranches = false }: { branchName?: string, syncAllBranches?: boolean }) => {
+    sync: async (repositoryId: Repo['id'], syncRequest: SyncRepositoryBodyV2) => {
       const callback = this.addOperation('repoManagement')
       try {
-        return apiClient.Repositories.syncRepository({
-          params: { repositoryId },
-          body: { branchName, syncAllBranches },
+        return apiClient.RepositoriesV2.syncRepositoryV2({
+          params: { projectId: this.id, repositoryId },
+          body: syncRequest,
         })
           .then((response: any) => extractData(response, 204))
       } finally { callback() }
     },
-    create: async (repoData: Omit<CreateRepositoryBody, 'projectId'>) => {
+    create: async (repoData: CreateRepositoryBodyV2) => {
       const callback = this.addOperation('repoManagement')
       try {
-        await apiClient.Repositories.createRepository({ body: { ...repoData, projectId: this.id } })
+        await apiClient.RepositoriesV2.createRepositoryV2({ params: { projectId: this.id }, body: repoData })
           .then((response: any) => extractData(response, 201))
         return this.Repositories.list()
       } finally { callback() }
     },
-    update: async (id: RepositoryParams['repositoryId'], repoData: Omit<UpdateRepositoryBody, 'projectId'>) => {
+    update: async (id: Repo['id'], repoData: UpdateRepositoryBodyV2) => {
       const callback = this.addOperation('repoManagement')
       try {
-        await apiClient.Repositories.updateRepository({ body: { ...repoData, projectId: this.id }, params: { repositoryId: id } })
+        await apiClient.RepositoriesV2.updateRepositoryV2({ params: { projectId: this.id, repositoryId: id }, body: repoData })
           .then((response: any) => extractData(response, 200))
         return this.Repositories.list()
       } finally { callback() }
@@ -341,7 +341,7 @@ export class Project implements ProjectV2 {
     delete: async (repositoryId: Repo['id']) => {
       const callback = this.addOperation('repoManagement')
       try {
-        await apiClient.Repositories.deleteRepository({ params: { repositoryId } })
+        await apiClient.RepositoriesV2.deleteRepositoryV2({ params: { projectId: this.id, repositoryId } })
           .then((response: any) => extractData(response, 204))
         return this.Repositories.list()
       } finally { callback() }

--- a/apps/client/src/utils/repository-utils.spec.ts
+++ b/apps/client/src/utils/repository-utils.spec.ts
@@ -1,0 +1,104 @@
+import type { RepoFormResult } from './repository-utils.js'
+import { fakeToken } from '@cpn-console/shared'
+import { faker } from '@faker-js/faker'
+import { describe, expect, it } from 'vitest'
+import { toCreateRepositoryBody, toUpdateRepositoryBody } from './repository-utils.js'
+
+function makeFormResult(overrides: RepoFormResult = {}): RepoFormResult {
+  return {
+    internalRepoName: 'candilib',
+    externalRepoUrl: 'https://github.com/cloud-pi-native/console.git',
+    isPrivate: false,
+    isInfra: false,
+    isStandalone: false,
+    ...overrides,
+  }
+}
+
+describe('toCreateRepositoryBody', () => {
+  it('should build a public repository body without credentials', () => {
+    const body = toCreateRepositoryBody(makeFormResult({ externalUserName: 'this-is-tobi', externalToken: 'secret' }))
+
+    expect(body).toEqual({
+      internalRepoName: 'candilib',
+      externalRepoUrl: 'https://github.com/cloud-pi-native/console.git',
+      isPrivate: false,
+      isInfra: false,
+      deployRevision: undefined,
+      deployPath: undefined,
+      helmValuesFiles: undefined,
+    })
+  })
+
+  it('should carry the credentials of a private repository', () => {
+    const body = toCreateRepositoryBody(makeFormResult({ isPrivate: true, externalUserName: 'this-is-tobi', externalToken: 'secret' }))
+
+    expect(body).toMatchObject({ isPrivate: true, externalUserName: 'this-is-tobi', externalToken: 'secret' })
+  })
+
+  it('should default the credentials of a private repository to empty strings', () => {
+    const body = toCreateRepositoryBody(makeFormResult({ isPrivate: true }))
+
+    expect(body).toMatchObject({ isPrivate: true, externalUserName: '', externalToken: '' })
+  })
+
+  it('should keep the deployment settings of an infra repository', () => {
+    const body = toCreateRepositoryBody(makeFormResult({
+      isInfra: true,
+      deployRevision: 'main',
+      deployPath: 'manifests/',
+      helmValuesFiles: 'values/extra.yaml,values-<env>/custom.yaml',
+    }))
+
+    expect(body).toMatchObject({
+      isInfra: true,
+      deployRevision: 'main',
+      deployPath: 'manifests/',
+      helmValuesFiles: 'values/extra.yaml,values-<env>/custom.yaml',
+    })
+  })
+})
+
+describe('toUpdateRepositoryBody', () => {
+  const persisted = {
+    id: faker.string.uuid(),
+    projectId: faker.string.uuid(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+
+  it('should drop the fields the v2 route does not accept', () => {
+    const body = toUpdateRepositoryBody(makeFormResult({ ...persisted }))
+
+    expect(body).toEqual({
+      externalRepoUrl: 'https://github.com/cloud-pi-native/console.git',
+      isPrivate: false,
+      isInfra: false,
+    })
+    expect(body).not.toHaveProperty('id')
+    expect(body).not.toHaveProperty('projectId')
+    expect(body).not.toHaveProperty('createdAt')
+    expect(body).not.toHaveProperty('updatedAt')
+    expect(body).not.toHaveProperty('internalRepoName')
+    expect(body).not.toHaveProperty('isStandalone')
+  })
+
+  it('should omit an unchanged token, signalled by the fakeToken placeholder', () => {
+    const body = toUpdateRepositoryBody(makeFormResult({ ...persisted, isPrivate: true, externalUserName: 'this-is-tobi', externalToken: fakeToken }))
+
+    expect(body).not.toHaveProperty('externalToken')
+    expect(body).toMatchObject({ isPrivate: true, externalUserName: 'this-is-tobi' })
+  })
+
+  it('should omit an empty token', () => {
+    const body = toUpdateRepositoryBody(makeFormResult({ ...persisted, externalToken: '' }))
+
+    expect(body).not.toHaveProperty('externalToken')
+  })
+
+  it('should send a token that was actually edited', () => {
+    const body = toUpdateRepositoryBody(makeFormResult({ ...persisted, isPrivate: true, externalUserName: 'this-is-tobi', externalToken: 'new-secret' }))
+
+    expect(body).toMatchObject({ externalToken: 'new-secret' })
+  })
+})

--- a/apps/client/src/utils/repository-utils.ts
+++ b/apps/client/src/utils/repository-utils.ts
@@ -1,0 +1,29 @@
+import type { CreateRepositoryBodyV2, Repo, UpdateRepositoryBodyV2 } from '@cpn-console/shared'
+import { fakeToken } from '@cpn-console/shared'
+
+// Ce que remonte RepoForm : un dépôt partiel, augmenté de la clé de formulaire `isStandalone`.
+export type RepoFormResult = Partial<Repo> & { isStandalone?: boolean }
+
+export function toCreateRepositoryBody(repo: RepoFormResult): CreateRepositoryBodyV2 {
+  const repositoryBase = {
+    internalRepoName: repo.internalRepoName ?? '',
+    externalRepoUrl: repo.externalRepoUrl,
+    isInfra: !!repo.isInfra,
+    deployRevision: repo.deployRevision,
+    deployPath: repo.deployPath,
+    helmValuesFiles: repo.helmValuesFiles,
+  }
+
+  return repo.isPrivate
+    ? { ...repositoryBase, isPrivate: true, externalUserName: repo.externalUserName ?? '', externalToken: repo.externalToken ?? '' }
+    : { ...repositoryBase, isPrivate: false }
+}
+
+export function toUpdateRepositoryBody(repo: RepoFormResult): UpdateRepositoryBodyV2 {
+  const { externalToken, id: _id, projectId: _projectId, createdAt: _createdAt, updatedAt: _updatedAt, internalRepoName: _internalRepoName, isStandalone: _isStandalone, ...repositoryFields } = repo
+
+  return {
+    ...repositoryFields,
+    ...externalToken && externalToken !== fakeToken && { externalToken },
+  }
+}

--- a/packages/shared/src/contracts/v2/repository.ts
+++ b/packages/shared/src/contracts/v2/repository.ts
@@ -1,3 +1,4 @@
+import type { ClientInferRequest } from '@ts-rest/core'
 import { ContractNoBody } from '@ts-rest/core'
 import { z } from 'zod'
 import { apiPrefixV2, contractInstance } from '../../api-client.js'
@@ -109,3 +110,11 @@ export const repositoryContractV2 = contractInstance.router({
     projectId: z.string().uuid(),
   }),
 })
+
+// Types de corps de requête : côté appelant ce sont les entrées des schémas
+// (avant transformations), d'où leur dérivation du contrat plutôt que de `z.infer`.
+export type CreateRepositoryBodyV2 = ClientInferRequest<typeof repositoryContractV2.createRepositoryV2>['body']
+
+export type UpdateRepositoryBodyV2 = ClientInferRequest<typeof repositoryContractV2.updateRepositoryV2>['body']
+
+export type SyncRepositoryBodyV2 = ClientInferRequest<typeof repositoryContractV2.syncRepositoryV2>['body']


### PR DESCRIPTION
## Issues liées

Issues numéro: #2423, #2422

---------

## Quel est le comportement actuel ?

Le client consomme les routes v1 des dépôts via `apiClient.Repositories` :

- `listRepositories({ query: { projectId } })`
- `createRepository({ body: { ...repoData, projectId } })`
- `updateRepository({ params: { repositoryId }, body: { ...repoData, projectId } })`
- `deleteRepository({ params: { repositoryId } })`
- `syncRepository({ params: { repositoryId }, body: { branchName, syncAllBranches } })`

Le `projectId` transite donc dans la query string ou dans le body. Le formulaire envoie par ailleurs son résultat brut au gestionnaire : sur une mise à jour, les champs non modifiables (`id`, `projectId`, `internalRepoName`, horodatages) et la clé de formulaire `isStandalone` partent dans le body, et le placeholder `fakeToken` — affiché à la place du token existant, jamais renvoyé par l'API — est réémis tel quel.

## Quel est le nouveau comportement ?

Le client passe sur `apiClient.RepositoriesV2`, aligné sur les routes `/api/v2/projects/:projectId/repositories` :

- `listRepositoriesV2({ params: { projectId } })`
- `createRepositoryV2({ params: { projectId }, body })`
- `updateRepositoryV2({ params: { projectId, repositoryId }, body })`
- `deleteRepositoryV2({ params: { projectId, repositoryId } })`
- `syncRepositoryV2({ params: { projectId, repositoryId }, body })`

`projectId` est un paramètre de chemin, plus un champ de query/body.

Deux adaptateurs isolent la conversion « résultat de formulaire → corps v2 » dans `apps/client/src/utils/repository-utils.ts` :

- `toCreateRepositoryBody` construit la branche attendue par l'union discriminée du contrat v2 : `isPrivate: true` porte `externalUserName` / `externalToken`, `isPrivate: false` ne les envoie pas.
- `toUpdateRepositoryBody` retire les champs que la route v2 refuse (`id`, `projectId`, `createdAt`, `updatedAt`, `internalRepoName`, `isStandalone`) et **n'envoie `externalToken` que s'il a réellement été saisi** : un token vide ou resté à `fakeToken` est omis, ce qui signale « inchangé » au back-end (#2422) au lieu d'écraser le secret en Vault par un placeholder.

La synchronisation construit désormais un body conforme à l'union du contrat : `{ syncAllBranches: true }` ou `{ syncAllBranches: false, branchName }`, au lieu d'un `branchName` potentiellement `undefined`.

Fichiers touchés :

- `apps/client/src/utils/project-utils.ts` — appels et types du gestionnaire `Repositories`
- `apps/client/src/utils/repository-utils.ts` — nouveau, les deux adaptateurs
- `apps/client/src/components/ProjectResources.vue` — `saveRepo` / `syncRepository` passent par les adaptateurs
- `apps/client/src/stores/project.spec.ts` — le spy cible `RepositoriesV2.listRepositoriesV2`
- `packages/shared/src/contracts/v2/repository.ts` — export des types de body (`ClientInferRequest`, donc les entrées des schémas avant transformation)

Vérifications : `vue-tsc --noEmit` passe ; `repository-utils.spec.ts` (8 tests, nouveaux) et `project.spec.ts` (4 tests) passent.

## Cette PR introduit-elle un breaking change ?

Non côté utilisateur : mêmes écrans, mêmes formulaires, mêmes actions. Le changement est interne au transport HTTP.

Correction de comportement au passage : modifier un dépôt privé sans toucher au champ token ne réécrit plus le secret avec `fakeToken`.

Prérequis de déploiement : les routes `/api/v2/projects/:projectId/repositories` doivent être servies (bloc nginx générique `/api/v2` + back-end v2). Sans cela, les écrans dépôts retournent 404.

## Autres informations

- PR empilée sur #2440 (`feat/repository-v2-await-reconciliation`) : à merger après.
- Les mutations de dépôts deviennent synchrones du fait de #2440 : une erreur de service remonte maintenant dans le snackbar au lieu de rester silencieuse.
