### PR TITLE
fix(server-nestjs): include projectsRootDir in vault techRO policy path

### DIFF
--- a/apps/server-nestjs/src/modules/vault/vault.service.spec.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.service.spec.ts
@@ -1,3 +1,4 @@
+import type { ConfigType } from '@nestjs/config'
 import type { DeepMockProxy } from 'vitest-mock-extended'
 import { faker } from '@faker-js/faker'
 import { Test } from '@nestjs/testing'
@@ -16,6 +17,8 @@ describe('vaultService', () => {
   let service: VaultService
   let datastore: DeepMockProxy<VaultDatastoreService>
   let client: DeepMockProxy<VaultClientService>
+  let vaultConfig: DeepMockProxy<ConfigType<typeof vaultConfigFactory>>
+  let baseConfig: DeepMockProxy<ConfigType<typeof baseConfigFactory>>
 
   beforeEach(async () => {
     datastore = mockDeep<VaultDatastoreService>({
@@ -37,13 +40,16 @@ describe('vaultService', () => {
       delete: vi.fn().mockResolvedValue(undefined),
     })
 
+    vaultConfig = mockDeep<ConfigType<typeof vaultConfigFactory>>({ kvName: 'forge-dso' })
+    baseConfig = mockDeep<ConfigType<typeof baseConfigFactory>>({ projectsRootDir: 'forge' })
+
     const module = await Test.createTestingModule({
       providers: [
         VaultService,
         { provide: VaultClientService, useValue: client },
         { provide: VaultDatastoreService, useValue: datastore },
-        { provide: vaultConfigFactory.KEY, useValue: vaultConfigFactory },
-        { provide: baseConfigFactory.KEY, useValue: baseConfigFactory },
+        { provide: vaultConfigFactory.KEY, useValue: vaultConfig },
+        { provide: baseConfigFactory.KEY, useValue: baseConfig },
       ],
     }).compile()
 
@@ -114,16 +120,21 @@ describe('vaultService', () => {
     expect(client.upsertIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-security`, expect.any(Object))
     expect(client.createIdentityGroupAlias).not.toHaveBeenCalled()
 
-    const policyCalls = client.upsertSysPoliciesAcl.mock.calls as Array<[string, { policy: string }]>
-    expect(policyCalls.find(([name]) => name === `project--${project.slug}--developer`)?.[1].policy)
-      .toBe(`path "${project.slug}/data/*" { capabilities = ["list"] }`)
-    expect(policyCalls.find(([name]) => name === `project--${project.slug}--readonly`)?.[1].policy)
-      .toBe(`path "${project.slug}/data/*" { capabilities = ["list"] }`)
-    expect(policyCalls.find(([name]) => name === `project--${project.slug}--security`)?.[1].policy)
-      .toBe([
+    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--developer`, {
+      policy: `path "${project.slug}/data/*" { capabilities = ["list"] }`,
+    })
+    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--readonly`, {
+      policy: `path "${project.slug}/data/*" { capabilities = ["list"] }`,
+    })
+    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--security`, {
+      policy: [
         `path "${project.slug}/metadata/*" { capabilities = ["list"] }`,
         `path "transit/keys/${project.slug}/*" { capabilities = ["list"] }`,
-      ].join('\n'))
+      ].join('\n'),
+    })
+    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`tech--${project.slug}--ro`, {
+      policy: `path "forge-dso/data/forge/${project.slug}/REGISTRY/ro-robot" { capabilities = ["read"] }`,
+    })
   })
 
   it('should delete project and destroy secrets on event', async () => {

--- a/apps/server-nestjs/src/modules/vault/vault.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.service.ts
@@ -493,8 +493,9 @@ export class VaultService {
   }
 
   async ensureTechReadOnlyPolicy(name: string, projectSlug: string): Promise<void> {
+    const robotSecretPath = generateProjectPath(this.baseConfig.projectsRootDir, `${projectSlug}/REGISTRY/ro-robot`)
     await this.client.upsertSysPoliciesAcl(name, {
-      policy: `path "${this.vaultConfig.kvName}/data/${projectSlug}/REGISTRY/ro-robot" { capabilities = ["read"] }`,
+      policy: `path "${this.vaultConfig.kvName}/data/${robotSecretPath}" { capabilities = ["read"] }`,
     })
   }
 


### PR DESCRIPTION
## Issues liées

Issues numéro: #2523

---------

## Quel est le comportement actuel ?

La politique Vault `tech--<slug>--ro` est générée sans le segment `PROJECTS_ROOT_DIR` (`path "forge-dso/data/<slug>/REGISTRY/ro-robot"`), alors que le module registry écrit le secret du robot Harbor sous `forge-dso/data/<rootDir>/<slug>/REGISTRY/ro-robot`. Le login AppRole reçoit un 403, VSO ne synchronise plus `registry-pull-secret`, et ArgoCD signale « Unable to retrieve some image pull secrets (registry-pull-secret) ». Masqué quand `PROJECTS_ROOT_DIR` est vide.

## Quel est le nouveau comportement ?

`ensureTechReadOnlyPolicy` construit le chemin via `generateProjectPath(this.baseConfig.projectsRootDir, ...)` — la politique autorise désormais le chemin réel d'écriture du secret. La spec du module vault épingle le rendu exact de la politique.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Reprise de la logique de l'implémentation historique `plugins/vault/src/vault-project-api.ts` (qui incluait `projectRootDir`). Analyse complète dans le commentaire d'investigation de l'issue #2523.
