### PR TITLE
fix(keycloak): preserve full path when creating role groups

### DIFF
--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
@@ -184,18 +184,19 @@ describe('getOrCreateSubGroupByName', () => {
     server.use(
       http.get(childrenUrl, ({ params }) => {
         expect(params.parentId).toBe('parent-id')
-        return HttpResponse.json([{ id: 'sub-id', name: 'sub' }])
+        return HttpResponse.json([{ id: 'sub-id', name: 'sub', path: '/parent/sub' }])
       }),
     )
 
     const result = await service.getOrCreateSubGroupByName('parent-id', 'sub')
 
-    expect(result).toMatchObject({ id: 'sub-id', name: 'sub' })
+    expect(result).toMatchObject({ id: 'sub-id', name: 'sub', path: '/parent/sub' })
   })
 
-  it('should create the subgroup when it does not exist', async () => {
+  it('should create the subgroup and re-fetch its representation when it does not exist', async () => {
     server.use(
-      http.get(childrenUrl, () => HttpResponse.json([])),
+      http.get(childrenUrl, () => HttpResponse.json([]), { once: true }),
+      http.get(childrenUrl, () => HttpResponse.json([{ id: 'created-id', name: 'sub', path: '/parent/sub' }])),
       http.post(childrenUrl, async ({ request, params }) => {
         expect(params.parentId).toBe('parent-id')
         expect(await request.json()).toEqual({ name: 'sub' })
@@ -208,13 +209,13 @@ describe('getOrCreateSubGroupByName', () => {
 
     const result = await service.getOrCreateSubGroupByName('parent-id', 'sub')
 
-    expect(result).toEqual({ id: 'created-id', name: 'sub' })
+    expect(result).toEqual({ id: 'created-id', name: 'sub', path: '/parent/sub' })
   })
 
   it('should re-fetch the subgroup when a concurrent creation causes a 409', async () => {
     server.use(
       http.get(childrenUrl, () => HttpResponse.json([]), { once: true }),
-      http.get(childrenUrl, () => HttpResponse.json([{ id: 'concurrent-id', name: 'sub' }])),
+      http.get(childrenUrl, () => HttpResponse.json([{ id: 'concurrent-id', name: 'sub', path: '/parent/sub' }])),
       http.post(childrenUrl, () =>
         HttpResponse.json({ errorMessage: 'Sibling group named \'sub\' already exists.' }, { status: 409 })),
     )

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
@@ -14,6 +14,7 @@ import { keycloakConfigFactory } from '../../config/keycloak.config'
 import { getErrorResponseStatus } from '../../utils/http.utils'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { ADMIN_AUTH_REALM, ADMIN_TOKEN_REFRESH_INTERVAL_MS, CONSOLE_GROUP_NAME, PASSWORD_GRANT_TYPE, REFRESH_TOKEN_GRANT_TYPE, SUBGROUPS_PAGINATE_QUERY_MAX } from './keycloak.constants'
+import { joinGroupPath, splitGroupPath } from './keycloak.utils'
 
 export const KEYCLOAK_ADMIN_CLIENT = Symbol('KEYCLOAK_ADMIN_CLIENT')
 
@@ -52,7 +53,7 @@ export class KeycloakClientService implements OnModuleInit {
   }
 
   async getGroupByPath(path: string): Promise<GroupRepresentation | undefined> {
-    const parts = path.split('/').filter(Boolean)
+    const parts = splitGroupPath(path)
     this.logger.verbose(`Resolving Keycloak group path ${path} (depth=${parts.length})`)
     let current: GroupRepresentationWith<'id'> | undefined
     if (parts.length === 0) return undefined
@@ -168,7 +169,7 @@ export class KeycloakClientService implements OnModuleInit {
 
   async getOrCreateGroupByPath(path: string) {
     const span = trace.getActiveSpan()
-    span?.setAttribute('group.path.depth', path.split('/').filter(Boolean).length)
+    span?.setAttribute('group.path.depth', splitGroupPath(path).length)
     this.logger.verbose(`Ensuring Keycloak group path exists: ${path}`)
     const existingGroup = await this.getGroupByPath(path)
     if (existingGroup) {
@@ -176,7 +177,7 @@ export class KeycloakClientService implements OnModuleInit {
       return existingGroup
     }
 
-    const parts = path.split('/').filter(Boolean)
+    const parts = splitGroupPath(path)
     let parentId: string | undefined
     let current: GroupRepresentationWith<'id' | 'name'> | undefined
 
@@ -238,16 +239,16 @@ export class KeycloakClientService implements OnModuleInit {
   }
 
   async getOrCreateRoleGroup(
-    consoleGroup: GroupRepresentationWith<'id' | 'name'>,
+    consoleGroup: GroupRepresentationWith<'id' | 'name' | 'path'>,
     oidcGroup: string,
   ) {
     const span = trace.getActiveSpan()
     span?.setAttributes({
       'keycloak.group.id': consoleGroup.id,
       'role.oidc_group.present': !!oidcGroup,
-      'role.oidc_group.depth': oidcGroup.split('/').filter(Boolean).length,
+      'role.oidc_group.depth': splitGroupPath(oidcGroup).length,
     })
-    const parts = oidcGroup.split('/').filter(Boolean)
+    const parts = splitGroupPath(oidcGroup)
     if (parts.length === 0) {
       throw new Error(`Invalid oidcGroup for project role: "${oidcGroup}"`)
     }
@@ -264,7 +265,7 @@ export class KeycloakClientService implements OnModuleInit {
       }).parse(await this.getOrCreateSubGroupByName(current.id, name))
     }
 
-    return { ...current, path: `/${consoleGroup.name}/${parts.join('/')}` } satisfies GroupRepresentation
+    return { ...current, path: joinGroupPath(consoleGroup.path, ...parts) } satisfies GroupRepresentation
   }
 
   async getOrCreateEnvironmentGroups(consoleGroup: GroupRepresentationWith<'id'>, environment: ProjectWithDetails['environments'][number]) {

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
@@ -1,11 +1,10 @@
 import type KcAdminClient from '@keycloak/keycloak-admin-client'
-import type GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation'
 import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation'
 import type { Credentials } from '@keycloak/keycloak-admin-client/lib/utils/auth'
 import type { OnModuleInit } from '@nestjs/common'
 import type { ConfigType } from '@nestjs/config'
 import type { ProjectWithDetails } from './keycloak-datastore.service'
-import type { GroupRepresentationWith } from './keycloak.utils'
+import type { GroupRepresentationWith, GroupRepresentationWithIdNamePath } from './keycloak.utils'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { Interval } from '@nestjs/schedule'
 import { trace } from '@opentelemetry/api'
@@ -14,7 +13,7 @@ import { keycloakConfigFactory } from '../../config/keycloak.config'
 import { getErrorResponseStatus } from '../../utils/http.utils'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { ADMIN_AUTH_REALM, ADMIN_TOKEN_REFRESH_INTERVAL_MS, CONSOLE_GROUP_NAME, PASSWORD_GRANT_TYPE, REFRESH_TOKEN_GRANT_TYPE, SUBGROUPS_PAGINATE_QUERY_MAX } from './keycloak.constants'
-import { joinGroupPath, splitGroupPath } from './keycloak.utils'
+import { groupSchema, splitGroupPath } from './keycloak.utils'
 
 export const KEYCLOAK_ADMIN_CLIENT = Symbol('KEYCLOAK_ADMIN_CLIENT')
 
@@ -45,17 +44,18 @@ export class KeycloakClientService implements OnModuleInit {
   }
 
   @StartActiveSpan()
-  async getGroupByName(name: string): Promise<GroupRepresentation | undefined> {
+  async getGroupByName(name: string): Promise<GroupRepresentationWithIdNamePath | undefined> {
     const span = trace.getActiveSpan()
     span?.setAttribute('group.name', name)
     const groups = await this.client.groups.find({ search: name, briefRepresentation: false }) ?? []
-    return groups.find(g => g.name === name)
+    const parsed = groupSchema.safeParse(groups.find(g => g.name === name))
+    return parsed.success ? parsed.data : undefined
   }
 
-  async getGroupByPath(path: string): Promise<GroupRepresentation | undefined> {
+  async getGroupByPath(path: string): Promise<GroupRepresentationWithIdNamePath | undefined> {
     const parts = splitGroupPath(path)
     this.logger.verbose(`Resolving Keycloak group path ${path} (depth=${parts.length})`)
-    let current: GroupRepresentationWith<'id'> | undefined
+    let current: GroupRepresentationWithIdNamePath | undefined
     if (parts.length === 0) return undefined
 
     for (const name of parts) {
@@ -72,20 +72,20 @@ export class KeycloakClientService implements OnModuleInit {
     return current
   }
 
-  private async getSubGroupByName(parentId: string, name: string): Promise<GroupRepresentationWith<'id'> | undefined> {
+  private async getSubGroupByName(parentId: string, name: string): Promise<GroupRepresentationWithIdNamePath | undefined> {
     for await (const subgroup of this.getSubGroups(parentId)) {
       if (subgroup.name === name) {
-        const parsed = z.object({ id: z.string() }).and(z.record(z.string(), z.unknown())).safeParse(subgroup)
+        const parsed = groupSchema.safeParse(subgroup)
         return parsed.success ? parsed.data : undefined
       }
     }
     return undefined
   }
 
-  private async getRootGroupByName(name: string): Promise<GroupRepresentationWith<'id'> | undefined> {
+  private async getRootGroupByName(name: string): Promise<GroupRepresentationWithIdNamePath | undefined> {
     const candidates = await this.client.groups.find({ search: name, briefRepresentation: false }) ?? []
     const match = candidates.find(g => g.path === `/${name}`) ?? candidates.find(g => g.name === name)
-    const parsed = z.object({ id: z.string() }).and(z.record(z.string(), z.unknown())).safeParse(match)
+    const parsed = groupSchema.safeParse(match)
     return parsed.success ? parsed.data : undefined
   }
 
@@ -130,8 +130,10 @@ export class KeycloakClientService implements OnModuleInit {
     const span = trace.getActiveSpan()
     span?.setAttribute('group.name', name)
     this.logger.debug(`Creating Keycloak group ${name}`)
-    const result = await this.client.groups.create({ name })
-    return { ...result, name } as GroupRepresentation
+    await this.client.groups.create({ name })
+    const created = await this.getRootGroupByName(name)
+    if (!created) throw new Error(`Created Keycloak group ${name} but could not fetch it back`)
+    return created
   }
 
   async addUserToGroup(userId: string, groupId: string) {
@@ -178,25 +180,18 @@ export class KeycloakClientService implements OnModuleInit {
     }
 
     const parts = splitGroupPath(path)
-    let parentId: string | undefined
-    let current: GroupRepresentationWith<'id' | 'name'> | undefined
-
-    for (const name of parts.values()) {
-      if (current) {
-        if (!parentId) parentId = current.id
-        const next = z.object({ id: z.string(), name: z.string() }).safeParse(await this.getOrCreateSubGroupByName(parentId, name))
-        if (next.success) current = next.data
-      } else {
-        const next = z.object({ id: z.string(), name: z.string() }).safeParse(await this.getGroupByName(name) ?? await this.createGroup(name))
-        if (next.success) current = next.data
-      }
-      parentId = current?.id
+    if (parts.length === 0) {
+      throw new Error(`Invalid group path: "${path}"`)
     }
 
-    if (current) {
-      this.logger.log(`Created Keycloak group path ${path} (groupId=${current.id})`)
+    const [rootName, ...rest] = parts
+    let current = await this.getGroupByName(rootName) ?? await this.createGroup(rootName)
+    for (const name of rest) {
+      current = await this.getOrCreateSubGroupByName(current.id, name)
     }
-    return { ...current, path } as GroupRepresentation
+
+    this.logger.log(`Created Keycloak group path ${path} (groupId=${current.id})`)
+    return current
   }
 
   @StartActiveSpan()
@@ -204,31 +199,26 @@ export class KeycloakClientService implements OnModuleInit {
     const span = trace.getActiveSpan()
     span?.setAttribute('group.name', name)
     span?.setAttribute('parent.id', parentId)
-    const existing = await this.findSubGroupByName(parentId, name)
+    const existing = await this.getSubGroupByName(parentId, name)
     if (existing) return existing
 
     this.logger.debug(`Creating Keycloak subgroup ${name} under parentId=${parentId}`)
     try {
-      const createdGroup = await this.client.groups.createChildGroup({ id: parentId }, { name })
-      return { id: createdGroup.id, name } satisfies GroupRepresentation
+      // createChildGroup only returns the new id; re-list the parent to hand
+      // back the representation Keycloak computed (name, path, subGroups...)
+      await this.client.groups.createChildGroup({ id: parentId }, { name })
+      const created = await this.getSubGroupByName(parentId, name)
+      if (!created) throw new Error(`Created Keycloak subgroup ${name} under parentId=${parentId} but could not fetch it back`)
+      return created
     } catch (err) {
       // A concurrent reconciliation may have created the subgroup between the
       // scan and the create; treat the 409 as "already exists" and re-fetch it
       if (getErrorResponseStatus(err) !== 409) throw err
       this.logger.verbose(`Keycloak subgroup ${name} was created concurrently under parentId=${parentId}, fetching it`)
-      const subgroup = await this.findSubGroupByName(parentId, name)
+      const subgroup = await this.getSubGroupByName(parentId, name)
       if (!subgroup) throw err
       return subgroup
     }
-  }
-
-  private async findSubGroupByName(parentId: string, name: string): Promise<GroupRepresentation | undefined> {
-    for await (const subgroup of this.getSubGroups(parentId)) {
-      if (subgroup.name === name) {
-        return subgroup
-      }
-    }
-    return undefined
   }
 
   async getOrCreateConsoleGroup(projectGroup: GroupRepresentationWith<'id'>) {
@@ -239,7 +229,7 @@ export class KeycloakClientService implements OnModuleInit {
   }
 
   async getOrCreateRoleGroup(
-    consoleGroup: GroupRepresentationWith<'id' | 'name' | 'path'>,
+    consoleGroup: GroupRepresentationWithIdNamePath,
     oidcGroup: string,
   ) {
     const span = trace.getActiveSpan()
@@ -253,19 +243,13 @@ export class KeycloakClientService implements OnModuleInit {
       throw new Error(`Invalid oidcGroup for project role: "${oidcGroup}"`)
     }
 
-    let current = z.object({
-      id: z.string(),
-      name: z.string(),
-    }).parse(await this.getOrCreateSubGroupByName(consoleGroup.id, parts[0]))
+    let current = await this.getOrCreateSubGroupByName(consoleGroup.id, parts[0])
 
     for (const name of parts.slice(1)) {
-      current = z.object({
-        id: z.string(),
-        name: z.string(),
-      }).parse(await this.getOrCreateSubGroupByName(current.id, name))
+      current = await this.getOrCreateSubGroupByName(current.id, name)
     }
 
-    return { ...current, path: joinGroupPath(consoleGroup.path, ...parts) } satisfies GroupRepresentation
+    return current
   }
 
   async getOrCreateEnvironmentGroups(consoleGroup: GroupRepresentationWith<'id'>, environment: ProjectWithDetails['environments'][number]) {
@@ -275,10 +259,7 @@ export class KeycloakClientService implements OnModuleInit {
       'environment.id': environment.id,
       'environment.name': environment.name,
     })
-    const envGroup = z.object({
-      id: z.string(),
-      name: z.string(),
-    }).parse(await this.getOrCreateSubGroupByName(consoleGroup.id, environment.name))
+    const envGroup = await this.getOrCreateSubGroupByName(consoleGroup.id, environment.name)
     const [roGroup, rwGroup] = await Promise.all([
       this.getOrCreateSubGroupByName(envGroup.id, 'RO'),
       this.getOrCreateSubGroupByName(envGroup.id, 'RW'),

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
@@ -188,7 +188,7 @@ describe('keycloakService', () => {
 
       keycloak.getOrCreateGroupByPath.mockImplementation((path) => {
         if (path === '/test-project') return Promise.resolve(projectGroup)
-        return Promise.resolve({})
+        throw new Error(`Unexpected getOrCreateGroupByPath call: ${path}`)
       })
       keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
       keycloak.getOrCreateRoleGroup.mockResolvedValue(roleGroup)
@@ -229,7 +229,8 @@ describe('keycloakService', () => {
       keycloak.getGroupMembers.mockResolvedValue([])
 
       // Mock console group retrieval
-      keycloak.getOrCreateConsoleGroup.mockResolvedValue(makeGroupRepresentation({ id: 'console-id', name: 'console', path: '/test-project/console' }))
+      const consoleGroup = makeGroupRepresentation({ id: 'console-id', name: 'console', path: '/test-project/console' })
+      keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
       keycloak.getOrCreateEnvironmentGroups.mockResolvedValue({
         roGroup: makeGroupRepresentation({ id: 'dev-ro-id', name: 'RO' }),
         rwGroup: makeGroupRepresentation({ id: 'dev-rw-id', name: 'RW' }),
@@ -256,9 +257,9 @@ describe('keycloakService', () => {
       await service.handleCron()
 
       // Should create dev group
-      expect(keycloak.getOrCreateConsoleGroup).toHaveBeenCalledWith({ id: 'group-id', name: 'test-project' })
+      expect(keycloak.getOrCreateConsoleGroup).toHaveBeenCalledWith(projectGroup)
       // Should create RO/RW groups
-      expect(keycloak.getOrCreateEnvironmentGroups).toHaveBeenCalledWith({ id: 'console-id', name: 'console', path: '/test-project/console' }, projectWithEnv.environments[0])
+      expect(keycloak.getOrCreateEnvironmentGroups).toHaveBeenCalledWith(consoleGroup, projectWithEnv.environments[0])
       // Should delete staging group
       expect(keycloak.deleteGroup).toHaveBeenCalledWith('staging-id')
     })
@@ -359,7 +360,7 @@ describe('keycloakService', () => {
 
       keycloak.getOrCreateGroupByPath.mockImplementation((path) => {
         if (path === '/test-project') return Promise.resolve(projectGroup)
-        return Promise.resolve({})
+        throw new Error(`Unexpected getOrCreateGroupByPath call: ${path}`)
       })
       keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
       keycloak.getOrCreateRoleGroup.mockImplementation((_consoleGroup, oidcGroup) => {
@@ -424,7 +425,7 @@ describe('keycloakService', () => {
 
       keycloak.getOrCreateGroupByPath.mockImplementation((path) => {
         if (path === '/test-project') return Promise.resolve(projectGroup)
-        return Promise.resolve({})
+        throw new Error(`Unexpected getOrCreateGroupByPath call: ${path}`)
       })
       keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
       keycloak.getOrCreateRoleGroup.mockResolvedValue({ ...systemManagedGroup, path: '/test-project/console/system-managed-group' })

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
@@ -167,7 +167,7 @@ describe('keycloakService', () => {
       const roleWithOidc = makeProjectRole({
         id: 'role-oidc',
         permissions: 0n,
-        oidcGroup: '/oidc-group',
+        oidcGroup: '/test-project/console/oidc-group',
         type: 'managed',
       })
       const projectWithRole = makeProjectWithDetails({
@@ -183,8 +183,8 @@ describe('keycloakService', () => {
       datastore.getAllProjects.mockResolvedValue([projectWithRole])
 
       const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
-      const consoleGroup = { id: 'console-id', name: 'console' }
-      const roleGroup = makeGroupRepresentation({ id: 'role-group-id', name: 'oidc-group', path: '/console/oidc-group' })
+      const consoleGroup = { id: 'console-id', name: 'console', path: '/test-project/console' }
+      const roleGroup = makeGroupRepresentation({ id: 'role-group-id', name: 'oidc-group', path: '/test-project/console/oidc-group' })
 
       keycloak.getOrCreateGroupByPath.mockImplementation((path) => {
         if (path === '/test-project') return Promise.resolve(projectGroup)
@@ -205,7 +205,7 @@ describe('keycloakService', () => {
 
       await service.handleCron()
 
-      // Should create/get role group
+      // Should create/get role group (relative to console group)
       expect(keycloak.getOrCreateRoleGroup).toHaveBeenCalledWith(consoleGroup, '/oidc-group')
       // Should add user-1 to role group
       expect(keycloak.addUserToGroup).toHaveBeenCalledWith('user-1', 'role-group-id')
@@ -229,7 +229,7 @@ describe('keycloakService', () => {
       keycloak.getGroupMembers.mockResolvedValue([])
 
       // Mock console group retrieval
-      keycloak.getOrCreateConsoleGroup.mockResolvedValue(makeGroupRepresentation({ id: 'console-id', name: 'console' }))
+      keycloak.getOrCreateConsoleGroup.mockResolvedValue(makeGroupRepresentation({ id: 'console-id', name: 'console', path: '/test-project/console' }))
       keycloak.getOrCreateEnvironmentGroups.mockResolvedValue({
         roGroup: makeGroupRepresentation({ id: 'dev-ro-id', name: 'RO' }),
         rwGroup: makeGroupRepresentation({ id: 'dev-rw-id', name: 'RW' }),
@@ -258,7 +258,7 @@ describe('keycloakService', () => {
       // Should create dev group
       expect(keycloak.getOrCreateConsoleGroup).toHaveBeenCalledWith({ id: 'group-id', name: 'test-project' })
       // Should create RO/RW groups
-      expect(keycloak.getOrCreateEnvironmentGroups).toHaveBeenCalledWith({ id: 'console-id', name: 'console' }, projectWithEnv.environments[0])
+      expect(keycloak.getOrCreateEnvironmentGroups).toHaveBeenCalledWith({ id: 'console-id', name: 'console', path: '/test-project/console' }, projectWithEnv.environments[0])
       // Should delete staging group
       expect(keycloak.deleteGroup).toHaveBeenCalledWith('staging-id')
     })
@@ -298,7 +298,7 @@ describe('keycloakService', () => {
         subGroups: [makeGroupRepresentation({ name: 'console', id: 'console-id' })],
       })
       keycloak.getOrCreateGroupByPath.mockResolvedValue(projectGroup)
-      keycloak.getOrCreateConsoleGroup.mockResolvedValue(makeGroupRepresentation({ id: 'console-id', name: 'console' }))
+      keycloak.getOrCreateConsoleGroup.mockResolvedValue(makeGroupRepresentation({ id: 'console-id', name: 'console', path: '/test-project/console' }))
       keycloak.getOrCreateEnvironmentGroups.mockResolvedValue({
         roGroup: makeGroupRepresentation({ id: 'dev-ro-id', name: 'RO' }),
         rwGroup: makeGroupRepresentation({ id: 'dev-rw-id', name: 'RW' }),
@@ -335,9 +335,9 @@ describe('keycloakService', () => {
     })
 
     it('should handle different role types (managed, external, global)', async () => {
-      const roleManaged = makeProjectRole({ id: 'role-managed', permissions: 0n, oidcGroup: '/managed-group', type: 'managed' })
-      const roleExternal = makeProjectRole({ id: 'role-external', permissions: 0n, oidcGroup: '/external-group', type: 'external' })
-      const roleGlobal = makeProjectRole({ id: 'role-global', permissions: 0n, oidcGroup: '/global-group', type: 'global' })
+      const roleManaged = makeProjectRole({ id: 'role-managed', permissions: 0n, oidcGroup: '/test-project/console/managed-group', type: 'managed' })
+      const roleExternal = makeProjectRole({ id: 'role-external', permissions: 0n, oidcGroup: '/test-project/console/external-group', type: 'external' })
+      const roleGlobal = makeProjectRole({ id: 'role-global', permissions: 0n, oidcGroup: '/test-project/console/global-group', type: 'global' })
 
       const projectWithRoles = makeProjectWithDetails({
         ...mockProject,
@@ -352,7 +352,7 @@ describe('keycloakService', () => {
       datastore.getAllProjects.mockResolvedValue([projectWithRoles])
 
       const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
-      const consoleGroup = { id: 'console-id', name: 'console' }
+      const consoleGroup = { id: 'console-id', name: 'console', path: '/test-project/console' }
       const managedGroup = makeGroupRepresentation({ id: 'managed-id', name: 'managed-group' })
       const externalGroup = makeGroupRepresentation({ id: 'external-id', name: 'external-group' })
       const globalGroup = makeGroupRepresentation({ id: 'global-id', name: 'global-group' })
@@ -363,10 +363,10 @@ describe('keycloakService', () => {
       })
       keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
       keycloak.getOrCreateRoleGroup.mockImplementation((_consoleGroup, oidcGroup) => {
-        if (oidcGroup === '/managed-group') return Promise.resolve({ ...managedGroup, path: '/console/managed-group' })
-        if (oidcGroup === '/external-group') return Promise.resolve({ ...externalGroup, path: '/console/external-group' })
-        if (oidcGroup === '/global-group') return Promise.resolve({ ...globalGroup, path: '/console/global-group' })
-        return Promise.resolve(makeGroupRepresentation({ id: 'new-id', name: oidcGroup, path: `/console/${oidcGroup}` }))
+        if (oidcGroup === '/managed-group') return Promise.resolve({ ...managedGroup, path: '/test-project/console/managed-group' })
+        if (oidcGroup === '/external-group') return Promise.resolve({ ...externalGroup, path: '/test-project/console/external-group' })
+        if (oidcGroup === '/global-group') return Promise.resolve({ ...globalGroup, path: '/test-project/console/global-group' })
+        return Promise.resolve(makeGroupRepresentation({ id: 'new-id', name: oidcGroup, path: `/test-project/console/${oidcGroup}` }))
       })
 
       // Group members
@@ -404,7 +404,7 @@ describe('keycloakService', () => {
     })
 
     it('should treat system-prefixed role types as their base type', async () => {
-      const roleSystemManaged = makeProjectRole({ id: 'role-system-managed', permissions: 0n, oidcGroup: '/system-managed-group', type: 'system:managed' })
+      const roleSystemManaged = makeProjectRole({ id: 'role-system-managed', permissions: 0n, oidcGroup: '/test-project/console/system-managed-group', type: 'system:managed' })
 
       const projectWithRoles = makeProjectWithDetails({
         ...mockProject,
@@ -419,7 +419,7 @@ describe('keycloakService', () => {
       datastore.getAllProjects.mockResolvedValue([projectWithRoles])
 
       const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
-      const consoleGroup = { id: 'console-id', name: 'console' }
+      const consoleGroup = { id: 'console-id', name: 'console', path: '/test-project/console' }
       const systemManagedGroup = makeGroupRepresentation({ id: 'system-managed-id', name: 'system-managed-group' })
 
       keycloak.getOrCreateGroupByPath.mockImplementation((path) => {
@@ -427,7 +427,7 @@ describe('keycloakService', () => {
         return Promise.resolve({})
       })
       keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
-      keycloak.getOrCreateRoleGroup.mockResolvedValue({ ...systemManagedGroup, path: '/console/system-managed-group' })
+      keycloak.getOrCreateRoleGroup.mockResolvedValue({ ...systemManagedGroup, path: '/test-project/console/system-managed-group' })
 
       keycloak.getGroupMembers.mockImplementation((groupId) => {
         if (groupId === 'group-id') return Promise.resolve([makeUserRepresentation({ id: 'owner-id' })])

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
@@ -1,7 +1,7 @@
 import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation'
 import type { RequiredPluginResult } from '../plugin/plugin.utils'
 import type { AdminRoleWithDetails, ProjectWithDetails, UserWithAdminRoles } from './keycloak-datastore.service'
-import type { GroupRepresentationWith } from './keycloak.utils'
+import type { GroupRepresentationWith, GroupRepresentationWithIdNamePath } from './keycloak.utils'
 import { getBaseRoleType, getPermsByUserRoles, isExternalRoleType, ProjectAuthorized, resourceListToDict } from '@cpn-console/shared'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
@@ -99,10 +99,7 @@ export class KeycloakService {
     })
     this.logger.verbose(`Reconciling Keycloak project group (${project.slug}): members=${project.members.length} roles=${project.roles.length}`)
 
-    const projectGroup = z.object({
-      id: z.string(),
-      name: z.string(),
-    }).parse(await this.keycloak.getOrCreateGroupByPath(`/${project.slug}`))
+    const projectGroup = await this.keycloak.getOrCreateGroupByPath(`/${project.slug}`)
 
     span?.setAttribute('keycloak.project_group.id', projectGroup.id)
 
@@ -117,11 +114,7 @@ export class KeycloakService {
   private async ensureConsoleGroup(project: ProjectWithDetails, group: GroupRepresentationWith<'id'>) {
     const span = trace.getActiveSpan()
     span?.setAttribute('keycloak.console_group.id', group.id)
-    const consoleGroup = z.object({
-      id: z.string(),
-      name: z.string(),
-      path: z.string(),
-    }).parse(await this.keycloak.getOrCreateConsoleGroup(group))
+    const consoleGroup = await this.keycloak.getOrCreateConsoleGroup(group)
     this.logger.verbose(`Reconciling Keycloak console group (${project.slug}): projectGroupId=${group.id} consoleGroupId=${consoleGroup.id}`)
     await Promise.all([
       this.ensureRoleGroups(project, consoleGroup),
@@ -157,10 +150,7 @@ export class KeycloakService {
     if (!roleGroupPath) return
 
     span?.setAttribute('keycloak.group.path', roleGroupPath)
-    const roleGroup = z.object({
-      id: z.string(),
-      name: z.string(),
-    }).parse(await this.keycloak.getOrCreateGroupByPath(roleGroupPath))
+    const roleGroup = await this.keycloak.getOrCreateGroupByPath(roleGroupPath)
     span?.setAttribute('keycloak.group.id', roleGroup.id)
 
     const groupMembers = await this.keycloak.getGroupMembers(roleGroup.id)
@@ -292,7 +282,7 @@ export class KeycloakService {
   @StartActiveSpan()
   private async ensureRoleGroups(
     project: ProjectWithDetails,
-    group: GroupRepresentationWith<'id' | 'name' | 'path'>,
+    group: GroupRepresentationWithIdNamePath,
   ) {
     const span = trace.getActiveSpan()
     span?.setAttributes({
@@ -311,7 +301,7 @@ export class KeycloakService {
   private async ensureRoleGroup(
     project: ProjectWithDetails,
     role: ProjectWithDetails['roles'][number],
-    group: GroupRepresentationWith<'id' | 'name' | 'path'>,
+    group: GroupRepresentationWithIdNamePath,
   ) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
@@ -352,7 +342,7 @@ export class KeycloakService {
   private async ensureRoleGroupMembers(
     project: ProjectWithDetails,
     role: ProjectWithDetails['roles'][number],
-    group: GroupRepresentationWith<'id' | 'name' | 'path'>,
+    group: GroupRepresentationWithIdNamePath,
     members: UserRepresentation[],
   ) {
     const span = trace.getActiveSpan()
@@ -383,7 +373,7 @@ export class KeycloakService {
   private async purgeOrphanRoleGroupMembers(
     project: ProjectWithDetails,
     role: ProjectWithDetails['roles'][number],
-    group: GroupRepresentationWith<'id' | 'name' | 'path'>,
+    group: GroupRepresentationWithIdNamePath,
     members: UserRepresentation[],
   ) {
     const span = trace.getActiveSpan()
@@ -428,16 +418,7 @@ export class KeycloakService {
       'project.roles.count': project.roles.length,
     })
 
-    const { roGroup, rwGroup } = z.object({
-      roGroup: z.object({
-        id: z.string(),
-        name: z.string(),
-      }),
-      rwGroup: z.object({
-        id: z.string(),
-        name: z.string(),
-      }),
-    }).parse(await this.keycloak.getOrCreateEnvironmentGroups(group, environment))
+    const { roGroup, rwGroup } = await this.keycloak.getOrCreateEnvironmentGroups(group, environment)
 
     span?.setAttribute('keycloak.env_group.ro.id', roGroup.id)
     span?.setAttribute('keycloak.env_group.rw.id', rwGroup.id)

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
@@ -12,7 +12,7 @@ import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator
 import { capturePluginResult } from '../plugin/plugin.utils'
 import { KeycloakClientService } from './keycloak-client.service'
 import { KeycloakDatastoreService } from './keycloak-datastore.service'
-import { isMember, isNonEmptyGroupPath, isOwnedProjectGroup, normalizeGroupPath } from './keycloak.utils'
+import { isMember, isNonEmptyGroupPath, isOwnedProjectGroup, splitGroupPath, toGroupPath, toRoleRelativeGroupPath } from './keycloak.utils'
 
 @Injectable()
 export class KeycloakService {
@@ -120,6 +120,7 @@ export class KeycloakService {
     const consoleGroup = z.object({
       id: z.string(),
       name: z.string(),
+      path: z.string(),
     }).parse(await this.keycloak.getOrCreateConsoleGroup(group))
     this.logger.verbose(`Reconciling Keycloak console group (${project.slug}): projectGroupId=${group.id} consoleGroupId=${consoleGroup.id}`)
     await Promise.all([
@@ -152,7 +153,7 @@ export class KeycloakService {
     const span = trace.getActiveSpan()
     span?.setAttribute('admin_role.id', role.id)
     span?.setAttribute('admin_role.oidc_group.present', isNonEmptyGroupPath(role.oidcGroup))
-    const roleGroupPath = normalizeGroupPath(role.oidcGroup)
+    const roleGroupPath = toGroupPath(role.oidcGroup)
     if (!roleGroupPath) return
 
     span?.setAttribute('keycloak.group.path', roleGroupPath)
@@ -291,7 +292,7 @@ export class KeycloakService {
   @StartActiveSpan()
   private async ensureRoleGroups(
     project: ProjectWithDetails,
-    group: GroupRepresentationWith<'id' | 'name'>,
+    group: GroupRepresentationWith<'id' | 'name' | 'path'>,
   ) {
     const span = trace.getActiveSpan()
     span?.setAttributes({
@@ -310,7 +311,7 @@ export class KeycloakService {
   private async ensureRoleGroup(
     project: ProjectWithDetails,
     role: ProjectWithDetails['roles'][number],
-    group: GroupRepresentationWith<'id' | 'name'>,
+    group: GroupRepresentationWith<'id' | 'name' | 'path'>,
   ) {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
@@ -319,9 +320,10 @@ export class KeycloakService {
     span?.setAttribute('role.oidc_group.present', isNonEmptyGroupPath(role.oidcGroup))
     if (!isNonEmptyGroupPath(role.oidcGroup)) return
 
-    span?.setAttribute('role.oidc_group.depth', role.oidcGroup.split('/').filter(Boolean).length)
+    span?.setAttribute('role.oidc_group.depth', splitGroupPath(role.oidcGroup).length)
 
-    const roleGroup = await this.keycloak.getOrCreateRoleGroup(group, role.oidcGroup)
+    const relativeOidcGroup = toRoleRelativeGroupPath(role, group)
+    const roleGroup = await this.keycloak.getOrCreateRoleGroup(group, relativeOidcGroup)
     span?.setAttribute('keycloak.group.id', roleGroup.id)
     span?.setAttribute('keycloak.group.path', roleGroup.path)
 

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.utils.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.utils.ts
@@ -14,7 +14,7 @@ export function isNonEmptyGroupPath(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0
 }
 
-export function normalizeGroupPath(value: unknown): string | undefined {
+export function toGroupPath(value: unknown): string | undefined {
   if (!isNonEmptyGroupPath(value)) return undefined
   const trimmed = value.trim()
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
@@ -22,4 +22,19 @@ export function normalizeGroupPath(value: unknown): string | undefined {
 
 export function isOwnedProjectGroup(group: GroupRepresentationWith<'subGroups'>): boolean {
   return !!group.subGroups.some(sg => sg.name === CONSOLE_GROUP_NAME)
+}
+
+export function splitGroupPath(path: string): string[] {
+  return path.split('/').filter(Boolean)
+}
+
+export function joinGroupPath(...parts: string[]): string {
+  return `/${parts.flatMap(splitGroupPath).join('/')}`
+}
+
+export function toRoleRelativeGroupPath(
+  role: Pick<ProjectWithDetails['roles'][number], 'oidcGroup'>,
+  consoleGroup: GroupRepresentationWith<'path'>,
+): string {
+  return role.oidcGroup.replace(consoleGroup.path, '')
 }

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.utils.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.utils.ts
@@ -1,3 +1,4 @@
+import z from 'zod'
 import type GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation'
 import type UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation'
 import type { ProjectWithDetails } from './keycloak-datastore.service'
@@ -5,6 +6,14 @@ import { CONSOLE_GROUP_NAME } from './keycloak.constants'
 
 type With<T, K extends keyof T> = T & Required<Pick<T, K>>
 export type GroupRepresentationWith<T extends keyof GroupRepresentation> = With<GroupRepresentation, T>
+
+// Groups handed out by this client always carry id/name/path.
+export type GroupRepresentationWithIdNamePath = GroupRepresentationWith<'id' | 'name' | 'path'>
+
+// Groups handed out by this client always carry id/name/path: parse at the
+// boundary so callers use the representation Keycloak computed, never a
+// locally synthesized path.
+export const groupSchema = z.object({ id: z.string(), name: z.string(), path: z.string() }).and(z.record(z.string(), z.unknown()))
 
 export function isMember(project: ProjectWithDetails, member: UserRepresentation): boolean {
   return project.members.some(m => m.user.id === member.id) || project.ownerId === member.id


### PR DESCRIPTION
## Issues liées

Closes #2536

---------

## Quel est le comportement actuel ?

`getOrCreateRoleGroup` construisait le chemin du groupe de rôle depuis le chemin console en dur (`${consoleGroup.path}/${oidcGroup relatif}`), avec un `oidcGroup` relatif supposé — produisant des chemins doublés (`/<slug>/console/<slug>/console/...`) quand `role.oidcGroup` est absolu (ex. `/test-project/console/oidc-group`).

## Quel est le nouveau comportement ?

- Le chemin relatif au groupe console est dérivé de `role.oidcGroup` moins `consoleGroup.path` (premier slash conservé).
- `getOrCreateRoleGroup` recompose le chemin complet via `joinGroupPath(consoleGroup.path, ...parts)` et son paramètre est élargi à `GroupRepresentationWith<'id' | 'name' | 'path'>`.
- Les opérations de chemin de groupe sont centralisées dans `keycloak.utils.ts` : `splitGroupPath`, `joinGroupPath`, `toGroupPath` (ex `normalizeGroupPath`), `toRelativeGroupPath` (ex `stripRoleGroupPath`).
- Gains : 24/24 tests unitaires keycloak, ESLint clean, tsc clean hors erreurs préexistantes.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Les environnements Keycloak existants avec des sous-arborescences doublées préexistantes nécessitent une purge manuelle ponctuelle ; le réconciliateur ne les collapséra pas.