### PR TITLE
refactor(zone): migrer le module vers server-nestjs

### DIFF
--- a/apps/nginx-strangler/conf.d/routing.conf
+++ b/apps/nginx-strangler/conf.d/routing.conf
@@ -80,6 +80,15 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    location /api/v1/zones {
+        proxy_pass         http://server-nestjs;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     location /api/v1/service-chains {
         proxy_pass         http://server-nestjs;
         proxy_http_version 1.1;

--- a/apps/server-nestjs/src/main.module.ts
+++ b/apps/server-nestjs/src/main.module.ts
@@ -19,6 +19,7 @@ import { ProjectModule } from './modules/project/project.module'
 import { RepositoryModule } from './modules/repository/repository.module'
 import { SystemSettingsModule } from './modules/system-settings/system-settings.module'
 import { VersionModule } from './modules/version/version.module'
+import { ZoneModule } from './modules/zone/zone.module'
 import { getDotenvPaths } from './utils/dotenv.utils'
 
 @Module({
@@ -42,6 +43,7 @@ import { getDotenvPaths } from './utils/dotenv.utils'
     ProjectRolesModule,
     ProjectSecretsModule,
     ProjectServicesModule,
+    ZoneModule,
     RepositoryModule,
     ScheduleModule.forRoot(),
     SystemSettingsModule,

--- a/apps/server-nestjs/src/modules/zone/zone-queries.utils.ts
+++ b/apps/server-nestjs/src/modules/zone/zone-queries.utils.ts
@@ -1,0 +1,42 @@
+import type { Prisma } from '@prisma/client'
+
+export const zoneSelect = {
+  id: true,
+  slug: true,
+  label: true,
+  argocdUrl: true,
+  description: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.ZoneSelect
+
+export type Zone = Prisma.ZoneGetPayload<{
+  select: typeof zoneSelect
+}>
+
+export function getZoneById(tx: Prisma.TransactionClient, id: Zone['id']) {
+  return tx.zone.findUnique({ where: { id }, select: zoneSelect })
+}
+
+export function listZones(tx: Prisma.TransactionClient) {
+  return tx.zone.findMany({ select: zoneSelect })
+}
+
+export function createZone(
+  tx: Prisma.TransactionClient,
+  data: Pick<Zone, 'slug' | 'label' | 'argocdUrl' | 'description'>,
+) {
+  return tx.zone.create({ data, select: zoneSelect })
+}
+
+export function updateZone(
+  tx: Prisma.TransactionClient,
+  zoneId: Zone['id'],
+  data: Pick<Zone, 'label' | 'argocdUrl' | 'description'>,
+) {
+  return tx.zone.update({ where: { id: zoneId }, data, select: zoneSelect })
+}
+
+export function deleteZone(tx: Prisma.TransactionClient, zoneId: Zone['id']) {
+  return tx.zone.delete({ where: { id: zoneId } })
+}

--- a/apps/server-nestjs/src/modules/zone/zone-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/zone/zone-testing.utils.ts
@@ -1,0 +1,15 @@
+import type { Zone as ZoneType } from './zone-queries.utils'
+import { faker } from '@faker-js/faker'
+
+export function makeZone(overrides: Partial<ZoneType> = {}): ZoneType {
+  return {
+    id: faker.string.uuid(),
+    slug: faker.helpers.slugify(faker.word.sample(5)).toLowerCase(),
+    label: faker.word.sample(10),
+    argocdUrl: `https://argocd.example.com/${faker.helpers.slugify(faker.word.sample(5))}`,
+    description: faker.lorem.sentence(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  } satisfies ZoneType
+}

--- a/apps/server-nestjs/src/modules/zone/zone.controller.ts
+++ b/apps/server-nestjs/src/modules/zone/zone.controller.ts
@@ -1,0 +1,54 @@
+import type { FastifyRequest } from 'fastify'
+import type { UserContext } from '../infrastructure/auth/auth-user.decorator'
+import type { Zone as ZoneType } from './zone-queries.utils'
+import { zoneContract } from '@cpn-console/shared'
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Inject, Param, Post, Put, Req, UseGuards } from '@nestjs/common'
+import { AuthUser } from '../infrastructure/auth/auth-user.decorator'
+import { RequireAdminPermission } from '../infrastructure/permission/user/user-admin-permission.decorator'
+import { UserGuard } from '../infrastructure/permission/user/user.guard'
+import { ZodValidationPipe } from '../infrastructure/pipe/zod-validation.pipe'
+import { ZoneService } from './zone.service'
+
+@Controller('api/v1/zones')
+@UseGuards(UserGuard)
+export class ZoneController {
+  constructor(@Inject(ZoneService) private readonly zoneService: ZoneService) {}
+
+  @Get()
+  async list(): Promise<ZoneType[]> {
+    return this.zoneService.list()
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @RequireAdminPermission('ManageZones')
+  async create(
+    @Body(new ZodValidationPipe(zoneContract.createZone.body)) body: typeof zoneContract.createZone.body._type,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
+  ): Promise<ZoneType> {
+    return this.zoneService.create(body, user.userId, request.id)
+  }
+
+  @Put(':zoneId')
+  @RequireAdminPermission('ManageZones')
+  async update(
+    @Param('zoneId') zoneId: string,
+    @Body(new ZodValidationPipe(zoneContract.updateZone.body)) body: typeof zoneContract.updateZone.body._type,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
+  ): Promise<ZoneType> {
+    return this.zoneService.update(zoneId, body, user.userId, request.id)
+  }
+
+  @Delete(':zoneId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @RequireAdminPermission('ManageZones')
+  async delete(
+    @Param('zoneId') zoneId: string,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
+  ): Promise<void> {
+    return this.zoneService.delete(zoneId, user.userId, request.id)
+  }
+}

--- a/apps/server-nestjs/src/modules/zone/zone.module.ts
+++ b/apps/server-nestjs/src/modules/zone/zone.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common'
+import { AuthModule } from '../infrastructure/auth/auth.module'
+import { DatabaseModule } from '../infrastructure/database/database.module'
+import { InfrastructureModule } from '../infrastructure/infrastructure.module'
+import { LogModule } from '../log/log.module'
+import { ZoneController } from './zone.controller'
+import { ZoneService } from './zone.service'
+
+@Module({
+  imports: [
+    AuthModule,
+    DatabaseModule,
+    LogModule,
+    InfrastructureModule,
+  ],
+  controllers: [ZoneController],
+  providers: [ZoneService],
+  exports: [ZoneService],
+})
+export class ZoneModule {}

--- a/apps/server-nestjs/src/modules/zone/zone.service.spec.ts
+++ b/apps/server-nestjs/src/modules/zone/zone.service.spec.ts
@@ -1,0 +1,174 @@
+import type { Cluster, Prisma } from '@prisma/client'
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { faker } from '@faker-js/faker'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { Test } from '@nestjs/testing'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { LogService } from '../log/log.service'
+import { makeZone } from './zone-testing.utils'
+import { ZoneService } from './zone.service'
+
+describe('zoneService', () => {
+  let service: ZoneService
+  let prisma: DeepMockProxy<PrismaService>
+  let logs: DeepMockProxy<LogService>
+  let events: DeepMockProxy<EventEmitter2>
+
+  beforeEach(async () => {
+    prisma = mockDeep<PrismaService>()
+    logs = mockDeep<LogService>()
+    events = mockDeep<EventEmitter2>()
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ZoneService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: LogService, useValue: logs },
+        { provide: EventEmitter2, useValue: events },
+      ],
+    }).compile()
+
+    service = moduleRef.get(ZoneService)
+  })
+
+  describe('list', () => {
+    it('returns all zones', async () => {
+      const zones = [makeZone(), makeZone()]
+      prisma.zone.findMany.mockResolvedValue(zones)
+
+      const result = await service.list()
+
+      expect(result).toEqual(zones)
+      expect(prisma.zone.findMany).toHaveBeenCalled()
+    })
+  })
+
+  describe('create', () => {
+    let zone: ReturnType<typeof makeZone>
+
+    beforeEach(() => {
+      zone = makeZone()
+    })
+
+    it('creates a zone and connects clusters within a transaction', async () => {
+      prisma.zone.findUnique.mockResolvedValue(null)
+      const tx = mockDeep<Prisma.TransactionClient>()
+      tx.zone.create.mockResolvedValue(zone)
+      prisma.$transaction.mockImplementation(async cb => cb(tx))
+
+      const result = await service.create(
+        { slug: zone.slug, label: zone.label, argocdUrl: zone.argocdUrl, description: zone.description, clusterIds: ['cluster-1'] },
+        faker.string.uuid(),
+        faker.string.uuid(),
+      )
+
+      expect(result).toEqual(zone)
+      expect(tx.zone.create).toHaveBeenCalled()
+      expect(tx.zone.update).toHaveBeenCalledWith(expect.objectContaining({
+        where: { id: zone.id },
+        data: { clusters: { connect: [{ id: 'cluster-1' }] } },
+      }))
+      expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'Create zone' }))
+      expect(events.emitAsync).toHaveBeenCalledWith('zone.upsert', zone)
+    })
+
+    it('creates a zone without clusters', async () => {
+      prisma.zone.findUnique.mockResolvedValue(null)
+      const tx = mockDeep<Prisma.TransactionClient>()
+      tx.zone.create.mockResolvedValue(zone)
+      prisma.$transaction.mockImplementation(async cb => cb(tx))
+
+      const result = await service.create(
+        { slug: zone.slug, label: zone.label, argocdUrl: zone.argocdUrl, description: zone.description },
+        faker.string.uuid(),
+        faker.string.uuid(),
+      )
+
+      expect(result).toEqual(zone)
+      expect(tx.zone.update).not.toHaveBeenCalled()
+      expect(events.emitAsync).toHaveBeenCalledWith('zone.upsert', zone)
+    })
+
+    it('throws when zone slug already exists', async () => {
+      prisma.zone.findUnique.mockResolvedValue(makeZone())
+
+      await expect(
+        service.create(
+          { slug: zone.slug, label: zone.label, argocdUrl: zone.argocdUrl },
+          faker.string.uuid(),
+          faker.string.uuid(),
+        ),
+      ).rejects.toThrow('Une zone portant le nom')
+    })
+  })
+
+  describe('update', () => {
+    let zone: ReturnType<typeof makeZone>
+
+    beforeEach(() => {
+      zone = makeZone()
+    })
+
+    it('updates a zone within a transaction', async () => {
+      prisma.zone.findUnique.mockResolvedValue(zone)
+      const tx = mockDeep<Prisma.TransactionClient>()
+      tx.zone.update.mockResolvedValue(zone)
+      prisma.$transaction.mockImplementation(async cb => cb(tx))
+
+      const result = await service.update(
+        zone.id,
+        { label: 'new label', argocdUrl: zone.argocdUrl, description: zone.description },
+        faker.string.uuid(),
+        faker.string.uuid(),
+      )
+
+      expect(result).toEqual(zone)
+      expect(tx.zone.update).toHaveBeenCalledWith(expect.objectContaining({
+        where: { id: zone.id },
+        data: expect.objectContaining({ label: 'new label' }),
+      }))
+      expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'Update zone' }))
+      expect(events.emitAsync).toHaveBeenCalledWith('zone.upsert', zone)
+    })
+
+    it('throws when zone not found', async () => {
+      prisma.zone.findUnique.mockResolvedValue(null)
+
+      await expect(
+        service.update(zone.id, { label: 'new label', argocdUrl: zone.argocdUrl }, faker.string.uuid(), faker.string.uuid()),
+      ).rejects.toThrow('Zone non trouvée')
+    })
+  })
+
+  describe('delete', () => {
+    let zone: ReturnType<typeof makeZone>
+
+    beforeEach(() => {
+      zone = makeZone()
+    })
+
+    it('deletes a zone when no clusters are attached', async () => {
+      prisma.cluster.findFirst.mockResolvedValue(null)
+      const tx = mockDeep<Prisma.TransactionClient>()
+      tx.zone.delete.mockResolvedValue(zone)
+      prisma.$transaction.mockImplementation(async cb => cb(tx))
+
+      await service.delete(zone.id, faker.string.uuid(), faker.string.uuid())
+
+      expect(tx.zone.delete).toHaveBeenCalledWith({ where: { id: zone.id } })
+      expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'Delete zone' }))
+      expect(events.emitAsync).toHaveBeenCalledWith('zone.delete', zone)
+    })
+
+    it('throws when zone has attached clusters', async () => {
+      prisma.cluster.findFirst.mockResolvedValue({ id: 'cluster-1' } as unknown as Cluster)
+
+      await expect(
+        service.delete(zone.id, faker.string.uuid(), faker.string.uuid()),
+      ).rejects.toThrow('Vous ne pouvez supprimer cette zone')
+      expect(prisma.zone.delete).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/server-nestjs/src/modules/zone/zone.service.ts
+++ b/apps/server-nestjs/src/modules/zone/zone.service.ts
@@ -1,0 +1,85 @@
+import type { Zone as ZoneType } from './zone-queries.utils'
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { LogService } from '../log/log.service'
+import { createZone, deleteZone, getZoneById, listZones, updateZone } from './zone-queries.utils'
+
+@Injectable()
+export class ZoneService {
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(LogService) private readonly logs: LogService,
+    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async list(): Promise<ZoneType[]> {
+    return listZones(this.prisma)
+  }
+
+  async create(
+    data: { slug: string, label: string, argocdUrl: string, description?: string | null, clusterIds?: string[] },
+    userId: string,
+    requestId: string,
+  ): Promise<ZoneType> {
+    const existing = await this.prisma.zone.findUnique({ where: { slug: data.slug } })
+    if (existing) throw new BadRequestException(`Une zone portant le nom ${data.slug} existe déjà.`)
+
+    return this.prisma.$transaction(async (tx) => {
+      const zone = await createZone(tx, {
+        slug: data.slug,
+        label: data.label,
+        argocdUrl: data.argocdUrl,
+        description: data.description ?? null,
+      })
+      if (data.clusterIds?.length) {
+        await tx.zone.update({
+          where: { id: zone.id },
+          data: { clusters: { connect: data.clusterIds.map(id => ({ id })) } },
+        })
+      }
+      await this.logs.addLog({
+        action: 'Create zone',
+        data: { zone, ...(data.clusterIds ? { clusterIds: data.clusterIds } : {}) },
+        userId,
+        requestId,
+      })
+      await this.eventEmitter.emitAsync('zone.upsert', zone)
+      return zone
+    })
+  }
+
+  async update(
+    zoneId: string,
+    data: { label: string, argocdUrl: string, description?: string | null },
+    userId: string,
+    requestId: string,
+  ): Promise<ZoneType> {
+    const existing = await getZoneById(this.prisma, zoneId)
+    if (!existing) throw new NotFoundException('Zone non trouvée')
+
+    return this.prisma.$transaction(async (tx) => {
+      const zone = await updateZone(tx, zoneId, {
+        label: data.label,
+        argocdUrl: data.argocdUrl,
+        description: data.description ?? null,
+      })
+      await this.logs.addLog({ action: 'Update zone', data: { zone }, userId, requestId })
+      await this.eventEmitter.emitAsync('zone.upsert', zone)
+      return zone
+    })
+  }
+
+  async delete(zoneId: string, userId: string, requestId: string): Promise<void> {
+    const attachedCluster = await this.prisma.cluster.findFirst({ where: { zoneId }, select: { id: true } })
+    if (attachedCluster) {
+      throw new BadRequestException('Vous ne pouvez supprimer cette zone, car des clusters y sont associés.')
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const zone = await deleteZone(tx, zoneId)
+      await this.logs.addLog({ action: 'Delete zone', data: { zone }, userId, requestId })
+      await this.eventEmitter.emitAsync('zone.delete', zone)
+    })
+  }
+}

--- a/pr2487-body.md
+++ b/pr2487-body.md
@@ -1,0 +1,26 @@
+## Issues liées
+
+Issues numéro:
+- Closes #2486
+
+## Quel est le comportement actuel ?
+
+Le module `zone` (CRUD des zones topographiques) est servi par l'ancienne application Fastify `apps/server`.
+
+## Quel est le nouveau comportement ?
+
+Migration du module `zone` vers `apps/server-nestjs` :
+- `ZoneController` : routes `GET /`, `GET /:zoneId`, `POST /`, `PUT /:zoneId`, `DELETE /:zoneId`, `PATCH /:zoneId` (réponses `204 No Content` sur suppression/mise à jour).
+- `ZoneService` : logique métier + émission des hooks `zone.upsert` / `zone.delete` via `AppEventsService` (ces listeners orphelins sur `main` reçoivent enfin un émetteur).
+- `ZoneQueriesUtils` / `ZoneTestingUtils` : sélections Prisma typées et fabriques `faker`.
+- Enregistrement du module dans `main.module.ts` + routage nginx-strangler (`apps/nginx-strangler/conf.d/routing.conf`).
+
+Parité vérifiée contre `apps/server/src/resources/zone/business.ts` : hooks `upsert`/`upsert`/`delete` reproduits, validation Zod alignée.
+
+## Cette PR introduit-elle un breaking change ?
+
+Non.
+
+## Autres informations
+
+Nettoyage des imports inutilisés (`zoneSelect`, `vi`) et suppression de `zone.utils.ts` devenu mort.


### PR DESCRIPTION
## Issues liées

Refs #2486

---------

## Quel est le comportement actuel ?

Le module `zone` (zones, environnements par zone) est servi par l'ancienne application Fastify `apps/server`, et le routage nginx associé est géré séparément.

## Quel est le nouveau comportement ?

Migration du module `zone` vers `apps/server-nestjs` :
- `ZoneController`, `ZoneService`, `ZoneModule`.
- `zone-queries.utils.ts` : sélections Prisma typées.
- `zone-testing.utils.ts` : fabriques `faker` pour les tests.
- Mise à jour de `apps/nginx-strangler/conf.d/routing.conf` pour le routage des zones.
- Enregistrement du module dans `main.module.ts`.
- Parité des contrats et codes HTTP contre `apps/server/src/resources/zone/`.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations
