### PR TITLE
fix(server-nestjs): use per-project cloud-pi-native.fr email for sonarqube robot account

### DIFF
--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
@@ -266,14 +266,14 @@ describe('sonarqubeService', () => {
       expect(vault.deleteSonarqubeUser).toHaveBeenCalledWith('no-user')
     })
 
-    it('should use owner email when creating user', async () => {
+    it('should use a per-project cloud-pi-native.fr email when creating user', async () => {
       const project = makeProjectWithDetails({ slug: 'with-owner', owner: { email: 'owner@example.com' } as any })
       client.generateUserToken.mockResolvedValue(makeUserToken({ login: project.slug }))
       client.searchUsers.mockImplementation(async function* () {})
 
       await service.handleUpsert(project)
 
-      expect(client.createUser).toHaveBeenCalledWith(expect.objectContaining({ email: 'owner@example.com', login: 'with-owner' }))
+      expect(client.createUser).toHaveBeenCalledWith(expect.objectContaining({ email: 'with-owner@cloud-pi-native.fr', login: 'with-owner' }))
     })
   })
 

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
@@ -204,9 +204,10 @@ export class SonarqubeService implements OnModuleInit {
     let newSecret: SonarqubeUserSecret | undefined
 
     if (!user) {
-      this.logger.log(`Creating SonarQube user (login=${project.slug}, email=${project.owner.email})`)
+      const email = `${project.slug}@cloud-pi-native.fr`
+      this.logger.log(`Creating SonarQube user (login=${project.slug}, email=${email})`)
       const password = generateRandomPassword(30)
-      await this.client.createUser({ email: project.owner.email, local: 'true', login: project.slug, name: project.slug, password })
+      await this.client.createUser({ email, local: 'true', login: project.slug, name: project.slug, password })
       const token = await this.rotateToken(project.slug)
       newSecret = { SONAR_USERNAME: project.slug, SONAR_PASSWORD: password, SONAR_TOKEN: token }
     } else if (existingSecret) {


### PR DESCRIPTION
## Issues liées

Closes #2510

---------

## Quel est le comportement actuel ?

Lors de la création du compte robot SonarQube d'un projet, la console utilise l'email **réel du propriétaire** (`project.owner.email`). Comme ce compte est `local: true`, l'email du propriétaire se retrouve lié à une identité SonarQube locale. Lorsque le propriétaire se connecte via le SSO (Keycloak), SonarQube détecte que l'email est déjà possédé par un compte local et refuse la liaison : « already associated with another authentication method ».

## Quel est le nouveau comportement ?

Le compte robot utilise désormais un email de domaine `cloud-pi-native.fr` dérivé du slug du projet (`${project.slug}@cloud-pi-native.fr`), unique et non lié à une identité humaine. La collision SSO disparaît. Le compte reste `local: true` (compte de service authentifié par token, pas par SSO).

## Cette PR introduit-elle un breaking change ?

Non. Seul l'email du compte robot change ; le `login` (`project.slug`) et le token CI (`SONAR_TOKEN`) sont inchangés.

## Autres informations

Régression introduite par le commit `44d6d2700a` (« use project owner email for sonarqube user creation »), rattaché par erreur à l'issue #2400 (bug Vault unrelated). Le compte robot reste `local` car il s'authentifie par token CI, non par SSO — un basculement OIDC n'est pas applicable aux comptes de service.