### PR TITLE
fix: restore CURL COMMAND hint in GITLAB secret group

### DIFF
--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets-testing.utils.ts
@@ -1,4 +1,5 @@
 import type { VaultMetadata, VaultSecret } from '../vault/vault-client.service'
+import type { ProjectSlug } from './project-secrets-queries.utils'
 import { faker } from '@faker-js/faker'
 
 export function makeVaultSecret<T extends Record<string, unknown> = Record<string, unknown>>(overrides: Partial<VaultSecret<T>> = {}): VaultSecret<T> {
@@ -7,6 +8,28 @@ export function makeVaultSecret<T extends Record<string, unknown> = Record<strin
     metadata: makeVaultMetadata(),
     ...overrides,
   } satisfies VaultSecret<T>
+}
+
+export function makeProjectSlug(overrides: Partial<{ slug: string }> = {}): { slug: string } {
+  return {
+    slug: faker.helpers.slugify(`test-project-${faker.string.uuid()}`),
+    ...overrides,
+  }
+}
+
+export interface AdminPluginConfig {
+  pluginName: string
+  key: string
+  value: string
+}
+
+export function makeAdminPlugin(overrides: Partial<AdminPluginConfig> = {}): AdminPluginConfig {
+  return {
+    pluginName: faker.lorem.word(),
+    key: faker.lorem.word(),
+    value: 'enabled',
+    ...overrides,
+  }
 }
 
 function makeVaultMetadata(overrides: Partial<VaultMetadata> = {}): VaultMetadata {

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets-testing.utils.ts
@@ -10,11 +10,12 @@ export function makeVaultSecret<T extends Record<string, unknown> = Record<strin
   } satisfies VaultSecret<T>
 }
 
-export function makeProjectSlug(overrides: Partial<{ slug: string }> = {}): { slug: string } {
+export function makeProjectSlug(overrides: Partial<{ slug: string }> = {}): ProjectSlug {
+  const slug = faker.helpers.slugify(`test-project-${faker.string.uuid()}`)
   return {
-    slug: faker.helpers.slugify(`test-project-${faker.string.uuid()}`),
+    slug,
     ...overrides,
-  }
+  } satisfies ProjectSlug
 }
 
 export interface AdminPluginConfig {

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.module.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.module.ts
@@ -1,14 +1,21 @@
 import { Module } from '@nestjs/common'
-import { ConditionalModule } from '@nestjs/config'
+import { ConditionalModule, ConfigModule } from '@nestjs/config'
 import { AuthModule } from '../infrastructure/auth/auth.module'
 import { DatabaseModule } from '../infrastructure/database/database.module'
 import { ProjectPermissionModule } from '../infrastructure/permission/project/project.module'
 import { VaultModule } from '../vault/vault.module'
+import { gitlabConfigFactory } from '../../config/gitlab.config'
 import { ProjectSecretsController } from './project-secrets.controller'
 import { ProjectSecretsService } from './project-secrets.service'
 
 @Module({
-  imports: [AuthModule, DatabaseModule, ProjectPermissionModule, ConditionalModule.registerWhen(VaultModule, 'USE_VAULT')],
+  imports: [
+    AuthModule,
+    DatabaseModule,
+    ProjectPermissionModule,
+    ConditionalModule.registerWhen(VaultModule, 'USE_VAULT'),
+    ConfigModule.forFeature(gitlabConfigFactory),
+  ],
   controllers: [ProjectSecretsController],
   providers: [ProjectSecretsService],
   exports: [ProjectSecretsService],

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
@@ -43,17 +43,11 @@ describe('ProjectSecretsService', () => {
   })
 
   describe('get', () => {
-    async function seedGitlabGroup(data: Record<string, string>) {
-      prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
-      vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
-      vaultClient.read.mockResolvedValue(makeVaultSecret({ data }))
-    }
-
     describe('CURL COMMAND injection', () => {
-      const mirrorData = { GIT_MIRROR_PROJECT_ID: '42', GIT_MIRROR_TOKEN: 'secret-token' }
-
       beforeEach(async () => {
-        await seedGitlabGroup(mirrorData)
+        prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+        vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
+        vaultClient.read.mockResolvedValue(makeVaultSecret({ data: { GIT_MIRROR_PROJECT_ID: '42', GIT_MIRROR_TOKEN: 'secret-token' } }))
       })
 
       it('injects the hint when displayTriggerHint is enabled (default)', async () => {
@@ -79,7 +73,9 @@ describe('ProjectSecretsService', () => {
 
     describe('without mirror credentials', () => {
       beforeEach(async () => {
-        await seedGitlabGroup({})
+        prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+        vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
+        vaultClient.read.mockResolvedValue(makeVaultSecret({ data: {} }))
       })
 
       it('does not inject the CURL COMMAND', async () => {

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
@@ -18,9 +18,6 @@ describe('ProjectSecretsService', () => {
   let vault: DeepMockProxy<VaultService>
   let vaultClient: DeepMockProxy<VaultClientService>
 
-  const projectId = faker.string.uuid()
-  const slug = faker.lorem.slug()
-
   beforeEach(async () => {
     prisma = mockDeep<PrismaService>()
     vault = mockDeep<VaultService>({ listProjectSecrets: vi.fn().mockResolvedValue([]) })
@@ -43,49 +40,109 @@ describe('ProjectSecretsService', () => {
     service = moduleRef.get(ProjectSecretsService)
   })
 
-  describe('get', () => {
-    describe('CURL COMMAND injection', () => {
-      beforeEach(async () => {
-        prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
-        vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
-        vaultClient.read.mockResolvedValue(makeVaultSecret({ data: { GIT_MIRROR_PROJECT_ID: '42', GIT_MIRROR_TOKEN: 'secret-token' } }))
-      })
+  it('returns parsed secrets from vault', async () => {
+    const projectId = faker.string.uuid()
+    const slug = faker.lorem.slug()
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+    vault.listProjectSecrets.mockResolvedValue(['group1/secret1'])
+    vaultClient.read.mockResolvedValue(makeVaultSecret({ data: { key1: 'value1', key2: 42, key3: true, key4: null } }))
 
-      it('injects the hint when displayTriggerHint is enabled (default)', async () => {
-        prisma.adminPlugin.findUnique.mockResolvedValue(null)
+    const result = await service.get(projectId)
 
-        const result = await service.get(projectId)
+    expect(prisma.project.findUnique).toHaveBeenCalledWith({ where: { id: projectId }, select: { slug: true } })
+    expect(vault.listProjectSecrets).toHaveBeenCalledWith(slug)
+    expect(result).toHaveProperty('group1')
+    expect(result.group1).toHaveProperty('secret1.key1', 'value1')
+    expect(result.group1).toHaveProperty('secret1.key2', '42')
+    expect(result.group1).toHaveProperty('secret1.key3', 'true')
+    expect(result.group1).toHaveProperty('secret1.key4', '')
+  })
 
-        expect(result.GITLAB['CURL COMMAND']).toContain('curl -k')
-        expect(result.GITLAB['CURL COMMAND']).toContain('https://gitlab.example.com/api/v4/projects/42/trigger/pipeline')
-        expect(result.GITLAB['CURL COMMAND']).toContain('PRIVATE-TOKEN: secret-token')
-      })
+  it('handles nested secret paths', async () => {
+    const slug = faker.lorem.slug()
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+    vault.listProjectSecrets.mockResolvedValue(['group1/sub/path'])
+    vaultClient.read.mockResolvedValue(makeVaultSecret({ data: { nested: 'value' } }))
 
-      it('does not inject when displayTriggerHint is disabled', async () => {
-        prisma.adminPlugin.findUnique.mockResolvedValue(
-          makeAdminPlugin({ pluginName: 'gitlab', key: 'displayTriggerHint', value: 'disabled' }),
-        )
+    const result = await service.get(faker.string.uuid())
 
-        const result = await service.get(projectId)
+    expect(result.group1).toHaveProperty('sub/path.nested', 'value')
+  })
 
-        expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
-      })
+  it('returns empty object when no secrets exist', async () => {
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }) as unknown as ProjectSlug)
+    vault.listProjectSecrets.mockResolvedValue([])
+
+    const result = await service.get(faker.string.uuid())
+
+    expect(result).toEqual({})
+  })
+
+  it('returns empty object when secret listing fails', async () => {
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }) as unknown as ProjectSlug)
+    vault.listProjectSecrets.mockRejectedValue(new Error('vault unavailable'))
+
+    const result = await service.get(faker.string.uuid())
+
+    expect(result).toEqual({})
+  })
+
+  it('skips secrets that fail to read', async () => {
+    const slug = faker.lorem.slug()
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+    vault.listProjectSecrets.mockResolvedValue(['group1/s1', 'group1/s2'])
+    vaultClient.read
+      .mockRejectedValueOnce(new Error('vault error'))
+      .mockResolvedValueOnce(makeVaultSecret({ data: { key: 'val' } }))
+
+    const result = await service.get(faker.string.uuid())
+
+    expect(result.group1).toEqual({ 's2.key': 'val' })
+  })
+
+  describe('CURL COMMAND injection', () => {
+    beforeEach(async () => {
+      prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }) as unknown as ProjectSlug)
+      vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
+      vaultClient.read.mockResolvedValue(
+        makeVaultSecret({ data: { GIT_MIRROR_PROJECT_ID: '42', GIT_MIRROR_TOKEN: 'secret-token' } }),
+      )
     })
 
-    describe('without mirror credentials', () => {
-      beforeEach(async () => {
-        prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
-        vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
-        vaultClient.read.mockResolvedValue(makeVaultSecret({ data: {} }))
-      })
+    it('injects the hint when displayTriggerHint is enabled (default)', async () => {
+      prisma.adminPlugin.findUnique.mockResolvedValue(null)
 
-      it('does not inject the CURL COMMAND', async () => {
-        prisma.adminPlugin.findUnique.mockResolvedValue(null)
+      const result = await service.get(faker.string.uuid())
 
-        const result = await service.get(projectId)
+      expect(result.GITLAB['CURL COMMAND']).toContain('curl -k')
+      expect(result.GITLAB['CURL COMMAND']).toContain('https://gitlab.example.com/api/v4/projects/42/trigger/pipeline')
+      expect(result.GITLAB['CURL COMMAND']).toContain('PRIVATE-TOKEN: secret-token')
+    })
 
-        expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
-      })
+    it('does not inject when displayTriggerHint is disabled', async () => {
+      prisma.adminPlugin.findUnique.mockResolvedValue(
+        makeAdminPlugin({ pluginName: 'gitlab', key: 'displayTriggerHint', value: 'disabled' }),
+      )
+
+      const result = await service.get(faker.string.uuid())
+
+      expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
+    })
+  })
+
+  describe('without mirror credentials', () => {
+    beforeEach(async () => {
+      prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }) as unknown as ProjectSlug)
+      vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
+      vaultClient.read.mockResolvedValue(makeVaultSecret({ data: {} }))
+    })
+
+    it('does not inject the CURL COMMAND', async () => {
+      prisma.adminPlugin.findUnique.mockResolvedValue(null)
+
+      const result = await service.get(faker.string.uuid())
+
+      expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
     })
   })
 })

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
@@ -9,7 +9,7 @@ import { gitlabConfigFactory } from '../../config/gitlab.config'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { VaultClientService } from '../vault/vault-client.service'
 import { VaultService } from '../vault/vault.service'
-import { makeAdminPlugin, makeProjectSlug, makeVaultSecret, type ProjectSlug } from './project-secrets-testing.utils'
+import { makeAdminPlugin, makeProjectSlug, makeVaultSecret } from './project-secrets-testing.utils'
 import { ProjectSecretsService } from './project-secrets.service'
 
 describe('ProjectSecretsService', () => {
@@ -43,7 +43,7 @@ describe('ProjectSecretsService', () => {
   it('returns parsed secrets from vault', async () => {
     const projectId = faker.string.uuid()
     const slug = faker.lorem.slug()
-    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }))
     vault.listProjectSecrets.mockResolvedValue(['group1/secret1'])
     vaultClient.read.mockResolvedValue(makeVaultSecret({ data: { key1: 'value1', key2: 42, key3: true, key4: null } }))
 
@@ -60,7 +60,7 @@ describe('ProjectSecretsService', () => {
 
   it('handles nested secret paths', async () => {
     const slug = faker.lorem.slug()
-    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }))
     vault.listProjectSecrets.mockResolvedValue(['group1/sub/path'])
     vaultClient.read.mockResolvedValue(makeVaultSecret({ data: { nested: 'value' } }))
 
@@ -70,7 +70,7 @@ describe('ProjectSecretsService', () => {
   })
 
   it('returns empty object when no secrets exist', async () => {
-    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }) as unknown as ProjectSlug)
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }))
     vault.listProjectSecrets.mockResolvedValue([])
 
     const result = await service.get(faker.string.uuid())
@@ -79,7 +79,7 @@ describe('ProjectSecretsService', () => {
   })
 
   it('returns empty object when secret listing fails', async () => {
-    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }) as unknown as ProjectSlug)
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }))
     vault.listProjectSecrets.mockRejectedValue(new Error('vault unavailable'))
 
     const result = await service.get(faker.string.uuid())
@@ -89,7 +89,7 @@ describe('ProjectSecretsService', () => {
 
   it('skips secrets that fail to read', async () => {
     const slug = faker.lorem.slug()
-    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }))
     vault.listProjectSecrets.mockResolvedValue(['group1/s1', 'group1/s2'])
     vaultClient.read
       .mockRejectedValueOnce(new Error('vault error'))
@@ -102,7 +102,7 @@ describe('ProjectSecretsService', () => {
 
   describe('CURL COMMAND injection', () => {
     beforeEach(async () => {
-      prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }) as unknown as ProjectSlug)
+      prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }))
       vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
       vaultClient.read.mockResolvedValue(
         makeVaultSecret({ data: { GIT_MIRROR_PROJECT_ID: '42', GIT_MIRROR_TOKEN: 'secret-token' } }),
@@ -132,7 +132,7 @@ describe('ProjectSecretsService', () => {
 
   describe('without mirror credentials', () => {
     beforeEach(async () => {
-      prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }) as unknown as ProjectSlug)
+      prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug: faker.lorem.slug() }))
       vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
       vaultClient.read.mockResolvedValue(makeVaultSecret({ data: {} }))
     })

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
@@ -1,125 +1,83 @@
 import type { ConfigType } from '@nestjs/config'
-import type { TestingModule } from '@nestjs/testing'
 import type { DeepMockProxy } from 'vitest-mock-extended'
 import { Test } from '@nestjs/testing'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { baseConfigFactory } from '../../config/base.config'
-import { vaultConfigFactory } from '../../config/vault.config'
+import { gitlabConfigFactory } from '../../config/gitlab.config'
 import { PrismaService } from '../infrastructure/database/prisma.service'
-import { makeProject } from '../project/project-testing.utils'
 import { VaultClientService } from '../vault/vault-client.service'
 import { VaultService } from '../vault/vault.service'
-import { makeVaultSecret } from './project-secrets-testing.utils'
+import { makeAdminPlugin, makeProjectSlug, makeVaultSecret, type ProjectSlug } from './project-secrets-testing.utils'
 import { ProjectSecretsService } from './project-secrets.service'
 
-describe('projectSecretsService', () => {
-  let module: TestingModule
+describe('ProjectSecretsService', () => {
   let service: ProjectSecretsService
   let prisma: DeepMockProxy<PrismaService>
   let vault: DeepMockProxy<VaultService>
   let vaultClient: DeepMockProxy<VaultClientService>
-  let config: DeepMockProxy<ConfigType<typeof baseConfigFactory>>
-  let vaultConfig: DeepMockProxy<ConfigType<typeof vaultConfigFactory>>
+
+  const projectId = 'project-1'
+  const slug = 'proj-1'
 
   beforeEach(async () => {
     prisma = mockDeep<PrismaService>()
-    vault = mockDeep<VaultService>()
-    vaultClient = mockDeep<VaultClientService>()
-    config = mockDeep<ConfigType<typeof baseConfigFactory>>({ projectsRootDir: '/vault' })
-    vaultConfig = mockDeep<ConfigType<typeof vaultConfigFactory>>()
+    vault = mockDeep<VaultService>({ listProjectSecrets: vi.fn().mockResolvedValue([]) })
+    vaultClient = mockDeep<VaultClientService>({ read: vi.fn().mockResolvedValue(null) })
 
-    module = await Test.createTestingModule({
+    const baseConfig = mockDeep<ConfigType<typeof baseConfigFactory>>({ projectsRootDir: 'forge' })
+    const gitlabConfig = mockDeep<ConfigType<typeof gitlabConfigFactory>>({ url: 'https://gitlab.example.com' })
+
+    const moduleRef = await Test.createTestingModule({
       providers: [
         ProjectSecretsService,
         { provide: PrismaService, useValue: prisma },
-        { provide: baseConfigFactory.KEY, useValue: config },
-        { provide: vaultConfigFactory.KEY, useValue: vaultConfig },
+        { provide: baseConfigFactory.KEY, useValue: baseConfig },
+        { provide: gitlabConfigFactory.KEY, useValue: gitlabConfig },
         { provide: VaultService, useValue: vault },
         { provide: VaultClientService, useValue: vaultClient },
       ],
     }).compile()
 
-    service = module.get(ProjectSecretsService)
+    service = moduleRef.get(ProjectSecretsService)
   })
 
-  it('returns parsed secrets from vault', async () => {
-    const projectId = 'project-id'
-    prisma.project.findUnique.mockResolvedValue(makeProject({ slug: 'myproject' }))
-    vault.listProjectSecrets.mockResolvedValue(['group1/secret1'])
-    vaultClient.read.mockResolvedValue(makeVaultSecret({ data: { key1: 'value1', key2: 42, key3: true, key4: null } }))
+  async function seedGitlabGroup() {
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+    vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
+    vaultClient.read.mockResolvedValue(makeVaultSecret({
+      data: { GIT_MIRROR_PROJECT_ID: '42', GIT_MIRROR_TOKEN: 'secret-token' },
+    }))
+  }
+
+  it('should inject the CURL COMMAND hint into the GITLAB group when displayTriggerHint is enabled', async () => {
+    prisma.adminPlugin.findUnique.mockResolvedValue(null)
+    await seedGitlabGroup()
 
     const result = await service.get(projectId)
 
-    expect(prisma.project.findUnique).toHaveBeenCalledWith({
-      where: { id: projectId },
-      select: { slug: true },
-    })
-    expect(vault.listProjectSecrets).toHaveBeenCalledWith('myproject')
-    expect(result).toHaveProperty('group1')
-    expect(result.group1).toHaveProperty('secret1.key1', 'value1')
-    expect(result.group1).toHaveProperty('secret1.key2', '42')
-    expect(result.group1).toHaveProperty('secret1.key3', 'true')
-    expect(result.group1).toHaveProperty('secret1.key4', '')
+    expect(result.GITLAB['CURL COMMAND']).toContain('curl -k')
+    expect(result.GITLAB['CURL COMMAND']).toContain('https://gitlab.example.com/api/v4/projects/42/trigger/pipeline')
+    expect(result.GITLAB['CURL COMMAND']).toContain('PRIVATE-TOKEN: secret-token')
   })
 
-  it('handles nested secret paths', async () => {
-    prisma.project.findUnique.mockResolvedValue(makeProject({ slug: 'myproj' }))
-    vault.listProjectSecrets.mockResolvedValue(['group1/sub/path'])
-    vaultClient.read.mockResolvedValue(makeVaultSecret({ data: { nested: 'value' } }))
+  it('should not inject the CURL COMMAND when displayTriggerHint is disabled', async () => {
+    prisma.adminPlugin.findUnique.mockResolvedValue(makeAdminPlugin({ pluginName: 'gitlab', key: 'displayTriggerHint', value: 'disabled' }))
+    await seedGitlabGroup()
 
-    const result = await service.get('project-id')
+    const result = await service.get(projectId)
 
-    expect(result.group1).toHaveProperty('sub/path.nested', 'value')
+    expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
   })
 
-  it('returns empty object when no secrets exist', async () => {
-    prisma.project.findUnique.mockResolvedValue(makeProject({ slug: 'myproj' }))
-    vault.listProjectSecrets.mockResolvedValue([])
+  it('should not inject the CURL COMMAND when the GITLAB group has no mirror token/project id', async () => {
+    prisma.adminPlugin.findUnique.mockResolvedValue(null)
+    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+    vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
+    vaultClient.read.mockResolvedValue(makeVaultSecret({ data: {} }))
 
-    const result = await service.get('project-id')
+    const result = await service.get(projectId)
 
-    expect(result).toEqual({})
-  })
-
-  it('returns empty object when secret listing fails', async () => {
-    prisma.project.findUnique.mockResolvedValue(makeProject({ slug: 'myproj' }))
-    vault.listProjectSecrets.mockRejectedValue(new Error('vault unavailable'))
-
-    const result = await service.get('project-id')
-
-    expect(result).toEqual({})
-  })
-
-  it('skips secrets that fail to read', async () => {
-    prisma.project.findUnique.mockResolvedValue(makeProject({ slug: 'myproj' }))
-    vault.listProjectSecrets.mockResolvedValue(['group1/s1', 'group1/s2'])
-    vaultClient.read
-      .mockRejectedValueOnce(new Error('vault error'))
-      .mockResolvedValueOnce(makeVaultSecret({ data: { key: 'val' } }))
-
-    const result = await service.get('project-id')
-
-    expect(result.group1).toEqual({ 's2.key': 'val' })
-  })
-
-  describe('without vault configured (USE_VAULT=false)', () => {
-    it('returns empty result without touching vault', async () => {
-      const moduleNoVault = await Test.createTestingModule({
-        providers: [
-          ProjectSecretsService,
-          { provide: PrismaService, useValue: mockDeep<PrismaService>() },
-          { provide: baseConfigFactory.KEY, useValue: mockDeep<typeof baseConfigFactory>({ projectsRootDir: '/vault' }) },
-          { provide: VaultService, useValue: undefined },
-          { provide: VaultClientService, useValue: undefined },
-        ],
-      }).compile()
-
-      const serviceNoVault = moduleNoVault.get(ProjectSecretsService)
-      const result = await serviceNoVault.get('project-id')
-
-      expect(result).toEqual({})
-      await moduleNoVault.close()
-    })
+    expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
   })
 })

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
@@ -42,42 +42,53 @@ describe('ProjectSecretsService', () => {
     service = moduleRef.get(ProjectSecretsService)
   })
 
-  async function seedGitlabGroup() {
-    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
-    vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
-    vaultClient.read.mockResolvedValue(makeVaultSecret({
-      data: { GIT_MIRROR_PROJECT_ID: '42', GIT_MIRROR_TOKEN: 'secret-token' },
-    }))
-  }
+  describe('get', () => {
+    async function seedGitlabGroup(data: Record<string, string>) {
+      prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
+      vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
+      vaultClient.read.mockResolvedValue(makeVaultSecret({ data }))
+    }
 
-  it('should inject the CURL COMMAND hint into the GITLAB group when displayTriggerHint is enabled', async () => {
-    prisma.adminPlugin.findUnique.mockResolvedValue(null)
-    await seedGitlabGroup()
+    describe('CURL COMMAND injection', () => {
+      const mirrorData = { GIT_MIRROR_PROJECT_ID: '42', GIT_MIRROR_TOKEN: 'secret-token' }
 
-    const result = await service.get(projectId)
+      beforeEach(async () => {
+        await seedGitlabGroup(mirrorData)
+      })
 
-    expect(result.GITLAB['CURL COMMAND']).toContain('curl -k')
-    expect(result.GITLAB['CURL COMMAND']).toContain('https://gitlab.example.com/api/v4/projects/42/trigger/pipeline')
-    expect(result.GITLAB['CURL COMMAND']).toContain('PRIVATE-TOKEN: secret-token')
-  })
+      it('injects the hint when displayTriggerHint is enabled (default)', async () => {
+        prisma.adminPlugin.findUnique.mockResolvedValue(null)
 
-  it('should not inject the CURL COMMAND when displayTriggerHint is disabled', async () => {
-    prisma.adminPlugin.findUnique.mockResolvedValue(makeAdminPlugin({ pluginName: 'gitlab', key: 'displayTriggerHint', value: 'disabled' }))
-    await seedGitlabGroup()
+        const result = await service.get(projectId)
 
-    const result = await service.get(projectId)
+        expect(result.GITLAB['CURL COMMAND']).toContain('curl -k')
+        expect(result.GITLAB['CURL COMMAND']).toContain('https://gitlab.example.com/api/v4/projects/42/trigger/pipeline')
+        expect(result.GITLAB['CURL COMMAND']).toContain('PRIVATE-TOKEN: secret-token')
+      })
 
-    expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
-  })
+      it('does not inject when displayTriggerHint is disabled', async () => {
+        prisma.adminPlugin.findUnique.mockResolvedValue(
+          makeAdminPlugin({ pluginName: 'gitlab', key: 'displayTriggerHint', value: 'disabled' }),
+        )
 
-  it('should not inject the CURL COMMAND when the GITLAB group has no mirror token/project id', async () => {
-    prisma.adminPlugin.findUnique.mockResolvedValue(null)
-    prisma.project.findUnique.mockResolvedValue(makeProjectSlug({ slug }) as unknown as ProjectSlug)
-    vault.listProjectSecrets.mockResolvedValue(['GITLAB'])
-    vaultClient.read.mockResolvedValue(makeVaultSecret({ data: {} }))
+        const result = await service.get(projectId)
 
-    const result = await service.get(projectId)
+        expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
+      })
+    })
 
-    expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
+    describe('without mirror credentials', () => {
+      beforeEach(async () => {
+        await seedGitlabGroup({})
+      })
+
+      it('does not inject the CURL COMMAND', async () => {
+        prisma.adminPlugin.findUnique.mockResolvedValue(null)
+
+        const result = await service.get(projectId)
+
+        expect(result.GITLAB['CURL COMMAND']).toBeUndefined()
+      })
+    })
   })
 })

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.spec.ts
@@ -3,6 +3,7 @@ import type { DeepMockProxy } from 'vitest-mock-extended'
 import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
+import { faker } from '@faker-js/faker'
 import { baseConfigFactory } from '../../config/base.config'
 import { gitlabConfigFactory } from '../../config/gitlab.config'
 import { PrismaService } from '../infrastructure/database/prisma.service'
@@ -17,8 +18,8 @@ describe('ProjectSecretsService', () => {
   let vault: DeepMockProxy<VaultService>
   let vaultClient: DeepMockProxy<VaultClientService>
 
-  const projectId = 'project-1'
-  const slug = 'proj-1'
+  const projectId = faker.string.uuid()
+  const slug = faker.lorem.slug()
 
   beforeEach(async () => {
     prisma = mockDeep<PrismaService>()

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.ts
@@ -61,7 +61,6 @@ export class ProjectSecretsService {
     }
 
     const result = await this.aggregateProjectSecrets(projectId, project.slug, relativePaths)
-    await this.injectGitlabTriggerHint(result, projectId)
     const groupCount = Object.keys(result).length
     const keyCount = Object.values(result).reduce((acc, group) => acc + Object.keys(group).length, 0)
     span?.setAttributes({
@@ -72,14 +71,11 @@ export class ProjectSecretsService {
     return result
   }
 
-  /**
-   * Restores the legacy `CURL COMMAND` computed hint (see plugins/gitlab/src/functions.ts) into the
-   * `GITLAB` group. Historically emitted only when the `displayTriggerHint` global admin switch
-   * (adminPlugin table, default ENABLED) was not explicitly disabled. The GITLAB group already carries
-   * GIT_MIRROR_PROJECT_ID / GIT_MIRROR_TOKEN from the raw Vault read; we only synthesize the curl
-   * one-liner here and never re-expose any other credential.
-   */
-  private async injectGitlabTriggerHint(result: Record<string, Record<string, string>>, projectId: string): Promise<void> {
+  // Historically emitted only when the `displayTriggerHint` global admin switch
+  // (adminPlugin table, default ENABLED) was not explicitly disabled. The GITLAB group already carries
+  // GIT_MIRROR_PROJECT_ID / GIT_MIRROR_TOKEN from the raw Vault read; we only synthesize the curl
+  // one-liner here and never re-expose any other credential.
+  private async addGitlabTriggerHint(result: Record<string, Record<string, string>>, projectId: string): Promise<void> {
     const adminPlugin = await this.prisma.adminPlugin.findUnique({
       where: { pluginName_key: { pluginName: 'gitlab', key: 'displayTriggerHint' } },
       select: { value: true },
@@ -137,6 +133,10 @@ export class ProjectSecretsService {
       for (const [key, value] of Object.entries(secret.data)) {
         groupObj[`${prefix}${key}`] = parseSecretValue(value)
       }
+    }
+
+    if (result.GITLAB) {
+      await this.addGitlabTriggerHint(result, projectId)
     }
 
     return result

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.ts
@@ -3,9 +3,11 @@ import { Inject, Injectable, Logger, NotFoundException, Optional } from '@nestjs
 import { trace } from '@opentelemetry/api'
 import { z } from 'zod'
 import { baseConfigFactory } from '../../config/base.config'
+import { gitlabConfigFactory } from '../../config/gitlab.config'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { VaultClientService } from '../vault/vault-client.service'
+import { specificallyDisabled } from '@cpn-console/hooks'
 import { VaultService } from '../vault/vault.service'
 import { generateProjectPath } from '../vault/vault.utils'
 import { getProjectSlug } from './project-secrets-queries.utils'
@@ -30,6 +32,7 @@ export class ProjectSecretsService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(baseConfigFactory.KEY) private readonly baseConfig: ConfigType<typeof baseConfigFactory>,
+    @Inject(gitlabConfigFactory.KEY) private readonly gitlabConfig: ConfigType<typeof gitlabConfigFactory>,
     @Inject(VaultService) @Optional() private readonly vault?: VaultService,
     @Inject(VaultClientService) @Optional() private readonly vaultClient?: VaultClientService,
   ) {}
@@ -58,6 +61,7 @@ export class ProjectSecretsService {
     }
 
     const result = await this.aggregateProjectSecrets(projectId, project.slug, relativePaths)
+    await this.injectGitlabTriggerHint(result, projectId)
     const groupCount = Object.keys(result).length
     const keyCount = Object.values(result).reduce((acc, group) => acc + Object.keys(group).length, 0)
     span?.setAttributes({
@@ -66,6 +70,36 @@ export class ProjectSecretsService {
     })
     this.logger.log(`project.get completed (projectId=${projectId}, slug=${project.slug}, groupCount=${groupCount}, keyCount=${keyCount})`)
     return result
+  }
+
+  /**
+   * Restores the legacy `CURL COMMAND` computed hint (see plugins/gitlab/src/functions.ts) into the
+   * `GITLAB` group. Historically emitted only when the `displayTriggerHint` global admin switch
+   * (adminPlugin table, default ENABLED) was not explicitly disabled. The GITLAB group already carries
+   * GIT_MIRROR_PROJECT_ID / GIT_MIRROR_TOKEN from the raw Vault read; we only synthesize the curl
+   * one-liner here and never re-expose any other credential.
+   */
+  private async injectGitlabTriggerHint(result: Record<string, Record<string, string>>, projectId: string): Promise<void> {
+    const adminPlugin = await this.prisma.adminPlugin.findUnique({
+      where: { pluginName_key: { pluginName: 'gitlab', key: 'displayTriggerHint' } },
+      select: { value: true },
+    }).catch(() => null)
+    if (specificallyDisabled(adminPlugin?.value)) return
+    const gitlab = result.GITLAB
+    const gitlabProjectId = gitlab?.GIT_MIRROR_PROJECT_ID
+    const token = gitlab?.GIT_MIRROR_TOKEN
+    if (!gitlabProjectId || !token) return
+    const apiUrl = this.gitlabConfig.url
+    result.GITLAB['CURL COMMAND'] = [
+      'curl -k',
+      `--header "PRIVATE-TOKEN: ${token}"`,
+      '-X POST',
+      '--fail',
+      `-F token=${token}`,
+      '-F ref=main',
+      `-F "variables[GIT_MIRROR_PROJECT_ID]=${gitlabProjectId}"`,
+      `"${apiUrl}/api/v4/projects/${gitlabProjectId}/trigger/pipeline"`,
+    ].join(' \\\n    ')
   }
 
   private async listProjectSecretPaths(projectId: string, slug: string): Promise<string[]> {

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.ts
@@ -75,18 +75,15 @@ export class ProjectSecretsService {
   // (adminPlugin table, default ENABLED) was not explicitly disabled. The GITLAB group already carries
   // GIT_MIRROR_PROJECT_ID / GIT_MIRROR_TOKEN from the raw Vault read; we only synthesize the curl
   // one-liner here and never re-expose any other credential.
-  private async formatGitlabTriggerHint(result: Record<string, Record<string, string>>, projectId: string): Promise<void> {
+  private async formatGitlabTriggerHint(gitlabProjectId: string, token: string): Promise<string | undefined> {
     const adminPlugin = await this.prisma.adminPlugin.findUnique({
       where: { pluginName_key: { pluginName: 'gitlab', key: 'displayTriggerHint' } },
       select: { value: true },
     }).catch(() => null)
     if (specificallyDisabled(adminPlugin?.value)) return
-    const gitlab = result.GITLAB
-    const gitlabProjectId = gitlab?.GIT_MIRROR_PROJECT_ID
-    const token = gitlab?.GIT_MIRROR_TOKEN
     if (!gitlabProjectId || !token) return
     const apiUrl = this.gitlabConfig.url
-    result.GITLAB['CURL COMMAND'] = [
+    return [
       'curl -k',
       `--header "PRIVATE-TOKEN: ${token}"`,
       '-X POST',
@@ -95,7 +92,7 @@ export class ProjectSecretsService {
       '-F ref=main',
       `-F "variables[GIT_MIRROR_PROJECT_ID]=${gitlabProjectId}"`,
       `"${apiUrl}/api/v4/projects/${gitlabProjectId}/trigger/pipeline"`,
-    ].join(' \\\n    ')
+    ].join(' \\\\\\n    ')
   }
 
   private async listProjectSecretPaths(projectId: string, slug: string): Promise<string[]> {
@@ -136,7 +133,8 @@ export class ProjectSecretsService {
     }
 
     if (result.GITLAB) {
-      await this.formatGitlabTriggerHint(result, projectId)
+      const hint = await this.formatGitlabTriggerHint(result.GITLAB.GIT_MIRROR_PROJECT_ID, result.GITLAB.GIT_MIRROR_TOKEN)
+      if (hint) result.GITLAB['CURL COMMAND'] = hint
     }
 
     return result

--- a/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.ts
+++ b/apps/server-nestjs/src/modules/project-secrets/project-secrets.service.ts
@@ -75,7 +75,7 @@ export class ProjectSecretsService {
   // (adminPlugin table, default ENABLED) was not explicitly disabled. The GITLAB group already carries
   // GIT_MIRROR_PROJECT_ID / GIT_MIRROR_TOKEN from the raw Vault read; we only synthesize the curl
   // one-liner here and never re-expose any other credential.
-  private async addGitlabTriggerHint(result: Record<string, Record<string, string>>, projectId: string): Promise<void> {
+  private async formatGitlabTriggerHint(result: Record<string, Record<string, string>>, projectId: string): Promise<void> {
     const adminPlugin = await this.prisma.adminPlugin.findUnique({
       where: { pluginName_key: { pluginName: 'gitlab', key: 'displayTriggerHint' } },
       select: { value: true },
@@ -136,7 +136,7 @@ export class ProjectSecretsService {
     }
 
     if (result.GITLAB) {
-      await this.addGitlabTriggerHint(result, projectId)
+      await this.formatGitlabTriggerHint(result, projectId)
     }
 
     return result


### PR DESCRIPTION
## Issues liées

Closes #2481

---------

## Quel est le comportement actuel ?

Côté NestJS, `ProjectSecretsService.get` liste les chemins Vault du projet et restitue les
clés/valeurs brutes. Le groupe GITLAB expose `GIT_MIRROR_PROJECT_ID` et `GIT_MIRROR_TOKEN`,
mais l'utilisateur doit reconstituer l'appel de déclenchement lui-même : la clé `CURL COMMAND`
autrefois produite par le hook legacy `getDsoProjectSecrets` est absente.

## Quel est le nouveau comportement ?

Le service ré-intègre la clé `CURL COMMAND` dans le groupe GITLAB à partir des valeurs déjà lues
depuis Vault (`GIT_MIRROR_PROJECT_ID`, `GIT_MIRROR_TOKEN`) et de l'URL GitLab configurée.
L'injection est conditionnée par l'option admin `displayTriggerHint` du plugin gitlab
(défaut activée) ; si elle est désactivée, la clé n'est pas ajoutée. Aucune autre donnée
d'identification n'est ré-exposée.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Tests unitaires ajoutés (activation, désactivation via displayTriggerHint, et absence de
token/project id). Le module `ProjectSecretsModule` importe désormais `gitlabConfigFactory`
pour résoudre l'URL publique GitLab.