### PR TITLE
fix(server-nestjs): corrige getRootGroupByName matchant des sous-groupes à mauvais chemin

### DIFF
--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
@@ -250,6 +250,89 @@ describe('getOrCreateSubGroupByName', () => {
   })
 })
 
+describe('getOrCreateGroupByPath', () => {
+  let module: TestingModule
+  let service: KeycloakClientService
+
+  const groupsSearchUrl = `${keycloakUrl}/admin/realms/${projectRealm}/groups`
+  const createGroupUrl = `${keycloakUrl}/admin/realms/${projectRealm}/groups`
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  beforeEach(async () => {
+    module = await createKeycloakClientServiceTestingModule().compile()
+    service = module.get(KeycloakClientService)
+    useTokenEndpoint()
+    await module.init()
+  })
+  afterEach(async () => {
+    await module.close()
+    server.resetHandlers()
+  })
+  afterAll(() => server.close())
+
+  it('should reuse an existing top-level group matching by path', async () => {
+    const projectSlug = 'myproject'
+    server.use(
+      http.get(groupsSearchUrl, () =>
+        HttpResponse.json([{ id: 'root-id', name: projectSlug, path: `/${projectSlug}` }])),
+    )
+
+    const result = await service.getOrCreateGroupByPath(`/${projectSlug}`)
+
+    expect(result.id).toBe('root-id')
+  })
+
+  it('should create a new top-level group when no group exists at the root path', async () => {
+    const projectSlug = 'newproject'
+    const postGroup = vi.fn(async ({ request }) => {
+      const body = await request.json()
+      if (body?.name === projectSlug) {
+        return new HttpResponse(null, {
+          status: 201,
+          headers: { location: `${keycloakUrl}/admin/realms/${projectRealm}/groups/new-id` },
+        })
+      }
+      return HttpResponse.json({ error: 'unexpected' }, { status: 400 })
+    })
+    server.use(
+      // getGroupByPath → getRootGroupByName → find returns only a subgroup at a different path
+      http.get(groupsSearchUrl, () =>
+        HttpResponse.json([{ id: 'sub-id', name: projectSlug, path: '/console/other/newproject' }])),
+      // getOrCreateGroupByPath → getGroupByName returns undefined → falls to getRootGroupByName
+      // getRootGroupByName finds no match by path or name → returns undefined
+      // Then createGroup is called
+      http.post(createGroupUrl, postGroup),
+    )
+
+    const result = await service.getOrCreateGroupByPath(`/${projectSlug}`)
+
+    expect(result.id).toBe('new-id')
+    expect(postGroup).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not reuse a subgroup at a different path as the project root group', async () => {
+    const projectSlug = 'shared-name'
+    server.use(
+      // Keycloak search returns a subgroup at /console/other/shared-name — NOT a root group
+      http.get(groupsSearchUrl, () =>
+        HttpResponse.json([{ id: 'stale-subgroup-id', name: projectSlug, path: '/console/other/shared-name' }])),
+      // The stale subgroup should NOT be used. A new top-level group should be created.
+      http.post(createGroupUrl, async ({ request }) => {
+        const body = await request.json()
+        expect(body).toEqual({ name: projectSlug })
+        return new HttpResponse(null, {
+          status: 201,
+          headers: { location: `${keycloakUrl}/admin/realms/${projectRealm}/groups/fresh-root-id` },
+        })
+      }),
+    )
+
+    const result = await service.getOrCreateGroupByPath(`/${projectSlug}`)
+
+    expect(result.id).toBe('fresh-root-id')
+  })
+})
+
 describe('deleteGroup', () => {
   let module: TestingModule
   let service: KeycloakClientService

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
@@ -83,7 +83,7 @@ export class KeycloakClientService implements OnModuleInit {
 
   private async getRootGroupByName(name: string): Promise<GroupRepresentationWith<'id'> | undefined> {
     const candidates = await this.client.groups.find({ search: name, briefRepresentation: false }) ?? []
-    const match = candidates.find(g => g.path === `/${name}`) ?? candidates.find(g => g.name === name)
+    const match = candidates.find(g => g.path === `/${name}`)
     const parsed = z.object({ id: z.string() }).and(z.record(z.string(), z.unknown())).safeParse(match)
     return parsed.success ? parsed.data : undefined
   }
@@ -186,7 +186,7 @@ export class KeycloakClientService implements OnModuleInit {
         const next = z.object({ id: z.string(), name: z.string() }).safeParse(await this.getOrCreateSubGroupByName(parentId, name))
         if (next.success) current = next.data
       } else {
-        const next = z.object({ id: z.string(), name: z.string() }).safeParse(await this.getGroupByName(name) ?? await this.createGroup(name))
+        const next = z.object({ id: z.string(), name: z.string() }).safeParse(await this.getRootGroupByName(name) ?? await this.createGroup(name))
         if (next.success) current = next.data
       }
       parentId = current?.id


### PR DESCRIPTION
## Issues liées

Closes #2518

---

## Quel est le comportement actuel ?

Lors de l'ajout d'un repo d'infrastructure, l'événement `project.upsert` déclenche `KeycloakService.syncProject` → `getOrCreateGroupByPath('/${project.slug}')`. Deux défauts dans `KeycloakClientService` :

1. `getRootGroupByName` : le fallback `?? candidates.find(g => g.name === name)` sur `groups.find({ search })` (recherche par sous-chaîne à toutes les profondeurs) peut retourner un **sous-groupe à un autre chemin** (ex. `/console/other/myproject`) au lieu du groupe racine `/{slug}`.
2. `getOrCreateGroupByPath` : le chemin de création du segment racine appelle `getGroupByName` (recherche large par nom) au lieu de `getRootGroupByName` (recherche par path).

L'ID de groupe erroné alimente ensuite `getGroupMembers` → `listMembers` → Keycloak répond **« Could not find group by id »**, alors même que le repo GitLab est bien créé (chaque handler plugin est isolé par `capturePluginResult`).

## Quel est le nouveau comportement ?

1. `getRootGroupByName` ne match plus que par path exact `/{name}` (groupes racine uniquement) — suppression du fallback par nom.
2. `getOrCreateGroupByPath` utilise `getRootGroupByName` pour le segment racine avant création.

3 tests unitaires couvrent : réutilisation d'un groupe racine existant (match par path), création d'un groupe racine neuf quand la recherche ne retourne qu'un sous-groupe à chemin différent, non-réutilisation d'un sous-groupe à mauvais chemin comme groupe racine du projet.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Le même correctif existe dans la pile du PR #2520 (commit `016ce4e86b`) ; cette PR l'extraie en PR minimal pour fusion indépendante et rapide. La fusion des deux étant redondante sur ces fichiers, le premier mergé rendra l'autre no-op sur ces lignes.