### PR TITLE
chore(server-nestjs): make msw server listen setup consistent across specs

### DIFF
--- a/apps/server-nestjs/src/modules/vault/vault-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/vault/vault-client.service.spec.ts
@@ -30,7 +30,7 @@ const server = setupServer(
 describe('vault', () => {
   let service: VaultClientService
 
-  beforeAll(() => server.listen())
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
   beforeEach(async () => {
     const config = mockDeep<ConfigType<typeof vaultConfigFactory>>({
       token: 'token',


### PR DESCRIPTION
## Issues liées

N/A — chantier de cohérence interne aux tests.

---

## Quel est le comportement actuel ?

Les 6 specs utilisant msw dans `server-nestjs` déclarent toutes le même cycle de vie (`setupServer` + `listen` / `resetHandlers` / `close`), mais `vault-client.service.spec.ts` est la seule à appeler `server.listen()` sans option. Les 5 autres (gitlab, keycloak ×4, nexus, registry, sonarqube) passent `onUnhandledRequest: 'error'`, qui fait échouer le test sur toute requête non mockée.

## Quel est le nouveau comportement ?

`vault-client.service.spec.ts` passe `server.listen({ onUnhandledRequest: 'error' })` comme toutes les autres specs — même garde contre les requêtes non mockées, comportement inchangé sinon (8/8 tests verts).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Commit unique `0bdbe275`, aucun changement fonctionnel : une ligne de setup de test.