### PR TITLE
refactor(config): normalize all URL env vars via shared urlSchema

### DIFF
--- a/apps/server-nestjs/src/config/argocd.config.ts
+++ b/apps/server-nestjs/src/config/argocd.config.ts
@@ -1,11 +1,11 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
-import { csv, truthySchema } from './config.utils'
+import { csv, truthySchema, urlSchema } from './config.utils'
 
 const argocdFeatureSchema = z.object({
   ARGO_NAMESPACE: z.string().default('argocd'),
-  ARGOCD_URL: z.string().url(),
-  ARGOCD_INTERNAL_URL: z.string().url().optional(),
+  ARGOCD_URL: urlSchema,
+  ARGOCD_INTERNAL_URL: urlSchema.optional(),
   ARGOCD_EXTRA_REPOSITORIES: csv(z.string()),
   DSO_ENV_CHART_VERSION: z.string().default('dso-env-1.6.0'),
   DSO_NS_CHART_VERSION: z.string().default('dso-ns-1.1.5'),

--- a/apps/server-nestjs/src/config/base.config.ts
+++ b/apps/server-nestjs/src/config/base.config.ts
@@ -1,6 +1,6 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
-import { flag, truthySchema } from './config.utils'
+import { flag, truthySchema, urlSchema } from './config.utils'
 
 const baseFeatureSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('production'),
@@ -8,7 +8,7 @@ const baseFeatureSchema = z.object({
   SERVER_HOST: z.string().default('localhost'),
   SERVER_PORT: z.string().transform(Number).default('0'),
   APP_VERSION: z.string().default('unknown'),
-  DB_URL: z.string().url(),
+  DB_URL: urlSchema,
   PROJECTS_ROOT_DIR: z.string().default(''),
 }).transform((raw) => {
   return {

--- a/apps/server-nestjs/src/config/config.utils.spec.ts
+++ b/apps/server-nestjs/src/config/config.utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import z from 'zod'
-import { csv, flag, truthySchema } from './config.utils'
+import { csv, flag, truthySchema, urlSchema } from './config.utils'
 
 describe('config.utils', () => {
   describe('flag', () => {
@@ -20,6 +20,18 @@ describe('config.utils', () => {
     it('falls back to the schema default when missing', () => {
       expect(flag(truthySchema.default('false')).parse(undefined)).toBe(false)
       expect(flag(truthySchema.default('true')).parse(undefined)).toBe(true)
+    })
+  })
+
+  describe('urlSchema', () => {
+    it('normalizes and strips the trailing slash', () => {
+      expect(urlSchema.parse('https://gitlab.internal/')).toBe('https://gitlab.internal')
+      expect(urlSchema.parse('HTTPS://GITLAB.INTERNAL:443')).toBe('https://gitlab.internal')
+    })
+
+    it('keeps path segments and rejects invalid urls', () => {
+      expect(urlSchema.parse('https://gitlab.internal/api/')).toBe('https://gitlab.internal/api')
+      expect(() => urlSchema.parse('not-a-url')).toThrow()
     })
   })
 

--- a/apps/server-nestjs/src/config/config.utils.ts
+++ b/apps/server-nestjs/src/config/config.utils.ts
@@ -67,6 +67,19 @@ export const cronSchema = z
     }
   })
 
+// URL env var: validates, then normalizes (case, dot-segments, default port)
+// and strips the root trailing slash that new URL() keeps — consumers join
+// paths with '/', so a trailing slash would yield double slashes.
+export const urlSchema = z
+  .string()
+  .url()
+  .transform((s) => {
+    const href = new URL(s).href
+    let end = href.length
+    while (end > 0 && href[end - 1] === '/') end--
+    return href.slice(0, end)
+  })
+
 // Shared truthy enum for flag(): 'true'/'false'/'1'/'0'.
 export const truthySchema = z.enum(['true', 'false', '1', '0'])
 

--- a/apps/server-nestjs/src/config/gitlab.config.spec.ts
+++ b/apps/server-nestjs/src/config/gitlab.config.spec.ts
@@ -8,8 +8,8 @@ describe('gitlabConfig', () => {
 
   it('parses a full config', () => {
     vi.stubEnv('GITLAB_TOKEN', 'token')
-    vi.stubEnv('GITLAB_URL', 'https://gitlab.internal')
-    vi.stubEnv('GITLAB_INTERNAL_URL', 'https://gitlab.internal:8080')
+    vi.stubEnv('GITLAB_URL', 'https://gitlab.internal/')
+    vi.stubEnv('GITLAB_INTERNAL_URL', 'https://gitlab.internal:8080/')
     vi.stubEnv('PROJECTS_ROOT_DIR', 'forge-test/projects')
     vi.stubEnv('GITLAB__SECRET_EXPOSE_INTERNAL_URL', '1')
     expect(gitlabConfigFactory()).toMatchObject({
@@ -24,7 +24,7 @@ describe('gitlabConfig', () => {
 
   it('falls back to public url when internal url is absent', () => {
     vi.stubEnv('GITLAB_TOKEN', 'token')
-    vi.stubEnv('GITLAB_URL', 'https://gitlab.internal')
+    vi.stubEnv('GITLAB_URL', 'https://gitlab.internal/')
     vi.stubEnv('PROJECTS_ROOT_DIR', 'forge-test/projects')
     vi.stubEnv('GITLAB__SECRET_EXPOSE_INTERNAL_URL', '1')
     const cfg = gitlabConfigFactory()

--- a/apps/server-nestjs/src/config/gitlab.config.ts
+++ b/apps/server-nestjs/src/config/gitlab.config.ts
@@ -2,10 +2,20 @@ import { registerAs } from '@nestjs/config'
 import z from 'zod'
 import { truthySchema } from './config.utils'
 
+// new URL() normalizes case/dot-segments but keeps a root trailing slash;
+// gitbeaker joins host + "api/v4" with "/", so that slash yields "//api/v4".
+// Strip trailing slashes linearly (no regex) to avoid any backtracking cost.
+const normalizeUrl = (s: string) => {
+  const href = new URL(s).href
+  let end = href.length
+  while (end > 0 && href[end - 1] === '/') end--
+  return href.slice(0, end)
+}
+
 const gitlabFeatureSchema = z.object({
   GITLAB_TOKEN: z.string().min(1),
-  GITLAB_URL: z.string().url(),
-  GITLAB_INTERNAL_URL: z.string().url().optional(),
+  GITLAB_URL: z.string().url().transform(normalizeUrl),
+  GITLAB_INTERNAL_URL: z.string().url().transform(normalizeUrl).optional(),
   GITLAB_MIRROR_TOKEN_EXPIRATION_DAYS: z.coerce.number().int().positive().default(365),
   GITLAB__SECRET_EXPOSE_INTERNAL_URL: truthySchema.default('false').transform(v => v === 'true' || v === '1'),
   PROJECTS_ROOT_DIR: z.string().min(1),

--- a/apps/server-nestjs/src/config/gitlab.config.ts
+++ b/apps/server-nestjs/src/config/gitlab.config.ts
@@ -1,21 +1,11 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
-import { truthySchema } from './config.utils'
-
-// new URL() normalizes case/dot-segments but keeps a root trailing slash;
-// gitbeaker joins host + "api/v4" with "/", so that slash yields "//api/v4".
-// Strip trailing slashes linearly (no regex) to avoid any backtracking cost.
-const normalizeUrl = (s: string) => {
-  const href = new URL(s).href
-  let end = href.length
-  while (end > 0 && href[end - 1] === '/') end--
-  return href.slice(0, end)
-}
+import { truthySchema, urlSchema } from './config.utils'
 
 const gitlabFeatureSchema = z.object({
   GITLAB_TOKEN: z.string().min(1),
-  GITLAB_URL: z.string().url().transform(normalizeUrl),
-  GITLAB_INTERNAL_URL: z.string().url().transform(normalizeUrl).optional(),
+  GITLAB_URL: urlSchema,
+  GITLAB_INTERNAL_URL: urlSchema.optional(),
   GITLAB_MIRROR_TOKEN_EXPIRATION_DAYS: z.coerce.number().int().positive().default(365),
   GITLAB__SECRET_EXPOSE_INTERNAL_URL: truthySchema.default('false').transform(v => v === 'true' || v === '1'),
   PROJECTS_ROOT_DIR: z.string().min(1),

--- a/apps/server-nestjs/src/config/harbor.config.ts
+++ b/apps/server-nestjs/src/config/harbor.config.ts
@@ -1,6 +1,6 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
-import { cronSchema } from './config.utils'
+import { cronSchema, urlSchema } from './config.utils'
 
 const ruleTemplateSchema = z.enum([
   'always',
@@ -13,8 +13,8 @@ const ruleTemplateSchema = z.enum([
 export type RuleTemplate = z.infer<typeof ruleTemplateSchema>
 
 const harborFeatureSchema = z.object({
-  HARBOR_URL: z.string().url(),
-  HARBOR_INTERNAL_URL: z.string().url().optional(),
+  HARBOR_URL: urlSchema,
+  HARBOR_INTERNAL_URL: urlSchema.optional(),
   HARBOR_ADMIN: z.string().min(1),
   HARBOR_ADMIN_PASSWORD: z.string().min(1),
   HARBOR_RULE_TEMPLATE: ruleTemplateSchema.optional(),

--- a/apps/server-nestjs/src/config/keycloak.config.ts
+++ b/apps/server-nestjs/src/config/keycloak.config.ts
@@ -1,5 +1,6 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
+import { urlSchema } from './config.utils'
 
 const keycloakFeatureSchema = z.object({
   KEYCLOAK_PROTOCOL: z.enum(['http', 'https']).default('https'),
@@ -10,7 +11,7 @@ const keycloakFeatureSchema = z.object({
   KEYCLOAK_ADMIN: z.string().min(1),
   KEYCLOAK_ADMIN_PASSWORD: z.string().min(1),
   KEYCLOAK_ADMIN_CLIENT_ID: z.string().default('admin-cli'),
-  KEYCLOAK_REDIRECT_URI: z.string().url(),
+  KEYCLOAK_REDIRECT_URI: urlSchema,
   KEYCLOAK_JWKS_CACHE_TTL_MS: z.coerce.number().int().positive().default(300_000),
   KEYCLOAK_JWKS_TIMEOUT_MS: z.coerce.number().int().positive().default(5_000),
   KEYCLOAK_OPENID_CONFIGURATION_CACHE_TTL_MS: z.coerce.number().int().positive().default(300_000),

--- a/apps/server-nestjs/src/config/nexus.config.ts
+++ b/apps/server-nestjs/src/config/nexus.config.ts
@@ -1,10 +1,10 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
-import { truthySchema } from './config.utils'
+import { truthySchema, urlSchema } from './config.utils'
 
 const nexusFeatureSchema = z.object({
-  NEXUS_URL: z.string().url(),
-  NEXUS_INTERNAL_URL: z.string().url().optional(),
+  NEXUS_URL: urlSchema,
+  NEXUS_INTERNAL_URL: urlSchema.optional(),
   NEXUS_ADMIN: z.string().min(1),
   NEXUS_ADMIN_PASSWORD: z.string().min(1),
   NEXUS__SECRET_EXPOSE_INTERNAL_URL: truthySchema.default('false').transform(v => v === 'true' || v === '1'),

--- a/apps/server-nestjs/src/config/observability.config.ts
+++ b/apps/server-nestjs/src/config/observability.config.ts
@@ -1,8 +1,9 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
+import { urlSchema } from './config.utils'
 
 const observabilityFeatureSchema = z.object({
-  GRAFANA_URL: z.string().url(),
+  GRAFANA_URL: urlSchema,
   DSO_OBSERVABILITY_CHART_VERSION: z.string().min(1),
 }).transform(raw => ({
   grafanaUrl: raw.GRAFANA_URL,

--- a/apps/server-nestjs/src/config/service-chain.config.ts
+++ b/apps/server-nestjs/src/config/service-chain.config.ts
@@ -1,10 +1,10 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
-import { truthySchema } from './config.utils'
+import { truthySchema, urlSchema } from './config.utils'
 
 const serviceChainFeatureSchema = z.object({
-  OPENCDS_URL: z.string().url(),
-  OPENCDS_INTERNAL_URL: z.string().url().optional(),
+  OPENCDS_URL: urlSchema,
+  OPENCDS_INTERNAL_URL: urlSchema.optional(),
   OPENCDS_API_TOKEN: z.string().min(1),
   OPENCDS_API_TLS_REJECT_UNAUTHORIZED: truthySchema.default('true').transform(v => v === 'true' || v === '1'),
 }).transform((raw) => {

--- a/apps/server-nestjs/src/config/sonarqube.config.ts
+++ b/apps/server-nestjs/src/config/sonarqube.config.ts
@@ -1,9 +1,10 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
+import { urlSchema } from './config.utils'
 
 const sonarqubeFeatureSchema = z.object({
-  SONARQUBE_URL: z.string().url(),
-  SONARQUBE_INTERNAL_URL: z.string().url().optional(),
+  SONARQUBE_URL: urlSchema,
+  SONARQUBE_INTERNAL_URL: urlSchema.optional(),
   SONAR_API_TOKEN: z.string().min(1),
 }).transform(raw => ({
   url: raw.SONARQUBE_URL,

--- a/apps/server-nestjs/src/config/vault.config.ts
+++ b/apps/server-nestjs/src/config/vault.config.ts
@@ -1,10 +1,11 @@
 import { registerAs } from '@nestjs/config'
 import z from 'zod'
+import { urlSchema } from './config.utils'
 
 const vaultFeatureSchema = z.object({
   VAULT_TOKEN: z.string().min(1),
-  VAULT_URL: z.string().url(),
-  VAULT_INTERNAL_URL: z.string().url().optional(),
+  VAULT_URL: urlSchema,
+  VAULT_INTERNAL_URL: urlSchema.optional(),
   VAULT_KV_NAME: z.string().default('forge-dso'),
 }).transform(raw => ({
   token: raw.VAULT_TOKEN,

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -218,7 +218,7 @@ export class GitlabClientService {
     const projectGroup = await this.getOrCreateProjectSubGroup(subGroupPath)
     const urlBase = this.config.internalUrl ?? this.config.url
     if (!urlBase) throw new Error('GITLAB_URL is required')
-    return `${urlBase}/${projectGroup.full_path}/${repoName}.git`
+    return new URL(`${projectGroup.full_path}/${repoName}.git`, urlBase).toString()
   }
 
   private async getOrCreateRepo(subGroupPath: string, ciConfigPath?: string) {

--- a/apps/server-nestjs/src/modules/infrastructure/auth/keycloak-secret-provider/keycloak-secret-provider.service.ts
+++ b/apps/server-nestjs/src/modules/infrastructure/auth/keycloak-secret-provider/keycloak-secret-provider.service.ts
@@ -5,12 +5,13 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { JwtSecretRequestType } from '@nestjs/jwt'
 import { z } from 'zod'
+import { urlSchema } from '../../../../config/config.utils'
 import { keycloakConfigFactory } from '../../../../config/keycloak.config'
 import { createKeycloakSecretProviderOpenIdConfigurationCacheKey, createKeycloakSecretProviderPublicKeyCacheKey } from './keycloak-secret-provider.utils'
 
 const OpenidConfigurationSchema = z.object({
-  issuer: z.string().url(),
-  jwks_uri: z.string().url(),
+  issuer: urlSchema,
+  jwks_uri: urlSchema,
 })
 
 type OpenidConfiguration = z.infer<typeof OpenidConfigurationSchema>

--- a/apps/server-nestjs/src/modules/observability/observability.utils.ts
+++ b/apps/server-nestjs/src/modules/observability/observability.utils.ts
@@ -1,6 +1,7 @@
 import type { ProjectWithDetails } from './observability-datastore.service'
 import { specificallyDisabled } from '@cpn-console/hooks'
 import { compressUUID, getPermsByUserRoles, ProjectAuthorized } from '@cpn-console/shared'
+import { urlSchema } from '../../config/config.utils'
 import { stringify } from 'yaml'
 import z from 'zod'
 import {
@@ -201,7 +202,7 @@ const observabilityChartSchema = z.object({
   dependencies: z.array(z.object({
     name: z.string(),
     version: z.string(),
-    repository: z.string().url(),
+    repository: urlSchema,
   })),
 })
 


### PR DESCRIPTION
## Issues liées

Closes #2524

---------

## Quel est le comportement actuel ?

La création de groupe / sous-groupe / dépôt GitLab échoue avec une erreur `GitbeakerRequestError: Internal Server Error` (HTTP 500) sur `POST /api/v4/groups` lorsque `GITLAB_URL` (ou `GITLAB_INTERNAL_URL`) se termine par un slash. gitbeaker construit l'URL de base en concaténant `host + "api" + "v4"` avec `/`, produisant `…fr//api/v4` (double slash) que le webservice GitLab ne route pas. Le même risque existe pour toutes les URLs injectées par variable d'environnement.

## Quel est le nouveau comportement ?

Une normalisation d'URL partagée (`urlSchema` dans `config.utils.ts`) est appliquée à **toutes** les variables d'environnement de type URL des schémas de configuration : `new URL(s).href` normalise la casse, les dot-segments et le port par défaut, puis le slash final (que `new URL()` conserve) est retiré. Couvre les 17 variables URL de `src/config/` (argocd, base, gitlab, harbor, keycloak, nexus, observability, service-chain, sonarqube, vault) ainsi que les champs URL hors config (configuration OpenID Keycloak, dépôt Helm observability). Les logiques locales (`.replace`, `normalizeUrl` GitLab) sont supprimées. Tests de régression ajoutés dans `config.utils.spec.ts`.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Indépendant de #2529 (collision 409 sur le nom d'utilisateur).