### PR TITLE
refactor(stage): migrate module from server

### DIFF
--- a/apps/server-nestjs/src/main.module.ts
+++ b/apps/server-nestjs/src/main.module.ts
@@ -17,6 +17,7 @@ import { ProjectSecretsModule } from './modules/project-secrets/project-secrets.
 import { ProjectServicesModule } from './modules/project-services/project-services.module'
 import { ProjectModule } from './modules/project/project.module'
 import { RepositoryModule } from './modules/repository/repository.module'
+import { StageModule } from './modules/stage/stage.module'
 import { SystemSettingsModule } from './modules/system-settings/system-settings.module'
 import { VersionModule } from './modules/version/version.module'
 import { getDotenvPaths } from './utils/dotenv.utils'
@@ -44,6 +45,7 @@ import { getDotenvPaths } from './utils/dotenv.utils'
     ProjectServicesModule,
     RepositoryModule,
     ScheduleModule.forRoot(),
+    StageModule,
     SystemSettingsModule,
     VersionModule,
   ],

--- a/apps/server-nestjs/src/modules/stage/stage-queries.utils.ts
+++ b/apps/server-nestjs/src/modules/stage/stage-queries.utils.ts
@@ -1,0 +1,138 @@
+import type { Cluster, Prisma, Stage } from '@prisma/client'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+
+// ── selects ───────────────────────────────────────────────────────────────────────────
+export const stageSelect = {
+  id: true,
+  name: true,
+} satisfies Prisma.StageSelect
+export type StageRecord = Prisma.StageGetPayload<{ select: typeof stageSelect }>
+
+export const stageWithClustersSelect = {
+  id: true,
+  name: true,
+  clusters: { select: { id: true } },
+} satisfies Prisma.StageSelect
+export type StageWithClustersRecord = Prisma.StageGetPayload<{ select: typeof stageWithClustersSelect }>
+
+export const stageEnvironmentsSelect = {
+  id: true,
+  name: true,
+  projectId: true,
+  memory: true,
+  cpu: true,
+  gpu: true,
+  autosync: true,
+  clusterId: true,
+  stageId: true,
+  createdAt: true,
+  updatedAt: true,
+  cluster: { select: { label: true } },
+  project: {
+    select: {
+      name: true,
+      owner: true,
+      slug: true,
+    },
+  },
+} satisfies Prisma.EnvironmentSelect
+export type StageEnvironmentsRecord = Prisma.EnvironmentGetPayload<{ select: typeof stageEnvironmentsSelect }>
+
+// ── queries ───────────────────────────────────────────────────────────────────────────
+export function listStages(prisma: PrismaService) {
+  return prisma.stage.findMany({
+    select: stageWithClustersSelect,
+  })
+}
+
+export function getAllStageIds(prisma: PrismaService) {
+  return prisma.stage.findMany({
+    select: { id: true },
+  })
+}
+
+export function getStageById(prisma: PrismaService, id: Stage['id']) {
+  return prisma.stage.findUnique({
+    where: { id },
+    select: stageWithClustersSelect,
+  })
+}
+
+export function getStageByName(prisma: PrismaService, name: Stage['name']) {
+  return prisma.stage.findUnique({ where: { name } })
+}
+
+export function getStageAssociatedEnvironments(prisma: PrismaService, id: Stage['id']) {
+  return prisma.environment.findMany({
+    where: { stageId: id },
+    select: stageEnvironmentsSelect,
+  })
+}
+
+export function getStageAssociatedEnvironmentCount(prisma: PrismaService, id: Stage['id']) {
+  return prisma.environment.count({
+    where: { stageId: id },
+  })
+}
+
+export function createStage(prisma: PrismaService, { name }: { name: Stage['name'] }) {
+  return prisma.stage.create({
+    data: { name },
+    select: stageSelect,
+  })
+}
+
+export function updateStageName(prisma: PrismaService, id: Stage['id'], name: Stage['name']) {
+  return prisma.stage.update({
+    where: { id },
+    data: { name },
+  })
+}
+
+export function linkStageToClusters(prisma: PrismaService, id: Stage['id'], clusterIds: Cluster['id'][]) {
+  return prisma.stage.update({
+    where: { id },
+    data: {
+      clusters: {
+        connect: clusterIds.map(clusterId => ({ id: clusterId })),
+      },
+    },
+  })
+}
+
+export function disconnectClusterFromStage(prisma: PrismaService, clusterId: Cluster['id'], stageId: Stage['id']) {
+  return prisma.stage.update({
+    where: { id: stageId },
+    data: {
+      clusters: {
+        disconnect: { id: clusterId },
+      },
+    },
+  })
+}
+
+export function deleteStage(prisma: PrismaService, id: Stage['id']) {
+  return prisma.stage.delete({ where: { id } })
+}
+
+export function linkClusterToStages(prisma: PrismaService, clusterId: Cluster['id'], stageIds: Stage['id'][]) {
+  return prisma.cluster.update({
+    where: { id: clusterId },
+    data: {
+      stages: {
+        connect: stageIds.map(stageId => ({ id: stageId })),
+      },
+    },
+  })
+}
+
+export function removeClusterFromStage(prisma: PrismaService, clusterId: Cluster['id'], stageId: Stage['id']) {
+  return prisma.cluster.update({
+    where: { id: clusterId },
+    data: {
+      stages: {
+        disconnect: { id: stageId },
+      },
+    },
+  })
+}

--- a/apps/server-nestjs/src/modules/stage/stage-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/stage/stage-testing.utils.ts
@@ -1,0 +1,80 @@
+import type { Cluster, Environment } from '@prisma/client'
+import type { StageEnvironmentsRecord, StageRecord, StageWithClustersRecord } from './stage-queries.utils'
+import { faker } from '@faker-js/faker'
+
+export function makeStageRecord(overrides: Partial<StageRecord> = {}): StageRecord {
+  return {
+    id: faker.string.uuid(),
+    name: faker.helpers.slugify(faker.word.sample(3)).toLowerCase().slice(0, 20),
+    ...overrides,
+  } satisfies StageRecord
+}
+
+export function makeStageWithClusters(overrides: Partial<StageWithClustersRecord> = {}): StageWithClustersRecord {
+  return {
+    id: faker.string.uuid(),
+    name: faker.helpers.slugify(faker.word.sample(3)).toLowerCase().slice(0, 20),
+    clusters: [{ id: faker.string.uuid() }],
+    ...overrides,
+  } satisfies StageWithClustersRecord
+}
+
+export function makeCluster(overrides: Partial<Cluster> = {}): Cluster {
+  return {
+    id: faker.string.uuid(),
+    label: faker.helpers.slugify(faker.word.sample(5)).toLowerCase(),
+    privacy: faker.helpers.arrayElement(['public', 'dedicated'] as const),
+    secretName: faker.string.uuid(),
+    clusterResources: faker.datatype.boolean(),
+    kubeConfigId: faker.string.uuid(),
+    infos: faker.lorem.sentence(),
+    cpu: faker.number.int({ min: 0, max: 64 }),
+    gpu: faker.number.int({ min: 0, max: 8 }),
+    memory: faker.number.int({ min: 0, max: 512 }),
+    zoneId: faker.string.uuid(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  } satisfies Cluster
+}
+
+export function makeEnvironment(overrides: Partial<Environment> = {}): Environment {
+  return {
+    id: faker.string.uuid(),
+    name: faker.helpers.slugify(faker.word.sample(3)).toLowerCase().slice(0, 11),
+    projectId: faker.string.uuid(),
+    memory: faker.number.int({ min: 0, max: 64 }),
+    cpu: faker.number.int({ min: 0, max: 16 }),
+    gpu: faker.number.int({ min: 0, max: 4 }),
+    autosync: faker.datatype.boolean(),
+    clusterId: faker.string.uuid(),
+    stageId: faker.string.uuid(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.past(),
+    ...overrides,
+  } satisfies Environment
+}
+
+export function makeStageEnvironmentRecord(overrides: Partial<StageEnvironmentsRecord> = {}): StageEnvironmentsRecord {
+  const environment = makeEnvironment()
+  return {
+    ...environment,
+    cluster: { label: faker.helpers.slugify(faker.word.sample(3)).toLowerCase() },
+    project: {
+      slug: faker.helpers.slugify(faker.word.sample(3)).toLowerCase(),
+      name: faker.company.name(),
+      owner: {
+        id: faker.string.uuid(),
+        firstName: faker.person.firstName(),
+        lastName: faker.person.lastName(),
+        email: faker.internet.email(),
+        createdAt: faker.date.past(),
+        updatedAt: faker.date.past(),
+        lastLogin: faker.date.past(),
+        adminRoleIds: [],
+        type: 'human' as const,
+      },
+    },
+    ...overrides,
+  } satisfies StageEnvironmentsRecord
+}

--- a/apps/server-nestjs/src/modules/stage/stage.controller.ts
+++ b/apps/server-nestjs/src/modules/stage/stage.controller.ts
@@ -1,0 +1,52 @@
+import type { CreateStageBody, Stage, StageAssociatedEnvironments, UpdateStageBody } from '@cpn-console/shared'
+import { StageSchema } from '@cpn-console/shared'
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Inject, Param, Post, Put, UseGuards } from '@nestjs/common'
+import { UserGuard } from '../infrastructure/permission/user/user.guard'
+import { RequireAdminPermission } from '../infrastructure/permission/user/user-admin-permission.decorator'
+import { ZodValidationPipe } from '../infrastructure/pipe/zod-validation.pipe'
+import { StageService } from './stage.service'
+
+@Controller('api/v1/stages')
+@UseGuards(UserGuard)
+export class StageController {
+  constructor(@Inject(StageService) private readonly service: StageService) {}
+
+  @Get()
+  async list(): Promise<Stage[]> {
+    return this.service.listStages()
+  }
+
+  @Get(':stageId/environments')
+  @RequireAdminPermission('ListStages')
+  async getStageEnvironments(
+    @Param('stageId') stageId: string,
+  ): Promise<StageAssociatedEnvironments> {
+    return this.service.getStageAssociatedEnvironments(stageId)
+  }
+
+  @Post()
+  @RequireAdminPermission('ManageStages')
+  async create(
+    @Body(new ZodValidationPipe(StageSchema.omit({ id: true }).partial({ clusterIds: true }))) data: CreateStageBody,
+  ): Promise<Stage> {
+    return this.service.createStage(data)
+  }
+
+  @Put(':stageId')
+  @RequireAdminPermission('ManageStages')
+  async update(
+    @Param('stageId') stageId: string,
+    @Body(new ZodValidationPipe(StageSchema.pick({ clusterIds: true, name: true }))) data: UpdateStageBody,
+  ): Promise<Stage> {
+    return this.service.updateStage(stageId, data)
+  }
+
+  @Delete(':stageId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @RequireAdminPermission('ManageStages')
+  async delete(
+    @Param('stageId') stageId: string,
+  ): Promise<void> {
+    await this.service.deleteStage(stageId)
+  }
+}

--- a/apps/server-nestjs/src/modules/stage/stage.module.ts
+++ b/apps/server-nestjs/src/modules/stage/stage.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { DatabaseModule } from '../infrastructure/database/database.module'
+import { StageController } from './stage.controller'
+import { StageService } from './stage.service'
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [StageController],
+  providers: [StageService],
+  exports: [StageService],
+})
+export class StageModule {}

--- a/apps/server-nestjs/src/modules/stage/stage.service.spec.ts
+++ b/apps/server-nestjs/src/modules/stage/stage.service.spec.ts
@@ -1,0 +1,126 @@
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { Test } from '@nestjs/testing'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { faker } from '@faker-js/faker'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { makeCluster, makeStageEnvironmentRecord, makeStageRecord, makeStageWithClusters } from './stage-testing.utils'
+import { StageService } from './stage.service'
+
+describe('StageService', () => {
+  let service: StageService
+  let prisma: DeepMockProxy<PrismaService>
+
+  beforeEach(async () => {
+    prisma = mockDeep<PrismaService>()
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StageService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile()
+
+    service = moduleRef.get(StageService)
+  })
+
+  it('lists stages with clusterIds', async () => {
+    const stages = [makeStageWithClusters(), makeStageWithClusters()]
+    prisma.stage.findMany.mockResolvedValue(stages)
+
+    const result = await service.listStages()
+
+    expect(result).toEqual(stages.map(stage => ({
+      id: stage.id,
+      name: stage.name,
+      clusterIds: stage.clusters.map(cluster => cluster.id),
+    })))
+  })
+
+  it('maps stage associated environments', async () => {
+    const environment = makeStageEnvironmentRecord()
+    prisma.environment.findMany.mockResolvedValue([environment])
+
+    const result = await service.getStageAssociatedEnvironments(faker.string.uuid())
+
+    expect(result).toEqual([{
+      project: environment.project.slug,
+      name: environment.name,
+      cluster: environment.cluster.label,
+      owner: environment.project.owner.email,
+    }])
+  })
+
+  it('creates a stage and links clusters', async () => {
+    const stage = makeStageRecord()
+    prisma.stage.findUnique.mockResolvedValue(null)
+    prisma.stage.create.mockResolvedValue(stage)
+    prisma.stage.update.mockResolvedValue(stage)
+
+    const clusterIds = [faker.string.uuid()]
+    const result = await service.createStage({ name: stage.name, clusterIds })
+
+    expect(result).toEqual({
+      id: stage.id,
+      name: stage.name,
+      clusterIds,
+    })
+    expect(prisma.stage.create).toHaveBeenCalledWith({ data: { name: stage.name }, select: expect.anything() })
+    expect(prisma.stage.update).toHaveBeenCalled()
+  })
+
+  it('rejects stage creation when the name is taken', async () => {
+    prisma.stage.findUnique.mockResolvedValue(makeStageRecord())
+
+    await expect(
+      service.createStage({ name: 'taken', clusterIds: [] }),
+    ).rejects.toThrow('Un type d\'environnement portant ce nom existe déjà')
+  })
+
+  it('updates stage name and cluster links', async () => {
+    const stage = makeStageWithClusters()
+    prisma.stage.findUnique.mockResolvedValue(stage)
+    prisma.stage.update.mockResolvedValue(stage)
+
+    const clusterIds = [faker.string.uuid()]
+    const result = await service.updateStage(stage.id, { name: 'new-name', clusterIds })
+
+    expect(result.id).toEqual(stage.id)
+    expect(prisma.stage.update).toHaveBeenCalled()
+  })
+
+  it('rejects updating a missing stage', async () => {
+    prisma.stage.findUnique.mockResolvedValue(null)
+
+    await expect(
+      service.updateStage(faker.string.uuid(), { name: 'new', clusterIds: [] }),
+    ).rejects.toThrow()
+  })
+
+  it('deletes a stage when no environments are attached', async () => {
+    prisma.environment.count.mockResolvedValue(0)
+    prisma.stage.delete.mockResolvedValue(makeStageRecord())
+
+    await service.deleteStage(faker.string.uuid())
+
+    expect(prisma.stage.delete).toHaveBeenCalled()
+  })
+
+  it('rejects stage deletion when environments are attached', async () => {
+    prisma.environment.count.mockResolvedValue(3)
+
+    await expect(
+      service.deleteStage(faker.string.uuid()),
+    ).rejects.toThrow('Impossible de supprimer le stage')
+  })
+
+  it('links a cluster to all stages', async () => {
+    prisma.stage.findMany.mockResolvedValue([makeStageRecord(), makeStageRecord()])
+    prisma.cluster.update.mockResolvedValue(makeCluster())
+
+    const clusterId = faker.string.uuid()
+    await service.linkClusterToStages(clusterId, [])
+
+    expect(prisma.cluster.update).toHaveBeenCalled()
+  })
+})

--- a/apps/server-nestjs/src/modules/stage/stage.service.ts
+++ b/apps/server-nestjs/src/modules/stage/stage.service.ts
@@ -1,0 +1,108 @@
+import type { CreateStageBody, Stage, StageAssociatedEnvironments, UpdateStageBody } from '@cpn-console/shared'
+import type { Cluster, Stage as StageDb } from '@prisma/client'
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import {
+  createStage as createStageQuery,
+  deleteStage as deleteStageQuery,
+  disconnectClusterFromStage,
+  getAllStageIds,
+  getStageAssociatedEnvironments,
+  getStageAssociatedEnvironmentCount,
+  getStageById,
+  getStageByName,
+  linkClusterToStages,
+  linkStageToClusters,
+  listStages as listStagesQuery,
+  removeClusterFromStage,
+  updateStageName,
+} from './stage-queries.utils'
+
+@Injectable()
+export class StageService {
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  async listStages(): Promise<Stage[]> {
+    const stages = await listStagesQuery(this.prisma)
+    return stages.map(({ clusters, ...stage }) => ({
+      ...stage,
+      clusterIds: clusters.map(({ id }) => id),
+    }))
+  }
+
+  async getStageAssociatedEnvironments(stageId: Stage['id']): Promise<StageAssociatedEnvironments> {
+    const environments = await getStageAssociatedEnvironments(this.prisma, stageId)
+    return environments.map(env => ({
+      project: env.project.slug,
+      name: env.name,
+      cluster: env.cluster.label,
+      owner: env.project.owner.email,
+    }))
+  }
+
+  async createStage({ clusterIds = [], name }: CreateStageBody): Promise<Stage> {
+    const isNameTaken = await getStageByName(this.prisma, name)
+    if (isNameTaken) throw new BadRequestException('Un type d\'environnement portant ce nom existe déjà')
+
+    const stage = await createStageQuery(this.prisma, { name })
+
+    if (clusterIds.length) {
+      await linkStageToClusters(this.prisma, stage.id, clusterIds)
+    }
+
+    return {
+      id: stage.id,
+      name: stage.name,
+      clusterIds,
+    }
+  }
+
+  async updateStage(stageId: Stage['id'], { clusterIds, name }: UpdateStageBody): Promise<Stage> {
+    const dbStage = await getStageById(this.prisma, stageId)
+    if (!dbStage) throw new NotFoundException()
+
+    if (name !== undefined && name !== dbStage.name) {
+      await updateStageName(this.prisma, stageId, name)
+    }
+
+    // Remove clusters no longer linked
+    const dbClusters = dbStage.clusters
+    if (dbClusters?.length) {
+      const clustersToRemove = dbClusters.filter(dbCluster => !clusterIds.includes(dbCluster.id))
+      for (const clusterToRemove of clustersToRemove) {
+        await disconnectClusterFromStage(this.prisma, clusterToRemove.id, stageId)
+      }
+    }
+
+    // Add clusters
+    if (clusterIds.length) {
+      await linkStageToClusters(this.prisma, stageId, clusterIds)
+    }
+
+    const updated = await getStageById(this.prisma, stageId)
+    if (!updated) throw new NotFoundException()
+
+    return {
+      id: stageId,
+      name: updated.name,
+      clusterIds: updated.clusters.map(({ id }) => id),
+    }
+  }
+
+  async deleteStage(stageId: Stage['id']): Promise<void> {
+    const attachedEnvironmentCount = await getStageAssociatedEnvironmentCount(this.prisma, stageId)
+    if (attachedEnvironmentCount > 0) {
+      throw new BadRequestException('Impossible de supprimer le stage, des environnements en activité y ont souscrit')
+    }
+
+    await deleteStageQuery(this.prisma, stageId)
+  }
+
+  async linkClusterToStages(clusterId: Cluster['id'], stageIds: Stage['id'][]): Promise<void> {
+    const allStageIds = stageIds.length ? stageIds : (await getAllStageIds(this.prisma)).map(({ id }) => id)
+    await linkClusterToStages(this.prisma, clusterId, allStageIds)
+    for (const stageId of allStageIds) {
+      await removeClusterFromStage(this.prisma, clusterId, stageId)
+    }
+  }
+}


### PR DESCRIPTION
## Issues liées

Refs #2493

---------

## Quel est le comportement actuel ?

Le module `stage` (stages, environnements par stage) est servi par l'ancienne application Fastify `apps/server`.

## Quel est le nouveau comportement ?

Migration du module `stage` vers `apps/server-nestjs` :
- `StageController`, `StageService`, `StageModule`.
- `stage-queries.utils.ts` : sélections Prisma typées.
- `stage-testing.utils.ts` : fabriques `faker` pour les tests.
- Enregistrement du module dans `main.module.ts`.
- Parité des contrats et codes HTTP contre `apps/server/src/resources/stage/`.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations
