### PR TITLE
fix(gitlab): return existing user on 409 instead of failing sync

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
@@ -917,6 +917,37 @@ describe('gitlab-client', () => {
         skipConfirmation: true,
       }))
     })
+
+    it('should return the existing user on 409 (already auto-provisioned via OIDC)', async () => {
+      const email = 'user@example.com'
+      const username = 'user'
+      const name = 'User Name'
+      const existing = makeExpandedUserSchema({ id: 2, email, username })
+
+      gitlabApi.Users.create.mockRejectedValueOnce(
+        makeGitbeakerRequestError({ status: 409, description: 'Username has already been taken' }),
+      )
+      const allMock = gitlabApi.Users.all as MockedFunction<typeof gitlabApi.Users.all>
+      allMock.mockResolvedValueOnce([existing])
+
+      const result = await service.createUser({ email, username, name })
+
+      expect(result).toEqual(existing)
+      expect(gitlabApi.Users.create).toHaveBeenCalledTimes(1)
+    })
+
+    it('should propagate a non-collision error', async () => {
+      const email = 'user@example.com'
+      const username = 'user'
+      const name = 'User Name'
+
+      gitlabApi.Users.create.mockRejectedValue(
+        makeGitbeakerRequestError({ status: 500, description: 'Internal Server Error' }),
+      )
+
+      await expect(service.createUser({ email, username, name })).rejects.toThrow()
+      expect(gitlabApi.Users.create).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('commitMirror', () => {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -404,13 +404,24 @@ export class GitlabClientService {
 
   async createUser(user: EditUserOptions) {
     this.logger.log(`Creating a GitLab user (email=${user.email}, username=${user.username})`)
-    return await this.client.Users.create({
-      ...user,
-      canCreateGroup: false,
-      forceRandomPassword: true,
-      projectsLimit: 0,
-      skipConfirmation: true,
-    }) as UserSchema
+    try {
+      return await this.client.Users.create({
+        ...user,
+        canCreateGroup: false,
+        forceRandomPassword: true,
+        projectsLimit: 0,
+        skipConfirmation: true,
+      }) as UserSchema
+    } catch (error) {
+      // GitLab auto-provisions users via OIDC, so a 409 means the user already
+      // exists (email index race in getUserByEmail). Return it instead of failing.
+      if (error instanceof GitbeakerRequestError && error.cause?.description?.includes('has already been taken')) {
+        const existing = user.email ? await this.getUserByEmail(user.email) : null
+        if (existing) return existing as UserSchema
+        throw error
+      }
+      throw error
+    }
   }
 
   async upsertUser(


### PR DESCRIPTION
## Issues liées

Closes #2529

---------

## Quel est le comportement actuel ?

Lors de la réconciliation GitLab (`upsertUser` → `createUser`), un 409 `Username has already been taken` interrompt la synchronisation du projet : `createUser` lève une exception et aucun membre n'est ajouté pour ce projet.

## Quel est le nouveau comportement ?

`createUser` capture le `GitbeakerRequestError` dont `cause.description` contient `has already been taken`, puis renvoie l'utilisateur déjà existant (résolu par `getUserByEmail`) au lieu de propager l'erreur. La réconciliation se termine normalement.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

GitLab auto-provisionne les utilisateurs via OIDC : un 409 sur `createUser` signifie que l'utilisateur existe déjà (course sur l'index e-mail dans `getUserByEmail`). Indépendant de #2524 / #2526 (erreur 500 `//api/v4` due au slash final de `GITLAB_URL`).
