### PR TITLE
fix(server-nestjs): carry the mirror repo id with the pipeline trigger token

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -538,7 +538,11 @@ export class GitlabClientService {
     }
   }
 
-  async getOrCreateMirrorPipelineTriggerToken(projectSlug: string): Promise<PipelineTriggerTokenSchema> {
+  /**
+   * The `mirror` repo id travels with the token: it is what callers persist as
+   * `GIT_MIRROR_PROJECT_ID`, and `PipelineTriggerTokenSchema` does not carry it.
+   */
+  async getOrCreateMirrorPipelineTriggerToken(projectSlug: string): Promise<PipelineTriggerTokenSchema & { repoId: number }> {
     const mirrorRepo = await this.upsertProjectMirrorRepo(projectSlug)
     this.logger.verbose(`Resolving a GitLab pipeline trigger token (projectSlug=${projectSlug}, repoId=${mirrorRepo.id})`)
     const currentTriggerToken = await find(
@@ -547,11 +551,11 @@ export class GitlabClientService {
     )
     if (currentTriggerToken) {
       this.logger.verbose(`GitLab pipeline trigger token found (projectSlug=${projectSlug}, repoId=${mirrorRepo.id})`)
-      return currentTriggerToken
+      return { ...currentTriggerToken, repoId: mirrorRepo.id }
     }
     const created = await this.client.PipelineTriggerTokens.create(mirrorRepo.id, TOKEN_DESCRIPTION)
     this.logger.log(`GitLab pipeline trigger token created (projectSlug=${projectSlug}, repoId=${mirrorRepo.id})`)
-    return created
+    return { ...created, repoId: mirrorRepo.id }
   }
 
   /**

--- a/apps/server-nestjs/src/utils/http.utils.ts
+++ b/apps/server-nestjs/src/utils/http.utils.ts
@@ -6,6 +6,23 @@ export function getErrorResponseStatus(error: unknown): number | undefined {
   return undefined
 }
 
+const urlCredentialsRegExp = /\/\/[^/:@\s]*:[^/@\s]*@/g
+
+/** Strips `//user:password@` credentials that GitLab echoes back in remote urls. */
+function maskUrlCredentials(value: string): string {
+  return value.replaceAll(urlCredentialsRegExp, '//MASKED:MASKED@')
+}
+
+/** Normalizes an error description for logging. */
+function normalizeDescription(description: unknown): unknown {
+  if (typeof description === 'string') return maskUrlCredentials(description)
+  try {
+    return JSON.parse(maskUrlCredentials(JSON.stringify(description)))
+  } catch {
+    return maskUrlCredentials(String(description))
+  }
+}
+
 /** HTTP details (status, url, response body) attached to errors carrying a fetch Response. */
 export function getErrorHttpDetails(error: Error): Record<string, unknown> {
   const details: Record<string, unknown> = {}
@@ -16,5 +33,20 @@ export function getErrorHttpDetails(error: Error): Record<string, unknown> {
   if ('responseData' in error && error.responseData !== undefined && error.responseData !== '') {
     details.responseData = error.responseData
   }
+
+  const cause: unknown = error.cause
+  if (typeof cause === 'object' && cause !== null) {
+    if ('response' in cause && cause.response instanceof Response) {
+      details.status = cause.response.status
+      details.url = maskUrlCredentials(cause.response.url)
+    }
+    if ('request' in cause && cause.request instanceof Request) {
+      details.method = cause.request.method
+    }
+    if ('description' in cause && cause.description !== undefined && cause.description !== '') {
+      details.description = normalizeDescription(cause.description)
+    }
+  }
+
   return details
 }


### PR DESCRIPTION
## Issues liées

Issues numéro: #2476

---------

## Quel est le comportement actuel ?

`getOrCreateMirrorPipelineTriggerToken` renvoie un `PipelineTriggerTokenSchema`, qui ne contient pas de `repoId`. L'interface gitbeaker étendant `Record<string, unknown>`, la lecture de `triggerToken.repoId` compile sans erreur et `GIT_MIRROR_PROJECT_ID` est écrit à `undefined` dans Vault pour tous les projets réconciliés par le serveur NestJS.

Par ailleurs, `getErrorHttpDetails` ne lit que `error.response` et `error.responseData`. gitbeaker place tout dans `error.cause` : chaque échec GitLab est journalisé en un simple `Bad Request`, sans le message renvoyé par GitLab.

## Quel est le nouveau comportement ?

L'id du dépôt `mirror` fait partie du type de retour de `getOrCreateMirrorPipelineTriggerToken` : le champ est typé et le secret Vault reçoit le bon id.

`getErrorHttpDetails` lit également `status`, `url`, `method` et `description` depuis `cause`. La description est conservée structurée (GitLab renvoie un objet, que `String()` aplatirait en `[object Object]`) et les identifiants `//user:password@` sont masqués comme le faisait `cleanGitlabError` côté legacy.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Le second correctif est ce qui a permis de diagnostiquer #2475 : sans lui, l'erreur de synchronisation ne remontait aucun message exploitable.

Les projets déjà réconciliés gardent un `GIT_MIRROR_PROJECT_ID` à `undefined` dans Vault jusqu'à leur prochaine réconciliation.
