### PR TITLE
refactor(stage): strangler offload routes to server-nestjs

### DIFF
--- a/apps/nginx-strangler/conf.d/routing.conf
+++ b/apps/nginx-strangler/conf.d/routing.conf
@@ -109,6 +109,15 @@ server {
     }
 
     # ── Routes par défaut (pour l'instant dans le legacy) ─────────────────────────
+    location /api/v1/stages {
+        proxy_pass         http://server-nestjs;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     location /api/ {
         proxy_pass         http://server-legacy;
         proxy_http_version 1.1;


### PR DESCRIPTION
## Issues liées

- Closes #1889

## Quel est le comportement actuel ?

Les routes `stages` (`/api/v1/stages`) sont servies par l'ancienne application Fastify `apps/server` via le nginx strangler.

## Quel est le nouveau comportement ?

Offload du routage `/api/v1/stages` de l'ancien serveur vers `server-nestjs` dans le nginx strangler.
Cette PR est empilée sur la PR de migration du module `stage` (#2496) : le module étant migré, le strangler bascule le trafic vers `server-nestjs`.

## Cette PR introduit-elle un breaking change ?

Non.