### PR TITLE
fix(server-nestjs): purge argocd values files on project delete

### DIFF
--- a/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
@@ -37,7 +37,6 @@ describe('argoCDService', () => {
     gitlab = mockDeep<GitlabClientService>()
     vault = mockDeep<VaultClientService>()
     argocdConfig = mockDeep<ConfigType<typeof argocdConfigFactory>>({
-      enabled: true,
       namespace: 'argocd',
       url: 'https://argocd.internal',
       internalUrl: undefined,
@@ -120,6 +119,103 @@ describe('argoCDService', () => {
       gitlab.getOrCreateInfraGroupRepo.mockRejectedValue(error)
 
       const result = await service.handleUpsert(mockProject)
+
+      expect(result).toEqual({
+        argocd: expect.objectContaining({
+          status: 'KO',
+          message: 'GitLab unreachable',
+          executionTime: expect.any(Number),
+          error,
+        }),
+      })
+    })
+  })
+
+  describe('handleDelete', () => {
+    it('should delete every project values file in every zone', async () => {
+      const mockProject = makeProjectWithDetails({
+        slug: 'project-1',
+        name: 'Project 1',
+        environments: [
+          makeProjectEnvironment({ name: 'dev', cluster: { id: 'c1', label: 'cluster-1', zone: { slug: 'zone-1' } } }),
+        ],
+        repositories: [makeProjectRepository({ internalRepoName: 'infra-repo', isInfra: true })],
+        deployments: [],
+      })
+
+      const zone1InfraProject = makeProjectSchema({ id: 100, http_url_to_repo: 'https://gitlab.internal/infra-1' })
+      const zone2InfraProject = makeProjectSchema({ id: 200, http_url_to_repo: 'https://gitlab.internal/infra-2' })
+      // The project has no environment left in zone-2, its leftovers must still be purged.
+      datastore.getAllZoneSlugs.mockResolvedValue(['zone-1', 'zone-2'])
+      gitlab.getOrCreateInfraGroupRepo.mockImplementation(async zoneSlug =>
+        zoneSlug === 'zone-1' ? zone1InfraProject : zone2InfraProject,
+      )
+      gitlab.listFiles.mockImplementation(async repo => repo.id === 100
+        ? [
+            makeRepositoryTreeSchema({ name: 'values.yaml', path: 'Project 1/cluster-1/dev/values.yaml' }),
+            makeRepositoryTreeSchema({ name: 'README.md', path: 'Project 1/README.md' }),
+          ]
+        : [
+            makeRepositoryTreeSchema({ name: 'values.yaml', path: 'Project 1/cluster-2/prod/values.yaml' }),
+          ])
+
+      const result = await service.handleDelete(mockProject)
+
+      expect(result).toEqual({
+        argocd: expect.objectContaining({ status: 'OK' }),
+      })
+
+      expect(gitlab.generateCreateOrUpdateAction).not.toHaveBeenCalled()
+      expect(gitlab.listFiles).toHaveBeenCalledWith(zone1InfraProject, { path: 'Project 1/', recursive: true })
+      expect(gitlab.listFiles).toHaveBeenCalledWith(zone2InfraProject, { path: 'Project 1/', recursive: true })
+      expect(gitlab.maybeCreateCommit).toHaveBeenCalledTimes(2)
+      expect(gitlab.maybeCreateCommit).toHaveBeenCalledWith(
+        zone1InfraProject,
+        'ci: :robot_face: Delete project-1',
+        [{ action: 'delete', filePath: 'Project 1/cluster-1/dev/values.yaml' }],
+      )
+      expect(gitlab.maybeCreateCommit).toHaveBeenCalledWith(
+        zone2InfraProject,
+        'ci: :robot_face: Delete project-1',
+        [{ action: 'delete', filePath: 'Project 1/cluster-2/prod/values.yaml' }],
+      )
+    })
+
+    it('should not commit when values files are already absent', async () => {
+      const mockProject = makeProjectWithDetails({
+        slug: 'project-1',
+        name: 'Project 1',
+        environments: [
+          makeProjectEnvironment({ name: 'dev', cluster: { id: 'c1', label: 'cluster-1', zone: { slug: 'zone-1' } } }),
+        ],
+        repositories: [],
+        deployments: [],
+      })
+
+      gitlab.getOrCreateInfraGroupRepo.mockResolvedValue(makeProjectSchema({ id: 100 }))
+      gitlab.listFiles.mockResolvedValue([])
+
+      const result = await service.handleDelete(mockProject)
+
+      expect(result).toEqual({
+        argocd: expect.objectContaining({ status: 'OK' }),
+      })
+      expect(gitlab.maybeCreateCommit).not.toHaveBeenCalled()
+    })
+
+    it('should return KO result when the cleanup throws', async () => {
+      const mockProject = makeProjectWithDetails({
+        slug: 'project-1',
+        name: 'Project 1',
+        environments: [],
+        repositories: [],
+        deployments: [],
+      })
+
+      const error = new Error('GitLab unreachable')
+      gitlab.getOrCreateInfraGroupRepo.mockRejectedValue(error)
+
+      const result = await service.handleDelete(mockProject)
 
       expect(result).toEqual({
         argocd: expect.objectContaining({

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -73,8 +73,63 @@ export class ArgoCDService {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.log(`Handling a project delete event for ${project.slug}`)
-    await this.ensureProject(project)
-    this.logger.log(`ArgoCD sync completed for project ${project.slug}`)
+    await this.purgeZones(project)
+    this.logger.log(`ArgoCD cleanup completed for project ${project.slug}`)
+  }
+
+  @StartActiveSpan()
+  private async purgeZones(project: ProjectWithDetails): Promise<void> {
+    const span = trace.getActiveSpan()
+    span?.setAttribute('project.slug', project.slug)
+    // Purge every zone, not only those with a current environment, so leftover
+    // values files are removed even from zones the project no longer deploys to.
+    const zones = await this.datastore.getAllZoneSlugs()
+    span?.setAttribute('argocd.zones.count', zones.length)
+    this.logger.verbose(`Purging ArgoCD zones for project ${project.slug} (count=${zones.length})`)
+    await Promise.all(zones.map(zoneSlug => this.purgeZone(project, zoneSlug)))
+  }
+
+  @StartActiveSpan()
+  private async purgeZone(project: ProjectWithDetails, zoneSlug: string): Promise<void> {
+    const span = trace.getActiveSpan()
+    span?.setAttribute('project.slug', project.slug)
+    const infraProject = await this.gitlab.getOrCreateInfraGroupRepo(zoneSlug)
+    span?.setAttributes({
+      'argocd.repo.id': infraProject.id,
+      'argocd.repo.path': infraProject.path_with_namespace,
+      'zone.slug': zoneSlug,
+    })
+
+    const actions = await this.generateDeleteProjectActions(project, infraProject, zoneSlug)
+
+    span?.setAttribute('argocd.repo.actions.count', actions.length)
+    if (actions.length === 0) {
+      this.logger.verbose(`No ArgoCD files to delete for project ${project.slug} in zone ${zoneSlug}`)
+      return
+    }
+
+    this.logger.log(`Deleting ArgoCD files for project ${project.slug} in zone ${zoneSlug} (actions=${actions.length})`)
+    await this.gitlab.maybeCreateCommit(infraProject, `ci: :robot_face: Delete ${project.slug}`, actions)
+  }
+
+  private async generateDeleteProjectActions(
+    project: ProjectWithDetails,
+    infraProject: CondensedProjectSchema,
+    zoneSlug: string,
+  ): Promise<CommitAction[]> {
+    const projectPrefix = `${project.name}/`
+    const existingFiles = await this.gitlab.listFiles(infraProject, {
+      path: projectPrefix,
+      recursive: true,
+    })
+
+    const actions = existingFiles
+      .filter(existingFile => existingFile.name === 'values.yaml' && existingFile.path.startsWith(projectPrefix))
+      .map(existingFile => ({ action: 'delete', filePath: existingFile.path } satisfies CommitAction))
+
+    this.logger.verbose(`Computed ArgoCD delete actions for project ${project.slug} in zone ${zoneSlug} (actions=${actions.length})`)
+
+    return actions
   }
 
   // @Cron(CronExpression.EVERY_HOUR)


### PR DESCRIPTION
## Issues liées

Issues numéro: #2528

---------

## Quel est le comportement actuel ?

Sur `project.delete`, le module argocd exécute la même réconciliation que sur un upsert : les `values.yaml` du projet sont recommités dans le dépôt d'infra au lieu d'être supprimés. Le hook remonte `OK` et ArgoCD continue de déployer le projet archivé.

## Quel est le nouveau comportement ?

`cleanupProject` purge au lieu de réconcilier : parcours de toutes les zones (y compris celles sans environnement restant) et suppression de chaque `values.yaml` sous `<project.name>/`. Idempotent si les fichiers sont déjà absents. Tests unitaires ajoutés sur `handleDelete`.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Sans objet.
