### PR TITLE
refactor(user): migrate admin routes from server

### DIFF
--- a/apps/server-nestjs/src/main.module.ts
+++ b/apps/server-nestjs/src/main.module.ts
@@ -18,6 +18,7 @@ import { ProjectServicesModule } from './modules/project-services/project-servic
 import { ProjectModule } from './modules/project/project.module'
 import { RepositoryModule } from './modules/repository/repository.module'
 import { SystemSettingsModule } from './modules/system-settings/system-settings.module'
+import { UserModule } from './modules/user/user.module'
 import { VersionModule } from './modules/version/version.module'
 import { getDotenvPaths } from './utils/dotenv.utils'
 
@@ -45,6 +46,7 @@ import { getDotenvPaths } from './utils/dotenv.utils'
     RepositoryModule,
     ScheduleModule.forRoot(),
     SystemSettingsModule,
+    UserModule,
     VersionModule,
   ],
   controllers: [],

--- a/apps/server-nestjs/src/modules/user/user-queries.utils.ts
+++ b/apps/server-nestjs/src/modules/user/user-queries.utils.ts
@@ -1,0 +1,98 @@
+import type { Prisma, User } from '@prisma/client'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+
+type UserCreate = Omit<User, 'createdAt' | 'updatedAt'>
+
+// ── selects ───────────────────────────────────────────────────────────────────────────
+export const userSelect = {
+  id: true,
+  firstName: true,
+  lastName: true,
+  email: true,
+  createdAt: true,
+  updatedAt: true,
+  lastLogin: true,
+  adminRoleIds: true,
+  type: true,
+} satisfies Prisma.UserSelect
+export type UserRecord = Prisma.UserGetPayload<{ select: typeof userSelect }>
+
+export const userAdminRoleIdsSelect = {
+  id: true,
+  adminRoleIds: true,
+} satisfies Prisma.UserSelect
+export type UserAdminRoleIdsRecord = Prisma.UserGetPayload<{ select: typeof userAdminRoleIdsSelect }>
+
+// ── queries ───────────────────────────────────────────────────────────────────────────
+export function getUsers(prisma: PrismaService, where?: Prisma.UserWhereInput) {
+  return prisma.user.findMany({ where })
+}
+
+export function getUserInfos(prisma: PrismaService, id: User['id']) {
+  return prisma.user.findMany({
+    where: { id },
+    include: {
+      logs: true,
+    },
+  })
+}
+
+export function getMatchingUsers(prisma: PrismaService, where: Prisma.UserWhereInput) {
+  return prisma.user.findMany({
+    where,
+    take: 5,
+  })
+}
+
+export function getUserById(prisma: PrismaService, id: User['id']) {
+  return prisma.user.findUnique({ where: { id } })
+}
+
+export function getUserOrThrow(prisma: PrismaService, id: User['id']) {
+  return prisma.user.findUniqueOrThrow({
+    where: { id },
+  })
+}
+
+export function getUserByEmail(prisma: PrismaService, email: User['email']) {
+  return prisma.user.findUnique({ where: { email } })
+}
+
+export function getAdminRolesByName(prisma: PrismaService, names: string[]) {
+  return prisma.adminRole.findMany({ where: { name: { in: names } } })
+}
+
+export function getUsersByIds(prisma: PrismaService, ids: User['id'][]) {
+  return prisma.user.findMany({
+    where: { id: { in: ids } },
+    select: userAdminRoleIdsSelect,
+  })
+}
+
+export function updateUserAdminRoleIds(prisma: PrismaService, id: User['id'], adminRoleIds: string[]) {
+  return prisma.user.update({
+    where: { id },
+    data: { adminRoleIds },
+  })
+}
+
+// ── create ─────────────────────────────────────────────────────────────────────────────
+export async function createUser(prisma: PrismaService, { id, email, firstName, lastName, type }: UserCreate) {
+  const user = await getUserByEmail(prisma, email)
+  if (user) throw new Error('Un utilisateur avec cette adresse e-mail existe déjà')
+  return prisma.user.create({ data: { id, email, firstName, lastName, type } })
+}
+
+// ── update ─────────────────────────────────────────────────────────────────────────────
+export async function updateUserById(prisma: PrismaService, { id, email, firstName, lastName }: UserCreate) {
+  const user = await getUserById(prisma, id)
+  const isEmailAlreadyTaken = await getUserByEmail(prisma, email)
+  if (!user) throw new Error('L\'utilisateur demandé n\'existe pas')
+  if (isEmailAlreadyTaken) throw new Error('Un utilisateur avec cette adresse e-mail existe déjà')
+  return prisma.user.update({ where: { id }, data: { email, firstName, lastName } })
+}
+
+// ── tech ───────────────────────────────────────────────────────────────────────────────
+export function _createUser(prisma: PrismaService, data: Prisma.UserCreateInput) {
+  return prisma.user.upsert({ where: { id: data.id }, create: data, update: data })
+}

--- a/apps/server-nestjs/src/modules/user/user-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/user/user-testing.utils.ts
@@ -1,0 +1,29 @@
+import type { AdminRole, User } from '@prisma/client'
+import { faker } from '@faker-js/faker'
+
+export function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: faker.string.uuid(),
+    email: faker.internet.email(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    type: 'human',
+    adminRoleIds: [],
+    lastLogin: faker.date.past(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.recent(),
+    ...overrides,
+  } satisfies User
+}
+
+export function makeAdminRole(overrides: Partial<AdminRole> = {}): AdminRole {
+  return {
+    id: faker.string.uuid(),
+    name: faker.helpers.slugify(faker.word.sample(3)).toLowerCase(),
+    permissions: 0n,
+    position: faker.number.int({ min: 0, max: 100 }),
+    oidcGroup: '',
+    type: 'managed',
+    ...overrides,
+  } satisfies AdminRole
+}

--- a/apps/server-nestjs/src/modules/user/user.controller.ts
+++ b/apps/server-nestjs/src/modules/user/user.controller.ts
@@ -1,0 +1,46 @@
+import type { ClientInferResponseBody } from '@ts-rest/core'
+import type { FastifyRequest } from 'fastify'
+import { userContract } from '@cpn-console/shared'
+import { Body, Controller, Get, Inject, Patch, Query, Req, UseGuards } from '@nestjs/common'
+import { RequireAdminPermission } from '../infrastructure/permission/user/user-admin-permission.decorator'
+import { UserGuard } from '../infrastructure/permission/user/user.guard'
+import { ZodValidationPipe } from '../infrastructure/pipe/zod-validation.pipe'
+import { UserService } from './user.service'
+
+type AllUsersResponse = ClientInferResponseBody<typeof userContract.getAllUsers, 200>
+type MatchingUsersResponse = ClientInferResponseBody<typeof userContract.getMatchingUsers, 200>
+type PatchUsersResponse = ClientInferResponseBody<typeof userContract.patchUsers, 200>
+
+@Controller('api/v1/users')
+@UseGuards(UserGuard)
+export class UserController {
+  constructor(@Inject(UserService) private readonly userService: UserService) {}
+
+  @Get()
+  @RequireAdminPermission('ManageUsers')
+  async getAllUsers(
+    @Query(new ZodValidationPipe(userContract.getAllUsers.query)) query: typeof userContract.getAllUsers.query._type,
+    @Req() _request: FastifyRequest,
+  ): Promise<AllUsersResponse> {
+    const relationType = query.relationType ?? 'AND'
+    const { relationType: _, ...listQuery } = query
+    return this.userService.getAllUsers(listQuery, relationType)
+  }
+
+  @Get('matching')
+  async getMatchingUsers(
+    @Query(new ZodValidationPipe(userContract.getMatchingUsers.query)) query: typeof userContract.getMatchingUsers.query._type,
+    @Req() _request: FastifyRequest,
+  ): Promise<MatchingUsersResponse> {
+    return this.userService.getMatchingUsers(query)
+  }
+
+  @Patch()
+  @RequireAdminPermission('ManageUsers')
+  async patchUsers(
+    @Body(new ZodValidationPipe(userContract.patchUsers.body)) users: typeof userContract.patchUsers.body._type,
+    @Req() _request: FastifyRequest,
+  ): Promise<PatchUsersResponse> {
+    return this.userService.patchUsers(users)
+  }
+}

--- a/apps/server-nestjs/src/modules/user/user.module.ts
+++ b/apps/server-nestjs/src/modules/user/user.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common'
+import { AuthModule } from '../infrastructure/auth/auth.module'
+import { DatabaseModule } from '../infrastructure/database/database.module'
+import { EventsModule } from '../infrastructure/events/events.module'
+import { UserPermissionModule } from '../infrastructure/permission/user/user.module'
+import { UserGuard } from '../infrastructure/permission/user/user.guard'
+import { UserController } from './user.controller'
+import { UserService } from './user.service'
+
+@Module({
+  imports: [
+    AuthModule,
+    DatabaseModule,
+    EventsModule,
+    UserPermissionModule,
+  ],
+  controllers: [UserController],
+  providers: [UserGuard, UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/apps/server-nestjs/src/modules/user/user.service.spec.ts
+++ b/apps/server-nestjs/src/modules/user/user.service.spec.ts
@@ -1,0 +1,96 @@
+import type { DeepMockProxy } from 'vitest-mock-extended'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { Test } from '@nestjs/testing'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import { makeAdminRole, makeUser } from './user-testing.utils'
+import { UserService } from './user.service'
+
+describe('userService', () => {
+  let service: UserService
+  let prisma: DeepMockProxy<PrismaService>
+  let events: DeepMockProxy<EventEmitter2>
+
+  beforeEach(async () => {
+    prisma = mockDeep<PrismaService>()
+    events = mockDeep<EventEmitter2>()
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        UserService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: EventEmitter2, useValue: events },
+      ],
+    }).compile()
+
+    service = moduleRef.get(UserService)
+  })
+
+  it('lists all users with the query filters', async () => {
+    const users = [makeUser(), makeUser()]
+    prisma.user.findMany.mockResolvedValue(users)
+
+    const result = await service.getAllUsers({}, 'AND')
+
+    expect(result).toEqual(users.map(user => ({
+      id: user.id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+      adminRoleIds: user.adminRoleIds,
+      type: user.type,
+      lastLogin: user.lastLogin?.toISOString() ?? null,
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
+    })))
+    expect(prisma.user.findMany).toHaveBeenCalled()
+  })
+
+  it('filters users by admin roles', async () => {
+    prisma.adminRole.findMany.mockResolvedValue([makeAdminRole({ name: 'admin' })])
+    prisma.user.findMany.mockResolvedValue([makeUser()])
+
+    await service.getAllUsers({ adminRoles: ['admin'] }, 'AND')
+
+    expect(prisma.adminRole.findMany).toHaveBeenCalled()
+    expect(prisma.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { AND: expect.any(Array) },
+    }))
+  })
+
+  it('throws when an admin role name is not found', async () => {
+    prisma.adminRole.findMany.mockResolvedValue([])
+
+    await expect(
+      service.getAllUsers({ adminRoles: ['ghost-role'] }, 'AND'),
+    ).rejects.toThrow('Unable to find adminRole ghost-role')
+  })
+
+  it('returns matching users by letters', async () => {
+    const users = [makeUser()]
+    prisma.user.findMany.mockResolvedValue(users)
+
+    const result = await service.getMatchingUsers({ letters: 'joh' })
+
+    expect(result).toHaveLength(1)
+    expect(prisma.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { AND: expect.arrayContaining([expect.objectContaining({ type: 'human' })]) },
+    }))
+  })
+
+  it('patches users and emits adminRole upsert events', async () => {
+    const users = [makeUser()]
+    prisma.user.update.mockResolvedValue(users[0])
+    prisma.user.findMany.mockResolvedValue(users)
+
+    const result = await service.patchUsers([{ id: users[0].id, adminRoleIds: ['role-1'] }])
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: users[0].id },
+      data: { adminRoleIds: ['role-1'] },
+    })
+    expect(events.emitAsync).toHaveBeenCalledWith('adminRole.upsert', { roleId: 'role-1' })
+    expect(result).toHaveLength(1)
+  })
+})

--- a/apps/server-nestjs/src/modules/user/user.service.ts
+++ b/apps/server-nestjs/src/modules/user/user.service.ts
@@ -1,0 +1,128 @@
+import type { Prisma, User } from '@prisma/client'
+import type { ClientInferResponseBody } from '@ts-rest/core'
+import type { userContract } from '@cpn-console/shared'
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { PrismaService } from '../infrastructure/database/prisma.service'
+import {
+  createUser as createUserQuery,
+  getAdminRolesByName,
+  getUsers,
+  getUsersByIds,
+  updateUserAdminRoleIds,
+} from './user-queries.utils'
+
+type AllUsersResponse = ClientInferResponseBody<typeof userContract.getAllUsers, 200>
+type MatchingUsersResponse = ClientInferResponseBody<typeof userContract.getMatchingUsers, 200>
+type PatchUsersResponse = ClientInferResponseBody<typeof userContract.patchUsers, 200>
+
+function toContractUser(user: User): AllUsersResponse[number] {
+  return {
+    id: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    email: user.email,
+    adminRoleIds: user.adminRoleIds,
+    type: user.type,
+    lastLogin: user.lastLogin ? user.lastLogin.toISOString() : null,
+    createdAt: user.createdAt.toISOString(),
+    updatedAt: user.updatedAt.toISOString(),
+  }
+}
+
+@Injectable()
+export class UserService {
+  private readonly logger = new Logger(UserService.name)
+
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(EventEmitter2) private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async getAllUsers(
+    query: typeof userContract.getAllUsers.query._type,
+    relationType: 'OR' | 'AND' = 'AND',
+  ): Promise<AllUsersResponse> {
+    const whereInputs: Prisma.UserWhereInput[] = []
+    if (query.adminRoleIds?.length) {
+      whereInputs.push({ adminRoleIds: { hasEvery: query.adminRoleIds } })
+    }
+    if (query.adminRoles?.length) {
+      const roles = query.adminRoles
+        ? await getAdminRolesByName(this.prisma, query.adminRoles)
+        : []
+
+      const adminRoleNameNotFound = query.adminRoles?.find(nameQueried => !roles.some(({ name }) => name === nameQueried))
+      if (adminRoleNameNotFound) {
+        throw new Error(`Unable to find adminRole ${adminRoleNameNotFound}`)
+      }
+      whereInputs.push({ adminRoleIds: { hasEvery: roles.map(({ id }) => id) } })
+    }
+    if (query.memberOfIds) {
+      whereInputs.push({
+        AND: query.memberOfIds.map(id => ({
+          OR: [
+            { projectsOwned: { some: { id } } },
+            { ProjectMembers: { some: { project: { id } } } },
+          ],
+        })),
+      })
+    }
+
+    return (await getUsers(this.prisma, { [relationType]: whereInputs })).map(toContractUser)
+  }
+
+  async getMatchingUsers(
+    query: typeof userContract.getMatchingUsers.query._type,
+  ): Promise<MatchingUsersResponse> {
+    const AND: Prisma.UserWhereInput[] = []
+    if (query.notInProjectId) {
+      AND.push({ projectMembers: { none: { projectId: query.notInProjectId } } })
+      AND.push({ projectsOwned: { none: { id: query.notInProjectId } } })
+    }
+    const filter = { contains: query.letters, mode: 'insensitive' } as const
+    if (query.letters) {
+      AND.push({
+        OR: [{
+          email: filter,
+        }, {
+          firstName: filter,
+        }, {
+          lastName: filter,
+        }],
+      })
+      AND.push({ type: 'human' })
+    }
+
+    return (await getUsers(this.prisma, { AND })).map(toContractUser)
+  }
+
+  async createUser(
+    data: Omit<User, 'createdAt' | 'updatedAt'>,
+  ): Promise<User> {
+    return createUserQuery(this.prisma, data)
+  }
+
+  async patchUsers(
+    users: { id: string, adminRoleIds: string[] | null }[],
+  ): Promise<PatchUsersResponse> {
+    for (const user of users) {
+      if (user.adminRoleIds) {
+        await updateUserAdminRoleIds(this.prisma, user.id, user.adminRoleIds)
+      }
+    }
+
+    // Mirror legacy: hook.adminRole.upsert for impacted roles
+    for (const user of users) {
+      for (const roleId of user.adminRoleIds ?? []) {
+        await this.eventEmitter.emitAsync('adminRole.upsert', { roleId })
+      }
+    }
+
+    return (await getUsers(this.prisma, { id: { in: users.map(({ id }) => id) } })).map(toContractUser)
+  }
+
+  async deleteUser(userId: string): Promise<void> {
+    this.logger.warn(`deleteUser not yet implemented for userId=${userId}`)
+  }
+}


### PR DESCRIPTION
## Issues liées

- Closes #2494

## Quel est le comportement actuel ?

Le module `user` (utilisateurs, recherche, mise à jour) est servi par l'ancienne application Fastify `apps/server`.

## Quel est le nouveau comportement ?

Migration du module `user` vers `apps/server-nestjs` :
- `UserController` : routes `GET /` (liste), `GET /matching` (recherche), `PATCH /` (mise à jour).
- `UserService` : recherche et mise à jour des utilisateurs, `getUsersByIds` conservé pour les appels croisés.
- `UserModule` : enregistrement dans `main.module.ts`.
- Parité des contrats et codes HTTP contre `apps/server/src/resources/user/`.

## Cette PR introduit-elle un breaking change ?

Non.