### PR TITLE
fix(server-nestjs): use per-project cloud-pi-native.fr email for sonarqube robot account

### DIFF
--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube-client.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube-client.service.ts
@@ -140,7 +140,8 @@ export interface CreateUserParams extends BaseParams {
 
 export interface UpdateUserParams extends BaseParams {
   login: string
-  password: string
+  password?: string
+  email?: string
 }
 
 export interface DeactivateUserParams extends BaseParams {

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
@@ -192,6 +192,56 @@ describe('sonarqubeService', () => {
       expect(vault.writeSonarqubeUser).toHaveBeenCalledWith(project.slug, expect.objectContaining({ SONAR_USERNAME: project.slug, SONAR_PASSWORD: expect.any(String), SONAR_TOKEN: expect.any(String) }))
     })
 
+    it('should reconcile the email of an existing robot account stamped with the owner real email (#2510 mitigation)', async () => {
+      const project = makeProjectWithDetails({ slug: 'with-owner', owner: { email: 'owner@example.com' } as any })
+      vault.readSonarqubeUser.mockResolvedValue(makeVaultSecret({ data: { SONAR_USERNAME: 'with-owner', SONAR_PASSWORD: 'old', SONAR_TOKEN: 'old' } }))
+      client.generateUserToken.mockResolvedValue(makeUserToken({ login: project.slug }))
+      client.searchUsers.mockImplementation(async function* () {
+        yield makeSonarqubeUser({ login: 'with-owner', email: 'owner@example.com' })
+      })
+
+      await service.handleUpsert(project)
+
+      expect(client.createUser).not.toHaveBeenCalled()
+      expect(client.updateUser).toHaveBeenCalledWith(expect.objectContaining({
+        login: 'with-owner',
+        email: 'with-owner@cloud-pi-native.fr',
+      }))
+      expect(client.updateUser).not.toHaveBeenCalledWith(expect.objectContaining({ password: expect.any(String) }))
+    })
+
+    it('should not call updateUser when an existing robot account already has the cloud-pi-native.fr email', async () => {
+      const project = makeProjectWithDetails({ slug: 'clean' })
+      vault.readSonarqubeUser.mockResolvedValue(makeVaultSecret({ data: { SONAR_USERNAME: 'clean', SONAR_PASSWORD: 'old', SONAR_TOKEN: 'old' } }))
+      client.generateUserToken.mockResolvedValue(makeUserToken({ login: project.slug }))
+      client.searchUsers.mockImplementation(async function* () {
+        yield makeSonarqubeUser({ login: 'clean', email: 'clean@cloud-pi-native.fr' })
+      })
+
+      await service.handleUpsert(project)
+
+      expect(client.updateUser).not.toHaveBeenCalled()
+    })
+
+    it('should update both email and password when an existing robot account has a stale email and the vault secret is missing', async () => {
+      const project = makeProjectWithDetails({ slug: 'stale', owner: { email: 'owner@example.com' } as any })
+      vault.readSonarqubeUser.mockResolvedValue(null)
+      client.generateUserToken.mockResolvedValue(makeUserToken({ login: project.slug }))
+      client.searchUsers.mockImplementation(async function* () {
+        yield makeSonarqubeUser({ login: 'stale', email: 'owner@example.com' })
+      })
+
+      await service.handleUpsert(project)
+
+      expect(client.createUser).not.toHaveBeenCalled()
+      expect(client.updateUser).toHaveBeenCalledWith(expect.objectContaining({
+        login: 'stale',
+        email: 'stale@cloud-pi-native.fr',
+        password: expect.any(String),
+      }))
+      expect(vault.writeSonarqubeUser).toHaveBeenCalledWith('stale', expect.objectContaining({ SONAR_USERNAME: 'stale', SONAR_PASSWORD: expect.any(String), SONAR_TOKEN: expect.any(String) }))
+    })
+
     it('should delete sonarqube projects for removed repositories', async () => {
       const project = makeProjectWithDetails({ repositories: [{ internalRepoName: 'kept' }] })
       const keptKey = generateProjectKey(project.slug, 'kept')
@@ -266,14 +316,21 @@ describe('sonarqubeService', () => {
       expect(vault.deleteSonarqubeUser).toHaveBeenCalledWith('no-user')
     })
 
-    it('should use owner email when creating user', async () => {
+    it('should use a per-project cloud-pi-native.fr email (never the owner real email) when creating user', async () => {
       const project = makeProjectWithDetails({ slug: 'with-owner', owner: { email: 'owner@example.com' } as any })
       client.generateUserToken.mockResolvedValue(makeUserToken({ login: project.slug }))
       client.searchUsers.mockImplementation(async function* () {})
 
       await service.handleUpsert(project)
 
-      expect(client.createUser).toHaveBeenCalledWith(expect.objectContaining({ email: 'owner@example.com', login: 'with-owner' }))
+      // Regression guard for #2510: using the owner's real email on a `local: true` robot account
+      // makes the owner's SSO login collide ("already associated with another authentication
+      // method"). The email must be derived from the slug, never from the owner identity.
+      expect(client.createUser).toHaveBeenCalledWith(expect.objectContaining({
+        login: project.slug,
+        email: `${project.slug}@cloud-pi-native.fr`,
+      }))
+      expect(client.createUser).not.toHaveBeenCalledWith(expect.objectContaining({ email: project.owner.email }))
     })
   })
 

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
@@ -2,7 +2,7 @@ import type { OnModuleInit } from '@nestjs/common'
 import type { ConfigType } from '@nestjs/config'
 import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { SonarqubeUserSecret } from '../vault/vault-client.service'
-import type { SonarqubeProjectResult, SonarqubeUser } from './sonarqube-client.service'
+import type { SonarqubeProjectResult, SonarqubeUser, UpdateUserParams } from './sonarqube-client.service'
 import type { ProjectWithDetails } from './sonarqube-datastore.service'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
@@ -199,24 +199,39 @@ export class SonarqubeService implements OnModuleInit {
 
   @StartActiveSpan()
   private async ensureUser(project: ProjectWithDetails): Promise<void> {
-    const existingSecret = await this.vault.readSonarqubeUser(project.slug)
     const user = await this.findUser(project.slug)
+    const email = `${project.slug}@cloud-pi-native.fr`
     let newSecret: SonarqubeUserSecret | undefined
 
     if (!user) {
-      this.logger.log(`Creating SonarQube user (login=${project.slug}, email=${project.owner.email})`)
+      this.logger.log(`Creating SonarQube user (login=${project.slug}, email=${email})`)
       const password = generateRandomPassword(30)
-      await this.client.createUser({ email: project.owner.email, local: 'true', login: project.slug, name: project.slug, password })
+      await this.client.createUser({ email, local: 'true', login: project.slug, name: project.slug, password })
       const token = await this.rotateToken(project.slug)
       newSecret = { SONAR_USERNAME: project.slug, SONAR_PASSWORD: password, SONAR_TOKEN: token }
-    } else if (existingSecret) {
-      this.logger.verbose(`SonarQube user already exists with vault credentials (login=${project.slug})`)
     } else {
-      this.logger.warn(`SonarQube user exists but vault secret is missing, regenerating password and rotating token (login=${project.slug})`)
-      const password = generateRandomPassword(30)
-      await this.client.updateUser({ login: project.slug, password })
-      const token = await this.rotateToken(project.slug)
-      newSecret = { SONAR_USERNAME: project.slug, SONAR_PASSWORD: password, SONAR_TOKEN: token }
+      const updateParams: UpdateUserParams = { login: project.slug }
+      // Existing robot accounts created before the per-project email fix still carry the owner's real
+      // email, which collides with the owner's SSO login ("already associated with another
+      // authentication method", see #2510). Rewrite it to the per-project email on every reconcile.
+      // SonarqubeUser.email is derived from the API and can be blank on a collision account; never
+      // push a blank email into users/update, which would erase the value instead of fixing it.
+      if (user.email !== email && user.email) {
+        updateParams.email = email
+        this.logger.log(`Reconciling SonarQube user email to ${email} (login=${project.slug})`)
+      }
+      const existingSecret = await this.vault.readSonarqubeUser(project.slug)
+      if (existingSecret) {
+        this.logger.verbose(`SonarQube user already exists with vault credentials (login=${project.slug})`)
+      } else {
+        this.logger.warn(`SonarQube user exists but vault secret is missing, regenerating password and rotating token (login=${project.slug})`)
+        updateParams.password = generateRandomPassword(30)
+        const token = await this.rotateToken(project.slug)
+        newSecret = { SONAR_USERNAME: project.slug, SONAR_PASSWORD: updateParams.password, SONAR_TOKEN: token }
+      }
+      if (updateParams.email || updateParams.password) {
+        await this.client.updateUser(updateParams)
+      }
     }
 
     if (newSecret) {


### PR DESCRIPTION
## Issues liées

Closes #2510

---------

## Quel est le comportement actuel ?

Lors de la création du compte robot SonarQube d'un projet, la console utilise l'email **réel du propriétaire** (`project.owner.email`). Comme ce compte est `local: true`, l'email du propriétaire se retrouve lié à une identité SonarQube locale. Lorsque le propriétaire se connecte via le SSO (Keycloak), SonarQube détecte que l'email est déjà possédé par un compte local et refuse la liaison : « already associated with another authentication method ».

Les comptes robots déjà créés avant ce correctif conservent cet email du propriétaire : ils ne sont pas corrigés automatiquement et continuent de provoquer la collision SSO pour leur propriétaire respectif.

## Quel est le nouveau comportement ?

- Le compte robot utilise désormais un email de domaine `cloud-pi-native.fr` dérivé du slug du projet (`${project.slug}@cloud-pi-native.fr`), unique et non lié à une identité humaine. La collision SSO disparaît. Le compte reste `local: true` (compte de service authentifié par token, pas par SSO).
- À chaque upsert ou réconciliation (cron), si l'email existant du compte robot diffère de l'email de domaine attendu, la console le réécrit en place (`updateUser` avec `email`). Les comptes hérités sont ainsi auto-corrigés sans migration dédiée, et le token CI est rotationné si le secret Vault est manquant.

## Cette PR introduit-elle un breaking change ?

Non. Seul l'email du compte robot change (création comme réconciliation) ; le `login` (`project.slug`) et le token CI (`SONAR_TOKEN`) sont inchangés.

## Autres informations

Régression introduite par le commit `44d6d2700a` (« use project owner email for sonarqube user creation »), rattaché par erreur à l'issue #2400 (bug Vault unrelated). Le compte robot reste `local` car il s'authentifie par token CI, non par SSO — un basculement OIDC n'est pas applicable aux comptes de service.
