### PR TITLE
fix(shared): accept a private repository carrying a single credential

### DIFF
--- a/packages/shared/src/schemas/v2/repository.spec.ts
+++ b/packages/shared/src/schemas/v2/repository.spec.ts
@@ -107,25 +107,52 @@ describe('createRepositorySchema', () => {
     expect(parsed).toMatchObject({ isPrivate: true, externalUserName, externalToken })
   })
 
-  it('rejects a private repository missing the token', () => {
+  // Un seul credential suffit : l'autre est collapsé en chaîne vide au boundary.
+  it('accepts a private repository providing only a token', () => {
+    const externalToken = faker.string.alphanumeric(16)
+    const parsed = CreateRepositorySchema.parse({
+      internalRepoName: 'my-repo',
+      externalRepoUrl: gitUrl,
+      isInfra: false,
+      isPrivate: true,
+      externalToken,
+    })
+
+    expect(parsed).toMatchObject({ isPrivate: true, externalUserName: '', externalToken })
+  })
+
+  it('accepts a private repository providing only a username', () => {
+    const externalUserName = faker.internet.username()
+    const parsed = CreateRepositorySchema.parse({
+      internalRepoName: 'my-repo',
+      externalRepoUrl: gitUrl,
+      isInfra: false,
+      isPrivate: true,
+      externalUserName,
+    })
+
+    expect(parsed).toMatchObject({ isPrivate: true, externalUserName, externalToken: '' })
+  })
+
+  it('rejects a private repository without any credential', () => {
     const result = CreateRepositorySchema.safeParse({
       internalRepoName: 'my-repo',
       externalRepoUrl: gitUrl,
       isInfra: false,
       isPrivate: true,
-      externalUserName: faker.internet.username(),
     })
 
     expect(result.success).toBe(false)
   })
 
-  it('rejects a private repository missing the username', () => {
+  it('rejects a private repository whose credentials are both empty', () => {
     const result = CreateRepositorySchema.safeParse({
       internalRepoName: 'my-repo',
       externalRepoUrl: gitUrl,
       isInfra: false,
       isPrivate: true,
-      externalToken: faker.string.alphanumeric(16),
+      externalUserName: '',
+      externalToken: '',
     })
 
     expect(result.success).toBe(false)

--- a/packages/shared/src/schemas/v2/repository.ts
+++ b/packages/shared/src/schemas/v2/repository.ts
@@ -29,8 +29,8 @@ const RepositoryWriteBaseSchema = z.object({
   helmValuesFiles: z.string().default(''),
 })
 
-// Union discriminée sur `isPrivate` : dans le type, les credentials sont requis pour
-// un dépôt privé et absents d'un dépôt public. Un dépôt public ne peut pas transporter
+// Union discriminée sur `isPrivate` : dans le type, les credentials sont portés par le
+// dépôt privé et absents d'un dépôt public. Un dépôt public ne peut pas transporter
 // de token au-delà du boundary (zod retire les clés inconnues de la branche publique).
 export const CreateRepositorySchema = z.discriminatedUnion('isPrivate', [
   RepositoryWriteBaseSchema.extend({
@@ -38,10 +38,15 @@ export const CreateRepositorySchema = z.discriminatedUnion('isPrivate', [
   }),
   RepositoryWriteBaseSchema.extend({
     isPrivate: z.literal(true),
-    externalUserName: z.string().min(1, { message: missingCredentials }),
-    externalToken: z.string().min(1, { message: missingCredentials }),
+    externalUserName: z.string().default(''),
+    externalToken: z.string().default(''),
   }),
 ])
+  // Un dépôt privé exige au moins un des deux credentials, et non les deux.
+  .refine(
+    repository => !repository.isPrivate || Boolean(repository.externalUserName || repository.externalToken),
+    { message: missingCredentials, path: ['externalUserName'] },
+  )
 
 // Champs modifiables d'un dépôt (internalRepoName exclu : non modifiable après création).
 export const UpdateRepositorySchema = RepoSchema.pick({


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

Depuis la migration des dépôts vers l'API v2, `CreateRepositorySchema` déclare
`externalUserName` et `externalToken` en `.min(1)` sur la branche `isPrivate: true`
de l'union discriminée : **les deux** credentials sont donc obligatoires.

L'API v1 (`CreateRepoFormSchema`), elle, n'a jamais exigé que **l'un des deux** — c'est
aussi ce que valide encore le formulaire client (`RepoForm.vue`). Créer un dépôt privé
avec un token seul (ou un nom d'utilisateur seul) passe la validation du front, puis
échoue côté serveur :

`POST /api/v2/projects/:projectId/repositories` → `400 Bad Request`

```json
{
  "formErrors": [],
  "fieldErrors": {
    "externalUserName": [
      "Si le dépôt est privé, vous devez renseigner au moins le nom d'utilisateur ou le token"
    ]
  }
}
```

Le message renvoyé contredit d'ailleurs la règle réellement appliquée. Deux tests e2e
échouent en CI sur ce 400 : *Should add an external private repo* (token seul) et
*Should add an external private infra repo* (nom d'utilisateur seul).


## Quel est le nouveau comportement ?

Un dépôt privé n'exige plus qu'**au moins un** des deux credentials, comme en v1 :

- `externalUserName` et `externalToken` passent à `z.string().default('')` ;
- un `.refine()` porté par l'union impose la présence d'au moins l'un des deux.

Le type de sortie `CreateRepository` est inchangé (les deux champs restent des `string`
non optionnelles pour un dépôt privé), donc aucun impact sur le service ni sur le mapping
côté serveur.

Tests unitaires du schéma mis à jour en conséquence : token seul accepté, nom
d'utilisateur seul accepté, aucun credential rejeté, les deux vides rejetés.

## Cette PR introduit-elle un breaking change ?

Non. La validation est assouplie : toutes les charges utiles acceptées auparavant le
restent. Aucun test e2e n'a été modifié — les deux tests qui échouaient passent désormais
sans changement.

## Autres informations

<img width="1725" height="929" alt="Screenshot 2026-08-07 at 16 55 43" src="https://github.com/user-attachments/assets/d339b848-9f46-49e7-9e33-f8316485e969" />