### PR TITLE
feat(environment): warn about linked deployments before environment deletion

### DIFF
--- a/apps/client/src/components/DeploymentModal.vue
+++ b/apps/client/src/components/DeploymentModal.vue
@@ -24,7 +24,7 @@ const props = defineProps<{
   disabled: boolean
 }>()
 
-const emit = defineEmits<{ close: [] }>()
+const emit = defineEmits<{ close: [], changed: [] }>()
 
 const snackbarStore = useSnackbarStore()
 
@@ -39,13 +39,18 @@ const options: ComputedRef<Omit<DsfrRadioButtonProps, 'modelValue'>[]> = compute
   })),
 )
 
-const deployment = ref<Partial<UpdateDeployment & { id: string }>>(
-  props.deployment ? toDeploymentDraft(props.deployment) : { projectId: props.project.id, autosync: true },
-)
+function toDraft(source?: Deployment) {
+  return source ? toDeploymentDraft(source) : { projectId: props.project.id, autosync: true }
+}
 
-watch(() => props.deployment, (newValue) => {
-  deployment.value = newValue ? toDeploymentDraft(newValue) : { projectId: props.project.id, autosync: true }
-}, { deep: true })
+const deployment = ref<Partial<UpdateDeployment & { id: string }>>(toDraft(props.deployment))
+
+// Also watch `opened`: reopening the same card leaves props.deployment identical,
+// so the form must be rebuilt on open, not only when the selection changes.
+watch([() => props.deployment, () => props.opened], ([newValue, isOpened]) => {
+  if (!isOpened) return
+  deployment.value = toDraft(newValue)
+}, { deep: true, immediate: true })
 
 const deploymentSourcesModel = computed({
   get: () => deployment.value?.deploymentSources ?? [],
@@ -94,6 +99,7 @@ function upsertDeployment() {
   isLoading.value = true
   request
     .then(() => {
+      emit('changed')
       closeModal()
       snackbarStore.setMessage('Déploiement enregistré, opérations en cours en arrière-plan...')
     })
@@ -107,6 +113,7 @@ function deleteDeployment() {
   isDeleting.value = true
   props.project.Deployments.delete(deployment.value.id)
     .then(() => {
+      emit('changed')
       closeModal()
       snackbarStore.setMessage('Suppression du déploiement enregistrée, opérations en cours en arrière-plan...')
     })

--- a/apps/client/src/components/DeploymentResources.vue
+++ b/apps/client/src/components/DeploymentResources.vue
@@ -11,6 +11,8 @@ const props = defineProps<{
   asProfile: 'user' | 'admin'
 }>()
 
+const emit = defineEmits<{ changed: [] }>()
+
 const snackbarStore = useSnackbarStore()
 
 const deployments = ref<Deployment[]>([])
@@ -42,8 +44,14 @@ function openModal(deployment?: Deployment) {
 }
 
 function closeModal() {
-  loadDeployments()
   isModalOpen.value = false
+}
+
+// Deployments changed: refresh the list here and let the parent refresh the
+// environments, whose deployments count drives the deletion warning.
+function onDeploymentChanged() {
+  loadDeployments()
+  emit('changed')
 }
 
 async function loadDeployments() {
@@ -52,9 +60,16 @@ async function loadDeployments() {
 
 onMounted(loadDeployments)
 
-watch([() => props.environments, () => props.repositories], () => {
-  loadDeployments()
-})
+// Keyed on ids, not array refs: a parent reload hands down new arrays with the same content.
+watch(
+  () => [
+    props.environments.map(({ id }) => id).join(','),
+    props.repositories.map(({ id }) => id).join(','),
+  ],
+  () => {
+    loadDeployments()
+  },
+)
 </script>
 
 <template>
@@ -91,6 +106,7 @@ watch([() => props.environments, () => props.repositories], () => {
     :project="props.project"
     :deployment="selectedDeployment"
     :disabled="!canManageDeploy"
+    @changed="onDeploymentChanged"
     @close="closeModal"
   />
 </template>

--- a/apps/client/src/components/EnvironmentForm.vue
+++ b/apps/client/src/components/EnvironmentForm.vue
@@ -3,6 +3,7 @@ import type {
   CleanedCluster,
   CreateEnvironment,
   Environment,
+  EnvironmentWithDeploymentsCount,
 } from '@cpn-console/shared'
 import {
   deleteValidationInput,
@@ -24,7 +25,7 @@ interface OptionType {
 }
 
 const props = withDefaults(defineProps<{
-  environment?: Partial<Omit<Environment, 'updatedAt' | 'createdAt'>>
+  environment?: Partial<Omit<EnvironmentWithDeploymentsCount, 'updatedAt' | 'createdAt'>>
   isEditable?: boolean
   canManage: boolean
   isProjectLocked?: boolean
@@ -343,6 +344,14 @@ watch(localEnvironment.value, () => {
         v-if="isDeletingEnvironment"
         class="fr-mt-4w"
       >
+        <DsfrAlert
+          v-if="localEnvironment.deploymentsCount"
+          data-testid="linkedDeploymentsAlert"
+          class="fr-mb-2w"
+          :description="`Cet environnement est lié à ${localEnvironment.deploymentsCount} déploiement${localEnvironment.deploymentsCount > 1 ? 's' : ''}. Leur suppression sera également effectuée. Cette opération est irréversible.`"
+          type="warning"
+          small
+        />
         <DsfrInput
           v-model="environmentToDelete"
           data-testid="deleteEnvironmentInput"

--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CleanedCluster, Cluster, CreateEnvironment, Environment, Repo, Stage, UpdateEnvironment, Zone } from '@cpn-console/shared'
+import type { CleanedCluster, Cluster, CreateEnvironment, Environment, EnvironmentWithDeploymentsCount, Repo, Stage, UpdateEnvironment, Zone } from '@cpn-console/shared'
 import type { Project } from '@/utils/project-utils.js'
 import type { RepoFormResult } from '@/utils/repository-utils.js'
 import { logger } from '@cpn-console/logger/browser'
@@ -27,7 +27,7 @@ const snackbarStore = useSnackbarStore()
 const stageStore = useStageStore()
 const userStore = useUserStore()
 
-const environments = ref<(Environment & { cluster?: Cluster, zone?: Zone, stage?: Stage })[]>([])
+const environments = ref<(EnvironmentWithDeploymentsCount & { cluster?: Cluster, zone?: Zone, stage?: Stage })[]>([])
 const repositories = ref<(Repo & { source: Source })[]>([])
 const projectUsage = ref<({
   hprod: { cpu: number, gpu: number, memory: number }
@@ -45,7 +45,7 @@ const repositoriesId = 'repositoriesTable'
 const environmentsId = 'environmentsTable'
 const syncFormId = 'syncFormId'
 const selectedRepo = ref<Repo>()
-const selectedEnv = ref<Environment>()
+const selectedEnv = ref<EnvironmentWithDeploymentsCount>()
 const newResource = ref<'repo' | 'env'>()
 const hideEnvs = computed(() => props.asProfile === 'user' && !ProjectAuthorized.ListEnvironments({ projectPermissions: props.project.myPerms }))
 const hideRepos = computed(() => props.asProfile === 'user' && !ProjectAuthorized.ListRepositories({ projectPermissions: props.project.myPerms }))
@@ -139,7 +139,7 @@ const timeAgo = new TimeAgo('fr-FR')
 
 async function reload() {
   environments.value = await props.project.Environments.list()
-    .then(envs => envs.map((environment: Environment) => {
+    .then(envs => envs.map((environment: EnvironmentWithDeploymentsCount) => {
       const cluster = clusterStore.clusters.find(cluster => cluster.id === environment.clusterId)
       const zone = zoneStore.zones.find(zone => zone.id === cluster?.zoneId)
       const stage = stageStore.stages.find(stage => stage.id === environment.stageId)
@@ -210,7 +210,14 @@ async function copyToClipboard(text: string) {
 </script>
 
 <template>
-  <DeploymentResources v-if="canListDeploy" :as-profile="props.asProfile" :environments :repositories :project />
+  <DeploymentResources
+    v-if="canListDeploy"
+    :as-profile="props.asProfile"
+    :environments
+    :repositories
+    :project
+    @changed="reload"
+  />
   <div
     class="grow"
   >

--- a/apps/client/src/utils/project-utils.ts
+++ b/apps/client/src/utils/project-utils.ts
@@ -4,6 +4,7 @@ import type {
   CreateRepositoryBodyV2,
   Deployment,
   Environment,
+  EnvironmentWithDeploymentsCount,
   GetLogsQuery,
   PermissionTarget,
   PluginsUpdateBody,
@@ -83,7 +84,7 @@ export class Project implements ProjectV2 {
   operationsInProgress: Ref<ProjectOperations[]>
   myPerms: bigint
   repositories: Ref<Repo[]>
-  environments: Ref<Environment[]>
+  environments: Ref<EnvironmentWithDeploymentsCount[]>
   deployments: Ref<Deployment[]>
   services: ProjectService[] = []
   lastSuccessProvisionningVersion: string | null

--- a/apps/server-nestjs/src/modules/environment/environment-datastore.service.spec.ts
+++ b/apps/server-nestjs/src/modules/environment/environment-datastore.service.spec.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { PrismaService } from '../infrastructure/database/prisma.service'
 import { EnvironmentDatastoreService } from './environment-datastore.service'
-import { makeCluster, makeEnvironment, makeStage } from './environment-testing.utils'
+import { makeCluster, makeEnvironment, makeEnvironmentWithStageAndCount, makeStage } from './environment-testing.utils'
 
 describe('environmentDatastoreService', () => {
   let module: TestingModule
@@ -41,15 +41,18 @@ describe('environmentDatastoreService', () => {
   })
 
   describe('getEnvironmentsByProjectId', () => {
-    it('should return environments for a project with their stage', async () => {
-      const environments = [makeEnvironment({ projectId: 'project1' })]
+    it('should return environments for a project with their stage and their deployments count', async () => {
+      const environments = [makeEnvironmentWithStageAndCount({ projectId: 'project1', _count: { deployments: 2 } })]
       prisma.environment.findMany.mockResolvedValue(environments)
 
       const result = await service.getEnvironmentsByProjectId('project1')
 
       expect(prisma.environment.findMany).toHaveBeenCalledWith({
         where: { projectId: 'project1' },
-        include: { stage: true },
+        include: {
+          stage: true,
+          _count: { select: { deployments: true } },
+        },
       })
       expect(result).toEqual(environments)
     })

--- a/apps/server-nestjs/src/modules/environment/environment-datastore.service.ts
+++ b/apps/server-nestjs/src/modules/environment/environment-datastore.service.ts
@@ -5,6 +5,8 @@ import { PROD_STAGE_NAME } from './environment.constants'
 
 export type EnvironmentWithCluster = Environment & { cluster: Cluster }
 export type EnvironmentWithStage = Environment & { stage: Stage }
+export type EnvironmentWithStageAndCount = EnvironmentWithStage & { _count: { deployments: number } }
+export type EnvironmentWithDeploymentsCount = EnvironmentWithStage & { deploymentsCount: number }
 
 export interface EnvironmentResourcesSum {
   _sum: {
@@ -25,10 +27,13 @@ export class EnvironmentDatastoreService {
     })
   }
 
-  getEnvironmentsByProjectId(projectId: string): Promise<EnvironmentWithStage[]> {
+  getEnvironmentsByProjectId(projectId: string): Promise<EnvironmentWithStageAndCount[]> {
     return this.prisma.environment.findMany({
       where: { projectId },
-      include: { stage: true },
+      include: {
+        stage: true,
+        _count: { select: { deployments: true } },
+      },
     })
   }
 

--- a/apps/server-nestjs/src/modules/environment/environment-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/environment/environment-testing.utils.ts
@@ -1,5 +1,5 @@
 import type { Cluster, Environment, Project, Stage } from '@prisma/client'
-import type { EnvironmentWithCluster, EnvironmentWithStage } from './environment-datastore.service'
+import type { EnvironmentWithCluster, EnvironmentWithDeploymentsCount, EnvironmentWithStage, EnvironmentWithStageAndCount } from './environment-datastore.service'
 import { faker } from '@faker-js/faker'
 
 export function makeEnvironment(overrides: Partial<Environment> = {}): Environment {
@@ -83,5 +83,19 @@ export function makeEnvironmentWithStage(overrides: Partial<EnvironmentWithStage
   return {
     ...base,
     stage: overrides.stage ?? makeStage({ id: base.stageId }),
+  }
+}
+
+export function makeEnvironmentWithStageAndCount(overrides: Partial<EnvironmentWithStageAndCount> = {}): EnvironmentWithStageAndCount {
+  return {
+    ...makeEnvironmentWithStage(overrides),
+    _count: overrides._count ?? { deployments: 0 },
+  }
+}
+
+export function makeEnvironmentWithDeploymentsCount(overrides: Partial<EnvironmentWithDeploymentsCount> = {}): EnvironmentWithDeploymentsCount {
+  return {
+    ...makeEnvironmentWithStage(overrides),
+    deploymentsCount: overrides.deploymentsCount ?? 0,
   }
 }

--- a/apps/server-nestjs/src/modules/environment/environment.controller.spec.ts
+++ b/apps/server-nestjs/src/modules/environment/environment.controller.spec.ts
@@ -8,7 +8,7 @@ import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { ProjectGuard } from '../infrastructure/permission/project/project.guard'
-import { makeEnvironment, makeEnvironmentWithStage } from './environment-testing.utils'
+import { makeEnvironment, makeEnvironmentWithDeploymentsCount } from './environment-testing.utils'
 import { EnvironmentController } from './environment.controller'
 import { EnvironmentService } from './environment.service'
 
@@ -64,7 +64,7 @@ describe('environmentController', () => {
 
   describe('list', () => {
     it('should call environmentService.listByProjectId with projectId', async () => {
-      const expectedResult = [makeEnvironmentWithStage({ projectId })]
+      const expectedResult = [makeEnvironmentWithDeploymentsCount({ projectId })]
 
       service.listByProjectId.mockResolvedValue(expectedResult)
 

--- a/apps/server-nestjs/src/modules/environment/environment.service.spec.ts
+++ b/apps/server-nestjs/src/modules/environment/environment.service.spec.ts
@@ -14,7 +14,7 @@ import { EnvironmentDatastoreService } from './environment-datastore.service'
 import {
   makeEnvironment,
   makeEnvironmentWithCluster,
-  makeEnvironmentWithStage,
+  makeEnvironmentWithStageAndCount,
 } from './environment-testing.utils'
 import { EnvironmentValidationService } from './environment-validation.service'
 import { EnvironmentService } from './environment.service'
@@ -77,13 +77,14 @@ describe('environmentService', () => {
 
   describe('listByProjectId', () => {
     it('should return environments by projectId', async () => {
-      const environments = [makeEnvironmentWithStage({ id: environmentId, projectId })]
+      const environments = [makeEnvironmentWithStageAndCount({ id: environmentId, projectId, _count: { deployments: 3 } })]
       datastore.getEnvironmentsByProjectId.mockResolvedValue(environments)
 
       const result = await service.listByProjectId(projectId)
 
       expect(datastore.getEnvironmentsByProjectId).toHaveBeenCalledWith(projectId)
-      expect(result).toEqual(environments)
+      const { _count, ...environment } = environments[0]
+      expect(result).toEqual([{ ...environment, deploymentsCount: 3 }])
     })
   })
 

--- a/apps/server-nestjs/src/modules/environment/environment.service.ts
+++ b/apps/server-nestjs/src/modules/environment/environment.service.ts
@@ -1,7 +1,7 @@
 import type { CreateEnvironment, UpdateEnvironment } from '@cpn-console/shared'
 import type { Environment } from '@prisma/client'
 import type { EventLogAction } from '../events/app-events.service'
-import type { EnvironmentWithCluster, EnvironmentWithStage } from './environment-datastore.service'
+import type { EnvironmentWithCluster, EnvironmentWithDeploymentsCount } from './environment-datastore.service'
 import {
   Inject,
   Injectable,
@@ -21,8 +21,12 @@ export class EnvironmentService {
     @Inject(AppEventsService) private readonly appEvents: AppEventsService,
   ) {}
 
-  async listByProjectId(projectId: string): Promise<EnvironmentWithStage[]> {
-    return this.environmentDatastoreService.getEnvironmentsByProjectId(projectId)
+  async listByProjectId(projectId: string): Promise<EnvironmentWithDeploymentsCount[]> {
+    const environments = await this.environmentDatastoreService.getEnvironmentsByProjectId(projectId)
+    return environments.map(({ _count, ...environment }) => ({
+      ...environment,
+      deploymentsCount: _count.deployments,
+    }))
   }
 
   async createEnvironment(projectId: string, environmentToCreate: CreateEnvironment, userId: string, requestId: string): Promise<Environment> {

--- a/packages/shared/src/contracts/environment.ts
+++ b/packages/shared/src/contracts/environment.ts
@@ -5,6 +5,7 @@ import { apiPrefix, apiPrefixV2, contractInstance } from '../api-client.js'
 import {
   CreateEnvironmentSchema,
   EnvironmentSchema,
+  EnvironmentWithDeploymentsCountSchema,
   UpdateEnvironmentSchema,
 } from '../schemas/index.js'
 import { baseHeaders, ErrorSchema } from './_utils.js'
@@ -118,7 +119,7 @@ export const environmentContractV2 = contractInstance.router({
     summary: 'Get environments',
     description: 'Retrieved project environments.',
     responses: {
-      200: EnvironmentSchema.array(),
+      200: EnvironmentWithDeploymentsCountSchema.array(),
       400: ErrorSchema,
       401: ErrorSchema,
       403: ErrorSchema,

--- a/packages/shared/src/schemas/environment.ts
+++ b/packages/shared/src/schemas/environment.ts
@@ -21,6 +21,10 @@ export const EnvironmentSchema = z.object({
   autosync: z.boolean(),
 }).extend(AtDatesToStringExtend)
 
+export const EnvironmentWithDeploymentsCountSchema = EnvironmentSchema.extend({
+  deploymentsCount: z.number().int().gte(0),
+})
+
 export const CreateEnvironmentSchema = EnvironmentSchema.omit({
   id: true,
   createdAt: true,
@@ -36,5 +40,6 @@ export const UpdateEnvironmentSchema = EnvironmentSchema.pick({
 })
 
 export type Environment = Zod.infer<typeof EnvironmentSchema>
+export type EnvironmentWithDeploymentsCount = Zod.infer<typeof EnvironmentWithDeploymentsCountSchema>
 export type CreateEnvironment = Zod.infer<typeof CreateEnvironmentSchema>
 export type UpdateEnvironment = Zod.infer<typeof UpdateEnvironmentSchema>


### PR DESCRIPTION
## Issues liées

Issues numéro: #2472

---------

## Quel est le comportement actuel ?

La suppression d'un environnement supprime en cascade les déploiements qui lui sont rattachés, sans que l'utilisateur en soit averti dans la modale de confirmation.

## Quel est le nouveau comportement ?

La modale de confirmation affiche un avertissement lorsque des déploiements sont liés : « Cet environnement est lié à N déploiement(s). Leur suppression sera également effectuée et est irréversible. » Aucun message si N vaut 0.

Le nombre est porté par la liste des environnements (`deploymentsCount`, via un `_count` Prisma sur la relation) plutôt que calculé côté client à partir de la liste des déploiements : celle-ci exige la permission `ListDeployments`, qu'un utilisateur habilité à gérer les environnements (`ManageEnvironments`) n'a pas forcément. La route environnements est déjà protégée par `ListEnvironments`, donc aucune permission supplémentaire n'est requise.

## Cette PR introduit-elle un breaking change ?

Non. Seule la réponse de `GET /api/v2/projects/:projectId/environments` gagne un champ `deploymentsCount` ; les autres routes sont inchangées.

## Autres informations

Tests unitaires serveur et client mis à jour et passants.
