### PR TITLE
refactor(cluster): migrate module from server

### DIFF
--- a/apps/nginx-strangler/conf.d/routing.conf
+++ b/apps/nginx-strangler/conf.d/routing.conf
@@ -61,6 +61,15 @@ server {
     }
 
     # ── Routes migrées vers NestJS ────────────────────────────────────────────────
+    location /api/v1/clusters {
+        proxy_pass         http://server-nestjs;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     location /api/v1/projects-bulk {
         proxy_pass         http://server-nestjs;
         proxy_http_version 1.1;

--- a/apps/server-nestjs/src/main.module.ts
+++ b/apps/server-nestjs/src/main.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config'
 import { ScheduleModule } from '@nestjs/schedule'
 import { TerminusModule } from '@nestjs/terminus'
 import { baseConfigFactory } from './config/base.config'
+import { ClusterModule } from './modules/cluster/cluster.module'
 import { DeploymentModule } from './modules/deployment/deployment.module'
 import { EnvironmentModule } from './modules/environment/environment.module'
 import { HealthzModule } from './modules/healthz/healthz.module'
@@ -29,6 +30,7 @@ import { getDotenvPaths } from './utils/dotenv.utils'
       load: [baseConfigFactory],
     }),
     TerminusModule.forRoot(),
+    ClusterModule,
     DeploymentModule,
     EnvironmentModule,
     HealthzModule,

--- a/apps/server-nestjs/src/modules/cluster/cluster-queries.utils.ts
+++ b/apps/server-nestjs/src/modules/cluster/cluster-queries.utils.ts
@@ -1,0 +1,286 @@
+import type { Cluster, Environment, Kubeconfig, Prisma, Project, Stage, Zone } from '@prisma/client'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+
+// ── selects ───────────────────────────────────────────────────────────────────────────
+export const clusterListSelect = {
+  id: true,
+  label: true,
+  privacy: true,
+  secretName: true,
+  clusterResources: true,
+  kubeConfigId: true,
+  infos: true,
+  zoneId: true,
+  cpu: true,
+  gpu: true,
+  memory: true,
+  createdAt: true,
+  updatedAt: true,
+  stages: true,
+} satisfies Prisma.ClusterSelect
+export type ClusterListRecord = Prisma.ClusterGetPayload<{ select: typeof clusterListSelect }>
+
+export const clusterDetailsSelect = {
+  id: true,
+  label: true,
+  privacy: true,
+  secretName: true,
+  clusterResources: true,
+  kubeConfigId: true,
+  infos: true,
+  zoneId: true,
+  cpu: true,
+  gpu: true,
+  memory: true,
+  createdAt: true,
+  updatedAt: true,
+  projects: { select: { id: true } },
+  kubeconfig: true,
+  stages: true,
+} satisfies Prisma.ClusterSelect
+export type ClusterDetailsRecord = Prisma.ClusterGetPayload<{ select: typeof clusterDetailsSelect }>
+
+export const clusterEnvironmentsSelect = {
+  id: true,
+  name: true,
+  cpu: true,
+  gpu: true,
+  memory: true,
+  projectId: true,
+  autosync: true,
+  clusterId: true,
+  stageId: true,
+  createdAt: true,
+  updatedAt: true,
+  project: {
+    select: {
+      slug: true,
+      name: true,
+      owner: true,
+      members: true,
+    },
+  },
+} satisfies Prisma.EnvironmentSelect
+export type ClusterEnvironmentsRecord = Prisma.EnvironmentGetPayload<{ select: typeof clusterEnvironmentsSelect }>
+
+// ── query: getClusterById ───────────────────────────────────────────────────────────
+export function getClusterById(prisma: PrismaService, id: Cluster['id']) {
+  return prisma.cluster.findUnique({
+    where: { id },
+    include: { kubeconfig: true },
+  })
+}
+
+// ── query: getClusterByIdOrThrow ────────────────────────────────────────────────────
+export function getClusterByIdOrThrow(prisma: PrismaService, id: Cluster['id']) {
+  return prisma.cluster.findUniqueOrThrow({
+    where: { id },
+    include: { kubeconfig: true, zone: true },
+  })
+}
+
+// ── query: getClusterEnvironments ────────────────────────────────────────────────────
+export function getClusterEnvironments(prisma: PrismaService, clusterId: Cluster['id']) {
+  return prisma.environment.findMany({
+    where: { clusterId },
+    select: clusterEnvironmentsSelect,
+  })
+}
+
+// ── query: getClusterDetails ─────────────────────────────────────────────────────────
+export function getClusterDetails(prisma: PrismaService, id: Cluster['id']) {
+  return prisma.cluster.findUniqueOrThrow({
+    where: { id },
+    select: clusterDetailsSelect,
+  })
+}
+
+// ── query: getClustersByIds ──────────────────────────────────────────────────────────
+export function getClustersByIds(prisma: PrismaService, clusterIds: Cluster['id'][]) {
+  return prisma.cluster.findMany({
+    where: { id: { in: clusterIds } },
+    include: { kubeconfig: true },
+  })
+}
+
+// ── query: getPublicClusters ─────────────────────────────────────────────────────────
+export function getPublicClusters(prisma: PrismaService) {
+  return prisma.cluster.findMany({
+    where: { privacy: 'public' },
+    include: { zone: true },
+  })
+}
+
+// ── query: getClusterNamesByZoneId ────────────────────────────────────────────────────
+export async function getClusterNamesByZoneId(prisma: PrismaService, zoneId: string) {
+  const clusterNames = await prisma.cluster.findMany({
+    where: { zoneId },
+    select: { label: true },
+  })
+  return clusterNames.map(({ label }) => label)
+}
+
+// ── query: getClusterByLabel ──────────────────────────────────────────────────────────
+export function getClusterByLabel(prisma: PrismaService, label: Cluster['label']) {
+  return prisma.cluster.findUnique({ where: { label } })
+}
+
+// ── query: getClusterByEnvironmentId ──────────────────────────────────────────────────
+export function getClusterByEnvironmentId(prisma: PrismaService, id: Environment['id']) {
+  return prisma.cluster.findMany({
+    where: { environments: { some: { id } } },
+    include: { kubeconfig: true },
+  })
+}
+
+// ── query: getClustersWithProjectIdAndConfig ──────────────────────────────────────────
+export function getClustersWithProjectIdAndConfig(prisma: PrismaService) {
+  return prisma.cluster.findMany({
+    select: {
+      id: true,
+      stages: true,
+      projects: {
+        where: { status: { not: 'archived' } },
+        select: { id: true, name: true, slug: true, status: true },
+      },
+      clusterResources: true,
+      label: true,
+      infos: true,
+      privacy: true,
+      secretName: true,
+      kubeconfig: true,
+      zoneId: true,
+      cpu: true,
+      gpu: true,
+      memory: true,
+    },
+  })
+}
+
+// ── query: listClusters ──────────────────────────────────────────────────────────────
+export function listClusters(prisma: PrismaService, where: Prisma.ClusterWhereInput) {
+  return prisma.cluster.findMany({
+    where,
+    select: clusterListSelect,
+  })
+}
+
+// ── query: getProjectsByClusterId ─────────────────────────────────────────────────────
+export async function getProjectsByClusterId(prisma: PrismaService, id: Cluster['id']) {
+  return (await prisma.cluster.findUniqueOrThrow({
+    where: { id },
+    select: { projects: true },
+  }))?.projects
+}
+
+// ── query: listStagesByClusterId ──────────────────────────────────────────────────────
+export async function listStagesByClusterId(prisma: PrismaService, id: Cluster['id']) {
+  return (await prisma.cluster.findUniqueOrThrow({
+    where: { id },
+    select: { stages: true },
+  }))?.stages
+}
+
+// ── query: createCluster ─────────────────────────────────────────────────────────────
+export function createCluster(
+  prisma: PrismaService,
+  data: Omit<Cluster, 'id' | 'updatedAt' | 'createdAt' | 'kubeConfigId' | 'secretName' | 'zoneId'>,
+  kubeconfig: Pick<Kubeconfig, 'user' | 'cluster'>,
+  zoneId: string,
+) {
+  return prisma.cluster.create({
+    data: {
+      ...data,
+      // @ts-ignore
+      kubeconfig: { create: kubeconfig },
+      zone: { connect: { id: zoneId } },
+    },
+  })
+}
+
+// ── query: updateCluster ─────────────────────────────────────────────────────────────
+export function updateCluster(
+  prisma: PrismaService,
+  id: Cluster['id'],
+  data: Partial<Omit<Cluster, 'id' | 'updatedAt' | 'createdAt' | 'kubeConfigId'>>,
+  kubeconfig: Pick<Kubeconfig, 'user' | 'cluster'>,
+) {
+  return prisma.cluster.update({
+    where: { id },
+    data: {
+      ...data,
+      kubeconfig: {
+        // @ts-ignore
+        update: kubeconfig,
+      },
+    },
+  })
+}
+
+// ── query: linkClusterToProjects ──────────────────────────────────────────────────────
+export function linkClusterToProjects(prisma: PrismaService, id: Cluster['id'], projectIds: Project['id'][]) {
+  return prisma.cluster.update({
+    where: { id },
+    data: {
+      projects: { connect: projectIds.map(projectId => ({ id: projectId })) },
+    },
+  })
+}
+
+// ── query: linkClusterToStages ────────────────────────────────────────────────────────
+export function linkClusterToStages(prisma: PrismaService, id: Cluster['id'], stageIds: Stage['id'][]) {
+  return prisma.cluster.update({
+    where: { id },
+    data: {
+      stages: { connect: stageIds.map(stageId => ({ id: stageId })) },
+    },
+  })
+}
+
+// ── query: removeClusterFromProject ───────────────────────────────────────────────────
+export function removeClusterFromProject(prisma: PrismaService, id: Cluster['id'], projectId: Project['id']) {
+  return prisma.cluster.update({
+    where: { id },
+    data: {
+      projects: { disconnect: { id: projectId } },
+    },
+  })
+}
+
+// ── query: removeClusterFromStage ─────────────────────────────────────────────────────
+export function removeClusterFromStage(prisma: PrismaService, id: Cluster['id'], stageId: Stage['id']) {
+  return prisma.cluster.update({
+    where: { id },
+    data: {
+      stages: { disconnect: { id: stageId } },
+    },
+  })
+}
+
+// ── query: deleteCluster ─────────────────────────────────────────────────────────────
+export function deleteCluster(prisma: PrismaService, id: Cluster['id']) {
+  return prisma.cluster.delete({ where: { id } })
+}
+
+// ── query: linkZoneToClusters ────────────────────────────────────────────────────────
+export function linkZoneToClusters(prisma: PrismaService, zoneId: Zone['id'], clusterIds: Cluster['id'][]) {
+  return prisma.zone.update({
+    where: { id: zoneId },
+    data: {
+      clusters: { connect: clusterIds.map(clusterId => ({ id: clusterId })) },
+    },
+  })
+}
+
+// ── query: getClusterUsage ───────────────────────────────────────────────────────────
+export async function getClusterUsage(prisma: PrismaService, clusterId: Cluster['id']) {
+  const clusterUsage = await prisma.environment.aggregate({
+    _sum: { memory: true, cpu: true, gpu: true },
+    where: { clusterId },
+  })
+  return {
+    cpu: clusterUsage._sum.cpu ?? 0,
+    gpu: clusterUsage._sum.gpu ?? 0,
+    memory: clusterUsage._sum.memory ?? 0,
+  }
+}

--- a/apps/server-nestjs/src/modules/cluster/cluster-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/cluster/cluster-testing.utils.ts
@@ -1,0 +1,129 @@
+import type { Cluster, Environment, Kubeconfig, ProjectMembers, Stage, User } from '@prisma/client'
+import { faker } from '@faker-js/faker'
+import type { ClusterDetailsRecord, ClusterEnvironmentsRecord, ClusterListRecord } from './cluster-queries.utils'
+
+export function makeCluster(overrides: Partial<Cluster> = {}): Cluster {
+  return {
+    id: faker.string.uuid(),
+    label: faker.helpers.slugify(faker.word.sample(5)).toLowerCase(),
+    privacy: faker.helpers.arrayElement(['public', 'dedicated'] as const),
+    secretName: faker.string.uuid(),
+    clusterResources: faker.datatype.boolean(),
+    kubeConfigId: faker.string.uuid(),
+    infos: faker.lorem.sentence(),
+    cpu: faker.number.int({ min: 0, max: 64 }),
+    gpu: faker.number.int({ min: 0, max: 8 }),
+    memory: faker.number.int({ min: 0, max: 512 }),
+    zoneId: faker.string.uuid(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  } satisfies Cluster
+}
+
+export function makeStage(overrides: Partial<Stage> = {}): Stage {
+  return {
+    id: faker.string.uuid(),
+    name: faker.helpers.slugify(faker.word.sample(3)).toLowerCase(),
+    ...overrides,
+  } satisfies Stage
+}
+
+export function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: faker.string.uuid(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    email: faker.internet.email(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    lastLogin: faker.date.past(),
+    adminRoleIds: [],
+    type: 'human',
+    ...overrides,
+  } satisfies User
+}
+
+export function makeProjectMember(overrides: Partial<ProjectMembers> = {}): ProjectMembers {
+  return {
+    projectId: faker.string.uuid(),
+    userId: faker.string.uuid(),
+    roleIds: [],
+    ...overrides,
+  } satisfies ProjectMembers
+}
+
+export function makeClusterListRecord(overrides: Partial<ClusterListRecord> = {}): ClusterListRecord {
+  return {
+    ...makeCluster(),
+    stages: [makeStage()],
+    ...overrides,
+  } satisfies ClusterListRecord
+}
+
+export function makeClusterDetailsRecord(overrides: Partial<ClusterDetailsRecord> = {}): ClusterDetailsRecord {
+  return {
+    ...makeCluster(),
+    projects: [{ id: faker.string.uuid() }],
+    stages: [makeStage()],
+    kubeconfig: makeKubeconfig(),
+    ...overrides,
+  } satisfies ClusterDetailsRecord
+}
+
+export function makeClusterEnvironmentsRecord(overrides: Partial<ClusterEnvironmentsRecord> = {}): ClusterEnvironmentsRecord {
+  return {
+    id: faker.string.uuid(),
+    name: faker.helpers.slugify(faker.word.sample(3)).toLowerCase().slice(0, 11),
+    cpu: faker.number.int({ min: 0, max: 16 }),
+    gpu: faker.number.int({ min: 0, max: 4 }),
+    memory: faker.number.int({ min: 0, max: 64 }),
+    projectId: faker.string.uuid(),
+    autosync: true,
+    clusterId: faker.string.uuid(),
+    stageId: faker.string.uuid(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    project: {
+      slug: faker.helpers.slugify(faker.word.sample(3)).toLowerCase(),
+      name: faker.company.name(),
+      owner: makeUser(),
+      members: [makeProjectMember()],
+    },
+    ...overrides,
+  } satisfies ClusterEnvironmentsRecord
+}
+
+export function makeKubeconfig(overrides: Partial<Kubeconfig> = {}): Kubeconfig {
+  return {
+    id: faker.string.uuid(),
+    user: {
+      username: faker.internet.userName(),
+      token: faker.string.alphanumeric(20),
+    },
+    cluster: {
+      server: faker.internet.url(),
+      tlsServerName: faker.internet.domainName(),
+    },
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  } satisfies Kubeconfig
+}
+
+export function makeEnvironment(overrides: Partial<Environment> = {}): Environment {
+  return {
+    id: faker.string.uuid(),
+    name: faker.helpers.slugify(faker.word.sample(3)).toLowerCase().slice(0, 11),
+    projectId: faker.string.uuid(),
+    memory: faker.number.int({ min: 0, max: 64 }),
+    cpu: faker.number.int({ min: 0, max: 16 }),
+    gpu: faker.number.int({ min: 0, max: 4 }),
+    autosync: faker.datatype.boolean(),
+    clusterId: faker.string.uuid(),
+    stageId: faker.string.uuid(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  } satisfies Environment
+}

--- a/apps/server-nestjs/src/modules/cluster/cluster.controller.ts
+++ b/apps/server-nestjs/src/modules/cluster/cluster.controller.ts
@@ -1,0 +1,74 @@
+import type { ClientInferResponseBody } from '@ts-rest/core'
+import type { FastifyRequest } from 'fastify'
+import type { UserContext } from '../infrastructure/auth/auth-user.decorator'
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Inject, Param, Post, Put, Req } from '@nestjs/common'
+import { AuthUser } from '../infrastructure/auth/auth-user.decorator'
+import { ZodValidationPipe } from '../infrastructure/pipe/zod-validation.pipe'
+import { clusterContract } from '@cpn-console/shared'
+import { ClusterService } from './cluster.service'
+
+type ClusterList = ClientInferResponseBody<typeof clusterContract.listClusters, 200>
+type ClusterDetails = ClientInferResponseBody<typeof clusterContract.getClusterDetails, 200>
+type ClusterUsage = ClientInferResponseBody<typeof clusterContract.getClusterUsage, 200>
+type CreateClusterBody = typeof clusterContract.createCluster.body._type
+type UpdateClusterBody = typeof clusterContract.updateCluster.body._type
+
+@Controller('api/v1/clusters')
+export class ClusterController {
+  constructor(@Inject(ClusterService) private readonly clusterService: ClusterService) {}
+
+  @Get('')
+  list(): Promise<ClusterList> {
+    return this.clusterService.listClusters()
+  }
+
+  @Get(':clusterId')
+  getDetails(@Param('clusterId') clusterId: string): Promise<ClusterDetails> {
+    return this.clusterService.getClusterDetails(clusterId)
+  }
+
+  @Get(':clusterId/usage')
+  getUsage(@Param('clusterId') clusterId: string): Promise<ClusterUsage> {
+    return this.clusterService.getClusterUsage(clusterId)
+  }
+
+  @Get(':clusterId/environments')
+  getEnvironments(@Param('clusterId') clusterId: string): Promise<unknown[]> {
+    return this.clusterService.getClusterAssociatedEnvironments(clusterId)
+  }
+
+  @Post('')
+  @HttpCode(HttpStatus.CREATED)
+  create(
+    @Body(new ZodValidationPipe(clusterContract.createCluster.body)) data: CreateClusterBody,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
+  ): Promise<ClusterDetails> {
+    return this.clusterService.createCluster(data, user.userId, request.id)
+  }
+
+  @Put(':clusterId')
+  @HttpCode(HttpStatus.OK)
+  update(
+    @Param('clusterId') clusterId: string,
+    @Body(new ZodValidationPipe(clusterContract.updateCluster.body)) data: UpdateClusterBody,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
+  ): Promise<ClusterDetails> {
+    return this.clusterService.updateCluster(data, clusterId, user.userId, request.id)
+  }
+
+  @Delete(':clusterId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  delete(
+    @Param('clusterId') clusterId: string,
+    @AuthUser() user: UserContext,
+    @Req() request: FastifyRequest,
+  ): Promise<string | null> {
+    return this.clusterService.deleteCluster({
+      clusterId,
+      userId: user.userId,
+      requestId: request.id,
+    })
+  }
+}

--- a/apps/server-nestjs/src/modules/cluster/cluster.module.ts
+++ b/apps/server-nestjs/src/modules/cluster/cluster.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { DatabaseModule } from '../infrastructure/database/database.module'
+import { ClusterController } from './cluster.controller'
+import { ClusterService } from './cluster.service'
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [ClusterController],
+  providers: [ClusterService],
+  exports: [ClusterService],
+})
+export class ClusterModule {}

--- a/apps/server-nestjs/src/modules/cluster/cluster.service.spec.ts
+++ b/apps/server-nestjs/src/modules/cluster/cluster.service.spec.ts
@@ -1,0 +1,234 @@
+import type { ConfigType } from '@nestjs/config'
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { Test } from '@nestjs/testing'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { faker } from '@faker-js/faker'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { baseConfigFactory } from '../../config/base.config'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { LogService } from '../log/log.service'
+import {
+  makeCluster,
+  makeClusterDetailsRecord,
+  makeClusterEnvironmentsRecord,
+  makeClusterListRecord,
+  makeEnvironment,
+} from './cluster-testing.utils'
+import { ClusterService } from './cluster.service'
+
+describe('ClusterService', () => {
+  let service: ClusterService
+  let prisma: DeepMockProxy<PrismaService>
+  let logs: DeepMockProxy<LogService>
+  let events: DeepMockProxy<EventEmitter2>
+  let baseConfig: DeepMockProxy<ConfigType<typeof baseConfigFactory>>
+
+  beforeEach(async () => {
+    prisma = mockDeep<PrismaService>()
+    logs = mockDeep<LogService>()
+    events = mockDeep<EventEmitter2>()
+    baseConfig = mockDeep<ConfigType<typeof baseConfigFactory>>()
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ClusterService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: LogService, useValue: logs },
+        { provide: EventEmitter2, useValue: events },
+        { provide: baseConfigFactory.KEY, useValue: baseConfig },
+      ],
+    }).compile()
+
+    service = moduleRef.get(ClusterService)
+  })
+
+  it('lists clusters with stageIds and normalized infos', async () => {
+    const record = makeClusterListRecord({ infos: null })
+    prisma.cluster.findMany.mockResolvedValue([record])
+
+    const result = await service.listClusters()
+
+    expect(result).toEqual([{
+      id: record.id,
+      label: record.label,
+      infos: '',
+      clusterResources: record.clusterResources,
+      privacy: record.privacy,
+      zoneId: record.zoneId,
+      cpu: record.cpu,
+      gpu: record.gpu,
+      memory: record.memory,
+      stageIds: [record.stages[0].id],
+    }])
+  })
+
+  it('passes the authorized user filter when listing clusters', async () => {
+    prisma.cluster.findMany.mockResolvedValue([])
+
+    const userId = faker.string.uuid()
+    await service.listClusters(userId)
+
+    expect(prisma.cluster.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { OR: expect.any(Array) },
+    }))
+  })
+
+  it('maps cluster details to the contract shape', async () => {
+    const record = makeClusterDetailsRecord({ infos: null })
+    prisma.cluster.findUniqueOrThrow.mockResolvedValue(record)
+
+    const result = await service.getClusterDetails(record.id)
+
+    expect(result).toEqual(expect.objectContaining({
+      id: record.id,
+      infos: '',
+      projectIds: [record.projects[0].id],
+      stageIds: [record.stages[0].id],
+      kubeconfig: { cluster: record.kubeconfig.cluster, user: record.kubeconfig.user },
+    }))
+  })
+
+  it('returns cluster usage from the aggregate', async () => {
+    const usage = { cpu: 1, gpu: 0, memory: 8 }
+    prisma.environment.aggregate.mockResolvedValue({
+      _sum: { cpu: 1, gpu: 0, memory: 8 },
+      _count: { _all: 1 },
+      _avg: { cpu: null, gpu: null, memory: null },
+      _min: { cpu: null, gpu: null, memory: null },
+      _max: { cpu: null, gpu: null, memory: null },
+    })
+
+    const result = await service.getClusterUsage(faker.string.uuid())
+
+    expect(result).toEqual(usage)
+  })
+
+  it('creates a cluster, links projects and stages, and emits the hook', async () => {
+    const record = makeClusterListRecord()
+    const cluster = makeCluster()
+    const details = makeClusterDetailsRecord()
+    prisma.cluster.findUnique.mockResolvedValue(null)
+    prisma.cluster.create.mockResolvedValue(cluster)
+    prisma.cluster.findUniqueOrThrow.mockResolvedValue(details)
+
+    const result = await service.createCluster(
+      {
+        label: record.label,
+        infos: record.infos ?? '',
+        clusterResources: record.clusterResources,
+        privacy: record.privacy,
+        zoneId: record.zoneId,
+        cpu: record.cpu,
+        gpu: record.gpu,
+        memory: record.memory,
+        projectIds: ['project-1'],
+        stageIds: ['stage-1'],
+        kubeconfig: { cluster: { tlsServerName: 'example.com' }, user: {} },
+      },
+      faker.string.uuid(),
+      faker.string.uuid(),
+    )
+
+    expect(result.id).toEqual(details.id)
+    expect(prisma.cluster.create).toHaveBeenCalled()
+    expect(prisma.cluster.update).toHaveBeenCalled()
+    expect(events.emitAsync).toHaveBeenCalledWith('cluster.upsert', expect.objectContaining({ clusterId: cluster.id }))
+    expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'Create Cluster' }))
+  })
+
+  it('rejects cluster creation when the label is already taken', async () => {
+    prisma.cluster.findUnique.mockResolvedValue(makeCluster())
+
+    await expect(
+      service.createCluster(
+        {
+          label: 'taken',
+          infos: '',
+          clusterResources: true,
+          privacy: 'public',
+          zoneId: faker.string.uuid(),
+          cpu: 1,
+          gpu: 0,
+          memory: 1,
+          stageIds: [],
+          kubeconfig: { cluster: { tlsServerName: 'example.com' }, user: {} },
+        },
+        faker.string.uuid(),
+        faker.string.uuid(),
+      ),
+    ).rejects.toThrow('Ce label existe déjà')
+  })
+
+  it('updates cluster fields and emits the hook', async () => {
+    const record = makeClusterDetailsRecord()
+    prisma.cluster.findUnique.mockResolvedValue(record)
+    prisma.cluster.update.mockResolvedValue(record)
+    prisma.cluster.findUniqueOrThrow.mockResolvedValue(record)
+
+    const result = await service.updateCluster(
+      { label: 'new-label' },
+      record.id,
+      faker.string.uuid(),
+      faker.string.uuid(),
+    )
+
+    expect(result.id).toEqual(record.id)
+    expect(prisma.cluster.update).toHaveBeenCalled()
+    expect(events.emitAsync).toHaveBeenCalledWith('cluster.upsert', expect.objectContaining({ clusterId: record.id }))
+    expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'Update Cluster' }))
+  })
+
+  it('rejects updating a missing cluster', async () => {
+    prisma.cluster.findUnique.mockResolvedValue(null)
+
+    await expect(
+      service.updateCluster({ label: 'new' }, faker.string.uuid(), faker.string.uuid(), faker.string.uuid()),
+    ).rejects.toThrow('Cluster not found')
+  })
+
+  it('deletes a cluster when no environments are deployed', async () => {
+    const record = makeClusterListRecord()
+    prisma.environment.findFirst.mockResolvedValue(null)
+    prisma.cluster.delete.mockResolvedValue(record)
+
+    const message = await service.deleteCluster({
+      clusterId: record.id,
+      userId: faker.string.uuid(),
+      requestId: faker.string.uuid(),
+    })
+
+    expect(message).toBeNull()
+    expect(prisma.cluster.delete).toHaveBeenCalledWith({ where: { id: record.id } })
+    expect(events.emitAsync).toHaveBeenCalledWith('cluster.delete', expect.objectContaining({ clusterId: record.id }))
+    expect(logs.addLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'Delete Cluster' }))
+  })
+
+  it('rejects cluster deletion when environments are deployed', async () => {
+    prisma.environment.findFirst.mockResolvedValue(makeEnvironment())
+
+    await expect(
+      service.deleteCluster({
+        clusterId: faker.string.uuid(),
+        userId: faker.string.uuid(),
+        requestId: faker.string.uuid(),
+      }),
+    ).rejects.toThrow('Impossible de supprimer le cluster')
+  })
+
+  it('maps cluster environments for the contract response', async () => {
+    const envs = [makeClusterEnvironmentsRecord(), makeClusterEnvironmentsRecord()]
+    prisma.environment.findMany.mockResolvedValue(envs)
+
+    const result = await service.getClusterAssociatedEnvironments(faker.string.uuid())
+
+    expect(result).toEqual(envs.map(env => ({
+      project: env.project.name,
+      name: env.name,
+      owner: env.project.owner.email,
+      cpu: env.cpu,
+      gpu: env.gpu,
+      memory: env.memory,
+    })))
+  })
+})

--- a/apps/server-nestjs/src/modules/cluster/cluster.service.ts
+++ b/apps/server-nestjs/src/modules/cluster/cluster.service.ts
@@ -1,0 +1,249 @@
+import {
+  CleanedCluster,
+  ClusterAssociatedEnvironments,
+  ClusterDetails,
+  ClusterPrivacySchema,
+  CreateClusterBody,
+  KubeconfigSchema,
+  UpdateClusterBody,
+} from '@cpn-console/shared'
+import type { Prisma, Project, User } from '@prisma/client'
+import type { ClientInferResponseBody } from '@ts-rest/core'
+import type { ConfigType } from '@nestjs/config'
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { baseConfigFactory } from '../../config/base.config'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { LogService } from '../log/log.service'
+import {
+  createCluster as createClusterQuery,
+  deleteCluster as deleteClusterQuery,
+  getClusterById,
+  getClusterByLabel,
+  getClusterDetails as getClusterDetailsQuery,
+  getClusterEnvironments,
+  getClusterUsage,
+  getProjectsByClusterId,
+  linkClusterToProjects,
+  linkClusterToStages,
+  linkZoneToClusters,
+  listClusters as listClustersQuery,
+  listStagesByClusterId,
+  removeClusterFromProject,
+  removeClusterFromStage,
+  updateCluster as updateClusterQuery,
+} from './cluster-queries.utils'
+import { clusterContract } from '@cpn-console/shared'
+
+type ClusterUsage = ClientInferResponseBody<typeof clusterContract.getClusterUsage, 200>
+
+const CLUSTER_PUBLIC = ClusterPrivacySchema.enum.public
+const CLUSTER_DEDICATED = ClusterPrivacySchema.enum.dedicated
+
+@Injectable()
+export class ClusterService {
+  private readonly logger = new Logger(ClusterService.name)
+
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
+    @Inject(LogService) private readonly logs: LogService,
+    @Inject(baseConfigFactory.KEY) private readonly baseConfig: ConfigType<typeof baseConfigFactory>,
+  ) {}
+
+  async listClusters(userId?: User['id']): Promise<CleanedCluster[]> {
+    const where: Prisma.ClusterWhereInput = userId
+      ? {
+          OR: [
+            { privacy: CLUSTER_PUBLIC },
+            { projects: { some: { members: { some: { userId } } } } },
+            { projects: { some: { ownerId: userId } } },
+            { environments: { some: { project: { members: { some: { userId } } } } } },
+          ],
+        }
+      : {}
+    const clusters = await listClustersQuery(this.prisma, where)
+    return clusters.map(({ stages, infos, secretName, kubeConfigId, createdAt, updatedAt, ...cluster }) => ({
+      ...cluster,
+      infos: infos ?? '',
+      stageIds: stages.map(({ id }) => id),
+    }))
+  }
+
+  async getClusterDetails(clusterId: string): Promise<ClusterDetails> {
+    const { infos, projects, stages, kubeconfig, secretName, kubeConfigId, createdAt, updatedAt, ...details } = await getClusterDetailsQuery(this.prisma, clusterId)
+    return {
+      ...details,
+      infos: infos ?? '',
+      projectIds: projects.map(project => project.id),
+      stageIds: stages.map(({ id }) => id),
+      kubeconfig: {
+        cluster: KubeconfigSchema.shape.cluster.parse(kubeconfig.cluster),
+        user: KubeconfigSchema.shape.user.parse(kubeconfig.user),
+      },
+    }
+  }
+
+  async getClusterUsage(clusterId: string): Promise<ClusterUsage> {
+    return getClusterUsage(this.prisma, clusterId)
+  }
+
+  async getClusterAssociatedEnvironments(clusterId: string): Promise<ClusterAssociatedEnvironments> {
+    const clusterEnvironments = await getClusterEnvironments(this.prisma, clusterId)
+    return clusterEnvironments.map((environment) => ({
+      project: environment.project?.name,
+      name: environment.name,
+      owner: environment.project?.owner.email,
+      cpu: environment.cpu,
+      gpu: environment.gpu,
+      memory: environment.memory,
+    }))
+  }
+
+  async createCluster(
+    data: CreateClusterBody,
+    userId: User['id'],
+    requestId: string,
+  ): Promise<ClusterDetails> {
+    const isLabelTaken = await getClusterByLabel(this.prisma, data.label)
+    if (isLabelTaken) throw new Error('Ce label existe déjà pour un autre cluster')
+
+    const { projectIds, stageIds, kubeconfig, zoneId, ...clusterData } = data
+
+    const clusterCreated = await createClusterQuery(this.prisma, clusterData, kubeconfig, zoneId)
+
+    if (data.privacy === CLUSTER_PUBLIC) {
+      // no project linking for public clusters
+    } else if (projectIds?.length) {
+      await linkClusterToProjects(this.prisma, clusterCreated.id, projectIds)
+    }
+
+    if (stageIds?.length) {
+      await linkClusterToStages(this.prisma, clusterCreated.id, stageIds)
+    }
+
+    await this.upsertClusterHook(clusterCreated.id)
+    await this.logs.addLog({
+      action: 'Create Cluster',
+      data: { clusterId: clusterCreated.id, zoneId },
+      userId,
+      requestId,
+    })
+
+    return this.getClusterDetails(clusterCreated.id)
+  }
+
+  async updateCluster(
+    data: UpdateClusterBody,
+    clusterId: string,
+    userId: User['id'],
+    requestId: string,
+  ): Promise<ClusterDetails> {
+    if (data?.privacy === CLUSTER_PUBLIC) delete data.projectIds
+
+    const dbCluster = await getClusterById(this.prisma, clusterId)
+    if (!dbCluster) throw new Error('Cluster not found')
+
+    const { projectIds, stageIds, kubeconfig, zoneId, ...clusterData } = data
+
+    const clusterUpdated = await updateClusterQuery(this.prisma, clusterId, clusterData,
+      // @ts-ignore
+      kubeconfig)
+
+    if (zoneId) {
+      await linkZoneToClusters(this.prisma, zoneId, [clusterId])
+    }
+
+    const dbProjects = await getProjectsByClusterId(this.prisma, clusterId)
+
+    let projectsToRemove: Project['id'][] = []
+
+    if (projectIds && clusterUpdated.privacy === CLUSTER_PUBLIC) {
+      projectsToRemove = dbProjects?.map(project => project.id) ?? []
+    } else if (projectIds && clusterUpdated.privacy === CLUSTER_DEDICATED) {
+      await linkClusterToProjects(this.prisma, clusterId, projectIds)
+      projectsToRemove = dbProjects?.map(project => project.id)?.filter(dbProjectId => !projectIds.includes(dbProjectId)) ?? []
+    } else if (clusterUpdated.privacy === CLUSTER_PUBLIC) {
+      projectsToRemove = dbProjects?.map(project => project.id) ?? []
+    }
+
+    for (const projectId of projectsToRemove) {
+      await removeClusterFromProject(this.prisma, clusterUpdated.id, projectId)
+    }
+
+    if (stageIds) {
+      await linkClusterToStages(this.prisma, clusterId, stageIds)
+
+      const dbStages = await listStagesByClusterId(this.prisma, clusterId)
+      if (dbStages) {
+        for (const stage of dbStages) {
+          if (!stageIds.includes(stage.id)) {
+            await removeClusterFromStage(this.prisma, clusterUpdated.id, stage.id)
+          }
+        }
+      }
+    }
+
+    await this.upsertClusterHook(clusterId)
+    await this.logs.addLog({
+      action: 'Update Cluster',
+      data: { clusterId },
+      userId,
+      requestId,
+    })
+
+    return this.getClusterDetails(clusterId)
+  }
+
+  async deleteCluster({
+    clusterId,
+    userId,
+    requestId,
+    force,
+  }: {
+    clusterId: string
+    userId?: string
+    requestId: string
+    force?: boolean
+  }): Promise<string | null> {
+    let message: string | null = null
+    if (force) {
+      const envs = await this.prisma.environment.deleteMany({
+        where: { clusterId },
+      })
+      message = `${envs.count} environnements supprimés de force, n'oubliez pas de reprovisionner les projets concernés`
+    } else {
+      const environment = await this.prisma.environment.findFirst({ where: { clusterId } })
+      if (environment) throw new Error('Impossible de supprimer le cluster, des environnements en activité y sont déployés')
+    }
+
+    await this.deleteClusterHook(clusterId)
+    await this.logs.addLog({
+      action: 'Delete Cluster',
+      data: { clusterId },
+      userId,
+      requestId,
+    })
+
+    await deleteClusterQuery(this.prisma, clusterId)
+    return message
+  }
+
+  // ── Cluster hook helpers ────────────────────────────────────────────────────────
+
+  private async upsertClusterHook(clusterId: string): Promise<void> {
+    try {
+      await this.eventEmitter.emitAsync('cluster.upsert', { clusterId })
+    } catch (error) {
+      this.logger.error(`cluster.upsert hook failed (clusterId=${clusterId})`, error instanceof Error ? error.stack : String(error))
+    }
+  }
+
+  private async deleteClusterHook(clusterId: string): Promise<void> {
+    try {
+      await this.eventEmitter.emitAsync('cluster.delete', { clusterId })
+    } catch (error) {
+      this.logger.error(`cluster.delete hook failed (clusterId=${clusterId})`, error instanceof Error ? error.stack : String(error))
+    }
+  }
+}


### PR DESCRIPTION
## Issues liées

Refs #2492

---------

## Quel est le comportement actuel ?

Le module `cluster` (clusters, usage, environnements) est servi par l'ancienne application Fastify `apps/server`.

## Quel est le nouveau comportement ?

Migration du module `cluster` vers `apps/server-nestjs` :
- `ClusterController` : routes `GET /`, `GET /:clusterId`, `GET /:clusterId/usage`, `GET /:clusterId/environments`, `POST /`, `PUT /:clusterId`, `DELETE /:clusterId`.
- `ClusterService` : CRUD + calcul d'usage et liste des environnements rattachés.
- `ClusterModule` : enregistrement dans `main.module.ts`.
- Parité des contrats et codes HTTP contre `apps/server/src/resources/cluster/`.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations
