### PR TITLE
fix(observability): scope repository url by project slug with .git suffix

### DIFF
--- a/apps/server-nestjs/src/modules/observability/observability.service.spec.ts
+++ b/apps/server-nestjs/src/modules/observability/observability.service.spec.ts
@@ -78,6 +78,20 @@ describe('observabilityService', () => {
     })
   })
 
+  describe('syncValuesFile', () => {
+    it('scopes the repository url by project slug with a .git suffix', async () => {
+      const project = makeProject({ slug: 'infra-observability' })
+      await service.handleUpsert(project)
+      expect(client.updateProjectConfig).toHaveBeenCalledWith(
+        { id: 1 },
+        project,
+        expect.objectContaining({
+          projectRepository: { url: 'https://gitlab.test/proj/infra-observability/infra-observability.git', path: '.' },
+        }),
+      )
+    })
+  })
+
   describe('handleDelete', () => {
     it('cleans up keycloak groups and values', async () => {
       await service.handleDelete(makeProject())

--- a/apps/server-nestjs/src/modules/observability/observability.service.ts
+++ b/apps/server-nestjs/src/modules/observability/observability.service.ts
@@ -131,7 +131,7 @@ export class ObservabilityService {
     const projectGroupPath = generateKeycloakRootGroupPath(project)
 
     const projectValue = generateObservabilityProject(project, {
-      repositoryUrl: `${repositoryUrl}/${OBSERVABILITY_REPOSITORY}`,
+      repositoryUrl: `${repositoryUrl}/${project.slug}/${OBSERVABILITY_REPOSITORY}.git`,
       tenantRbacProd: generateGrafanaProdRbacGroupPaths(projectGroupPath),
       tenantRbacHProd: generateGrafanaHprodRbacGroupPaths(projectGroupPath),
     })


### PR DESCRIPTION
## Issues liées

Issues numéro: #2503

## Quel est le comportement actuel ?

Lors de la synchronisation de la configuration observabilité (Grafana), `syncValuesFile` génère une URL de dépôt `…/projects/infra-observability` dans `values.yaml` : le segment `<slug-du-projet>` et le suffixe `.git` sont absents.

## Quel est le nouveau comportement ?

L'URL est désormais construite comme `…/projects/<slug>/infra-observability.git`, scopée par projet et conforme au format attendu par les autres services (miroir, CI, schema `projectRepository.url`).

Régression introduite lors de la migration `server-nestjs` (commit `ab5c0ebd4c`).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Test ajouté : `observability.service.spec.ts` vérifie l'URL scopée par slug avec suffixe `.git`.