### PR TITLE
fix(gitlab): set ci_config_path only on externally mirrored repos

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
@@ -26,6 +26,7 @@ import {
   makeRepositoryTreeSchema,
 } from './gitlab-testing.utils'
 import {
+  GITLAB_CI_CONFIG_PATH,
   GROUP_ROOT_CUSTOM_ATTRIBUTE_KEY,
   INFRA_GROUP_CUSTOM_ATTRIBUTE_KEY,
   MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY,
@@ -273,6 +274,7 @@ describe('gitlab-client', () => {
       expect(gitlabApi.Projects.edit).toHaveBeenCalledWith(repoId, expect.objectContaining({
         name: 'mirror',
         path: 'mirror',
+        ciConfigPath: '',
       }))
     })
 
@@ -641,6 +643,76 @@ describe('gitlab-client', () => {
       }))
       expect(gitlabApi.ProjectCustomAttributes.set).toHaveBeenCalledWith(projectId, MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY, 'true')
       expect(gitlabApi.ProjectCustomAttributes.set).toHaveBeenCalledWith(projectId, PROJECT_GROUP_CUSTOM_ATTRIBUTE_KEY, 'project-1')
+    })
+
+    it('should create repo with a custom ciConfigPath when provided', async () => {
+      const subGroupPath = 'project-1'
+      const repoName = 'repo-1'
+      const fullPath = `${subGroupPath}/${repoName}`
+      const projectId = 789
+      const groupId = 456
+      const rootId = 123
+
+      const gitlabProjectsAllMock = gitlabApi.Projects.all as MockedFunction<typeof gitlabApi.Projects.all>
+      gitlabProjectsAllMock.mockResolvedValueOnce({
+        data: [],
+        paginationInfo: { next: null },
+      })
+
+      const gitlabGroupsAllMock = gitlabApi.Groups.all as MockedFunction<typeof gitlabApi.Groups.all>
+      gitlabGroupsAllMock.mockResolvedValueOnce({
+        data: [{ id: rootId, full_path: 'forge' }],
+        paginationInfo: { next: null },
+      })
+
+      gitlabGroupsAllMock.mockResolvedValueOnce({
+        data: [{ id: groupId, name: subGroupPath, parent_id: rootId, full_path: `forge/${subGroupPath}` }],
+        paginationInfo: { next: null },
+      })
+
+      gitlabApi.Projects.create.mockResolvedValue(makeProjectSchema({ id: projectId, name: repoName }))
+
+      const result = await service.getOrCreateProjectGroupRepo(subGroupPath, fullPath, GITLAB_CI_CONFIG_PATH)
+
+      expect(result).toEqual(expect.objectContaining({ id: projectId }))
+      expect(gitlabApi.Projects.create).toHaveBeenCalledWith(expect.objectContaining({
+        ciConfigPath: GITLAB_CI_CONFIG_PATH,
+      }))
+    })
+
+    it('should create repo without a ciConfigPath when none is provided', async () => {
+      const subGroupPath = 'project-1'
+      const repoName = 'repo-1'
+      const fullPath = `${subGroupPath}/${repoName}`
+      const projectId = 789
+      const groupId = 456
+      const rootId = 123
+
+      const gitlabProjectsAllMock = gitlabApi.Projects.all as MockedFunction<typeof gitlabApi.Projects.all>
+      gitlabProjectsAllMock.mockResolvedValueOnce({
+        data: [],
+        paginationInfo: { next: null },
+      })
+
+      const gitlabGroupsAllMock = gitlabApi.Groups.all as MockedFunction<typeof gitlabApi.Groups.all>
+      gitlabGroupsAllMock.mockResolvedValueOnce({
+        data: [{ id: rootId, full_path: 'forge' }],
+        paginationInfo: { next: null },
+      })
+
+      gitlabGroupsAllMock.mockResolvedValueOnce({
+        data: [{ id: groupId, name: subGroupPath, parent_id: rootId, full_path: `forge/${subGroupPath}` }],
+        paginationInfo: { next: null },
+      })
+
+      gitlabApi.Projects.create.mockResolvedValue(makeProjectSchema({ id: projectId, name: repoName }))
+
+      const result = await service.getOrCreateProjectGroupRepo(subGroupPath, fullPath)
+
+      expect(result).toEqual(expect.objectContaining({ id: projectId }))
+      expect(gitlabApi.Projects.create).not.toHaveBeenCalledWith(expect.objectContaining({
+        ciConfigPath: expect.anything(),
+      }))
     })
   })
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -221,7 +221,7 @@ export class GitlabClientService {
     return `${urlBase}/${projectGroup.full_path}/${repoName}.git`
   }
 
-  private async getOrCreateRepo(subGroupPath: string) {
+  private async getOrCreateRepo(subGroupPath: string, ciConfigPath?: string) {
     const fullPath = this.config.projectRootDir
       ? `${this.config.projectRootDir}/${subGroupPath}`
       : subGroupPath
@@ -259,7 +259,7 @@ export class GitlabClientService {
         path: repoName,
         namespaceId: parentGroup.id,
         defaultBranch: defaultBranchName,
-        ciConfigPath: '.gitlab-ci-dso.yml',
+        ciConfigPath,
       })
       this.logger.log(`Created a GitLab project repository (path=${fullPath}, repoId=${created.id})`)
       return created
@@ -273,8 +273,8 @@ export class GitlabClientService {
     }
   }
 
-  async getOrCreateProjectGroupRepo(projectSlug: string, subGroupPath: string) {
-    const repo = await this.getOrCreateRepo(subGroupPath)
+  async getOrCreateProjectGroupRepo(projectSlug: string, subGroupPath: string, ciConfigPath?: string) {
+    const repo = await this.getOrCreateRepo(subGroupPath, ciConfigPath)
     await this.setManagedProjectAttributes(repo.id, projectSlug)
     return repo
   }
@@ -451,14 +451,15 @@ export class GitlabClientService {
     }
   }
 
-  async upsertProjectGroupRepo(projectSlug: string, repoName: string, description?: string) {
+  async upsertProjectGroupRepo(projectSlug: string, repoName: string, description?: string, ciConfigPath?: string) {
     const fullPath = `${projectSlug}/${repoName}`
-    const repo = await this.getOrCreateProjectGroupRepo(projectSlug, fullPath)
+    const repo = await this.getOrCreateProjectGroupRepo(projectSlug, fullPath, ciConfigPath)
     const updated = await this.client.Projects.edit(repo.id, {
       name: repoName,
       path: repoName,
       topics: [TOPIC_PLUGIN_MANAGED],
       description,
+      ciConfigPath: ciConfigPath ?? '',
     })
     return updated
   }

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
@@ -7,8 +7,11 @@ export const INFRA_GROUP_PATH = 'infra'
 export const INFRA_APPS_REPO_NAME = 'infra-apps'
 export const MIRROR_REPO_NAME = 'mirror'
 
-/** Console-managed plumbing repositories, never a valid mirroring target. */
+// Console-managed plumbing repositories, never a valid mirroring target
 export const SPECIAL_REPO_NAMES: string[] = [INFRA_APPS_REPO_NAME, MIRROR_REPO_NAME]
+
+// Custom CI config path applied to user repositories mirroring an external URL
+export const GITLAB_CI_CONFIG_PATH = '.gitlab-ci-dso.yml'
 
 // Managed resources sentinel
 export const TOPIC_PLUGIN_MANAGED = 'plugin-managed'

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX,
   DEFAULT_PROJECT_MAINTAINER_GROUP_PATH_SUFFIX,
   DEFAULT_PROJECT_REPORTER_GROUP_PATH_SUFFIX,
+  GITLAB_CI_CONFIG_PATH,
   INFRA_APPS_REPO_NAME,
   PLUGIN_NAME,
   PROJECT_DEVELOPER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
@@ -359,8 +360,6 @@ export class GitlabService {
       'project.slug': project.slug,
       'repositories.count': project.repositories.length,
     })
-    const gitlabRepositories = await getAll(this.gitlab.getRepos(project.slug))
-    span?.setAttribute('gitlab.repositories.count', gitlabRepositories.length)
     let mirroringEnabledCount = 0
     let mirroringDisabledCount = 0
     for (const repo of project.repositories) {
@@ -371,7 +370,12 @@ export class GitlabService {
         ...(externalHost ? { 'repository.external.host': externalHost } : {}),
         'repository.external': !!repo.externalRepoUrl,
       })
-      await this.ensureRepository(project, repo, gitlabRepositories)
+      await this.gitlab.upsertProjectGroupRepo(
+        project.slug,
+        repo.internalRepoName,
+        undefined,
+        repo.externalRepoUrl ? GITLAB_CI_CONFIG_PATH : undefined,
+      )
 
       if (repo.externalRepoUrl) {
         span?.setAttribute('repository.mirroring', true)
@@ -416,18 +420,6 @@ export class GitlabService {
       }
       span?.setAttribute('managed.repositories.warned.count', warnedCount)
     }
-  }
-
-  private async ensureRepository(
-    project: ProjectWithDetails,
-    repo: ProjectWithDetails['repositories'][number],
-    gitlabRepositories: ProjectSchema[],
-  ) {
-    return gitlabRepositories.find(r => r.name === repo.internalRepoName)
-      ?? await this.gitlab.upsertProjectGroupRepo(
-        project.slug,
-        repo.internalRepoName,
-      )
   }
 
   @StartActiveSpan()

--- a/apps/server-nestjs/test/gitlab.e2e-spec.ts
+++ b/apps/server-nestjs/test/gitlab.e2e-spec.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import z from 'zod'
 import { baseConfigFactory } from '../src/config/base.config'
 import { GITLAB_REST_CLIENT, GitlabClientService } from '../src/modules/gitlab/gitlab-client.service'
+import { GITLAB_CI_CONFIG_PATH } from '../src/modules/gitlab/gitlab.constants'
 import { projectSelect } from '../src/modules/gitlab/gitlab-datastore.service'
 import { GitlabModule } from '../src/modules/gitlab/gitlab.module'
 import { AuthModule } from '../src/modules/infrastructure/auth/auth.module'
@@ -19,6 +20,7 @@ import { LoggerModule } from '../src/modules/infrastructure/logger/logger.module
 import { PermissionModule } from '../src/modules/infrastructure/permission/permission.module'
 import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
+import { getAll } from '../src/utils/iterable.utils'
 import { EXTERNAL_SYNC_TIMEOUT } from './e2e-timeout'
 
 const canRunGitlabE2E
@@ -168,6 +170,62 @@ describeWithGitLab('GitlabService (e2e)', () => {
     const repoSecret = await vaultService.read(repoVaultPath)
     expect(repoSecret?.data?.GIT_OUTPUT_USER).toBeTruthy()
     expect(repoSecret?.data?.GIT_OUTPUT_PASSWORD).toBeTruthy()
+  }, EXTERNAL_SYNC_TIMEOUT)
+
+  it('system repos use the default CI file, user repos mirroring an external URL use the custom one', async () => {
+    const project = await prisma.project.findUniqueOrThrow({
+      where: { id: testProjectId },
+      select: projectSelect,
+    })
+
+    await eventEmitter.emitAsync('project.upsert', project)
+
+    const repos = await getAll(gitlabClientService.getRepos(testProjectSlug))
+    const mirror = repos.find(repo => repo.name === 'mirror')
+    if (!mirror) throw new Error('mirror repo not found')
+    const infraApps = repos.find(repo => repo.name === 'infra-apps')
+    if (!infraApps) throw new Error('infra-apps repo not found')
+    const app = repos.find(repo => repo.name === 'app')
+    if (!app) throw new Error('app repo not found')
+
+    // The mirror pipeline must resolve the default .gitlab-ci.yml committed by commitMirror.
+    // A custom ci_config_path would make GitLab look for .gitlab-ci-dso.yml, which is never
+    // committed into the mirror repo (issue #2475: HTTP 400 on pipeline trigger).
+    expect(mirror.ci_config_path).toBeFalsy()
+    expect(infraApps.ci_config_path).toBeFalsy()
+
+    // Mirroring an external URL pin the custom CI config path.
+    expect(app.ci_config_path).toBe(GITLAB_CI_CONFIG_PATH)
+
+    // commitMirror wrote the default CI file into the mirror repo
+    const ciFile = await gitlabClientService.getFile(mirror, '.gitlab-ci.yml', 'main')
+    expect(ciFile).toBeTruthy()
+  }, EXTERNAL_SYNC_TIMEOUT)
+
+  it('should trigger the mirror pipeline using the mirror repo default CI config', async () => {
+    const project = await prisma.project.findUniqueOrThrow({
+      where: { id: testProjectId },
+      select: projectSelect,
+    })
+    await eventEmitter.emitAsync('project.upsert', project)
+
+    const allRepos = await getAll(gitlabClientService.getRepos(testProjectSlug))
+    const mirror = allRepos.find(repo => repo.name === 'mirror')
+    if (!mirror) throw new Error('mirror repo not found')
+
+    // The mirror pipeline includes mirror.yml ($CATALOG_PATH) from the DSO catalog
+    // project forge-mi/projects/catalog. The integration GitLab sets CATALOG_PATH at
+    // the instance/group level but not on the ephemeral test projects under
+    // forge-dev/projects, so set it (and its project-level permission) here.
+    await gitlabClient.ProjectVariables.create(mirror.id, 'CATALOG_PATH', 'forge-mi/projects/catalog', {
+      variableType: 'env_var',
+      masked: false,
+      protected: false,
+      raw: true,
+    })
+
+    const pipeline = await gitlabClientService.triggerMirror(testProjectSlug, 'app', false, 'main')
+    expect(pipeline.id).toBeTruthy()
   }, EXTERNAL_SYNC_TIMEOUT)
 
   describe('project members', () => {


### PR DESCRIPTION
NestJS getOrCreateRepo pinned ciConfigPath '.gitlab-ci-dso.yml' on every repo, including the mirror and infra-apps system repos. commitMirror writes '.gitlab-ci.yml' into the mirror repo, so GitLab was pointed at a CI file that is never committed and triggerMirror returned HTTP 400.

Align with legacy plugins/gitlab: only user repos mirroring an external URL (clone: true) get the custom ci_config_path; system repos resolve the default .gitlab-ci.yml. upsertProjectGroupRepo now resets ci_config_path to '' on edit so already-created mirror/infra repos self-heal on next sync.

Adds unit coverage for ci_config_path forwarding and an e2e test asserting ci_config_path parity plus a successful mirror pipeline trigger.

## Issues liées

Issues numéro: #2475

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
