### PR TITLE
fix: provision GitLab CI variables for SonarQube

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
@@ -3,6 +3,7 @@ import type { ConfigType } from '@nestjs/config'
 import type { TestingModule } from '@nestjs/testing'
 import type { MockedFunction } from 'vitest'
 import type { DeepMockProxy } from 'vitest-mock-extended'
+import { GitbeakerRequestError } from '@gitbeaker/requester-utils'
 import { Test } from '@nestjs/testing'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -965,6 +966,63 @@ describe('gitlab-client', () => {
           expect.objectContaining({ filePath: 'mirror.sh', action: 'create' }),
         ]),
       )
+    })
+  })
+
+  describe('cI variables', () => {
+    const groupId = 42
+    const repoId = 99
+
+    it('should create a missing group variable', async () => {
+      gitlabApi.GroupVariables.show.mockRejectedValueOnce(makeGitbeakerRequestError({ description: '404 Group variable Not Found', status: 404 }))
+
+      await service.setGitlabGroupVariable(groupId, 'SONAR_TOKEN', 'secret', { masked: true, protected: false, variableType: 'env_var' })
+
+      expect(gitlabApi.GroupVariables.create).toHaveBeenCalledWith(groupId, 'SONAR_TOKEN', 'secret', expect.objectContaining({ masked: true, variableType: 'env_var' }))
+      expect(gitlabApi.GroupVariables.edit).not.toHaveBeenCalled()
+    })
+
+    it('should update a group variable when value differs', async () => {
+      gitlabApi.GroupVariables.show.mockResolvedValueOnce({ key: 'SONAR_TOKEN', value: 'old', variable_type: 'env_var', masked: true, protected: false })
+
+      await service.setGitlabGroupVariable(groupId, 'SONAR_TOKEN', 'new', { masked: true, protected: false, variableType: 'env_var' })
+
+      expect(gitlabApi.GroupVariables.edit).toHaveBeenCalledWith(groupId, 'SONAR_TOKEN', 'new', expect.objectContaining({ variableType: 'env_var' }))
+      expect(gitlabApi.GroupVariables.create).not.toHaveBeenCalled()
+    })
+
+    it('should skip write when group variable matches', async () => {
+      gitlabApi.GroupVariables.show.mockResolvedValueOnce({ key: 'SONAR_TOKEN', value: 'secret', variable_type: 'env_var', masked: true, protected: false })
+
+      await service.setGitlabGroupVariable(groupId, 'SONAR_TOKEN', 'secret', { masked: true, protected: false, variableType: 'env_var' })
+
+      expect(gitlabApi.GroupVariables.create).not.toHaveBeenCalled()
+      expect(gitlabApi.GroupVariables.edit).not.toHaveBeenCalled()
+    })
+
+    it('should create a missing repo variable', async () => {
+      gitlabApi.ProjectVariables.show.mockRejectedValueOnce(makeGitbeakerRequestError({ description: '404 Project variable Not Found', status: 404 }))
+
+      await service.setGitlabRepoVariable(repoId, 'PROJECT_KEY', 'key', { masked: false, protected: false, variableType: 'env_var', environmentScope: '*' })
+
+      expect(gitlabApi.ProjectVariables.create).toHaveBeenCalledWith(repoId, 'PROJECT_KEY', 'key', expect.objectContaining({ variableType: 'env_var', environmentScope: '*' }))
+    })
+
+    it('should skip write when repo variable matches', async () => {
+      gitlabApi.ProjectVariables.show.mockResolvedValueOnce({ key: 'PROJECT_KEY', value: 'key', variable_type: 'env_var', masked: false, protected: false, environment_scope: '*' })
+
+      await service.setGitlabRepoVariable(repoId, 'PROJECT_KEY', 'key', { masked: false, protected: false, variableType: 'env_var', environmentScope: '*' })
+
+      expect(gitlabApi.ProjectVariables.create).not.toHaveBeenCalled()
+    })
+
+    it('should tolerate a non-string cause.description (regression: .includes is not a function)', async () => {
+      const error = new GitbeakerRequestError('boom', { cause: { description: 404 as unknown as string, request: new Request('https://gitlab.internal.example/api'), response: new Response(null, { status: 404 }) } })
+      gitlabApi.GroupVariables.show.mockRejectedValueOnce(error)
+
+      await service.setGitlabGroupVariable(groupId, 'SONAR_TOKEN', 'secret', { masked: true, protected: false, variableType: 'env_var' })
+
+      expect(gitlabApi.GroupVariables.create).toHaveBeenCalledWith(groupId, 'SONAR_TOKEN', 'secret', expect.objectContaining({ masked: true, variableType: 'env_var' }))
     })
   })
 })

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -13,6 +13,7 @@ import type {
   PaginationRequestOptions,
   PipelineTriggerTokenSchema,
   SimpleUserSchema,
+  VariableType,
 } from '@gitbeaker/core'
 import type { ConfigType } from '@nestjs/config'
 import { join } from 'node:path'
@@ -34,7 +35,7 @@ import {
   TOPIC_PLUGIN_MANAGED,
   USER_ID_CUSTOM_ATTRIBUTE_KEY,
 } from './gitlab.constants'
-import { generateGitlabCIConfigContent, generateMirrorScriptContent, hasFileContentChanged } from './gitlab.utils'
+import { generateGitlabCIConfigContent, generateMirrorScriptContent, hasFileContentChanged, hasGitbeakerCause, isGitbeakerNotFound } from './gitlab.utils'
 
 export const GITLAB_REST_CLIENT = Symbol('GITLAB_REST_CLIENT')
 
@@ -140,7 +141,7 @@ export class GitlabClientService {
       }
       return created
     } catch (error) {
-      if (error instanceof GitbeakerRequestError && error.cause?.description?.includes('has already been taken')) {
+      if (hasGitbeakerCause(error, 'has already been taken')) {
         this.logger.warn(`GitLab group already exists (race); reloading ${path}`)
         const existing = await this.getGroupByPath(path)
         if (existing) return existing
@@ -162,7 +163,7 @@ export class GitlabClientService {
       }
       return created
     } catch (error) {
-      if (error instanceof GitbeakerRequestError && error.cause?.description?.includes('has already been taken')) {
+      if (hasGitbeakerCause(error, 'has already been taken')) {
         this.logger.warn(`GitLab subgroup already exists (race); reloading ${fullPath}`)
         const existing = await this.getGroupByPath(fullPath)
         if (existing) return existing
@@ -233,7 +234,7 @@ export class GitlabClientService {
         return existingRepo
       }
     } catch (error) {
-      if (!(error instanceof GitbeakerRequestError) || !error.cause?.description?.includes('404')) {
+      if (!isGitbeakerNotFound(error)) {
         throw error
       }
     }
@@ -264,7 +265,7 @@ export class GitlabClientService {
       this.logger.log(`Created a GitLab project repository (path=${fullPath}, repoId=${created.id})`)
       return created
     } catch (error) {
-      if (error instanceof GitbeakerRequestError && error.cause?.description?.includes('has already been taken')) {
+      if (hasGitbeakerCause(error, 'has already been taken')) {
         this.logger.warn(`GitLab project repository already exists (race); reloading ${fullPath}`)
         const reloaded = await this.client.Projects.show(fullPath)
         return reloaded
@@ -302,7 +303,7 @@ export class GitlabClientService {
     try {
       return await this.client.RepositoryFiles.show(repo.id, filePath, ref)
     } catch (error) {
-      if (error instanceof GitbeakerRequestError && error.cause?.description?.includes('Not Found')) {
+      if (hasGitbeakerCause(error, 'Not Found')) {
         this.logger.debug(`GitLab file not found (repoId=${repo.id}, ref=${ref}, filePath=${filePath})`)
         return
       }
@@ -353,10 +354,7 @@ export class GitlabClientService {
       this.logger.verbose(`Listed GitLab repository tree (repoId=${repo.id}, ref=${ref}, path=${path}, count=${files.length})`)
       return files
     } catch (error) {
-      if (error instanceof GitbeakerRequestError && error.cause?.description?.includes('Not Found')) {
-        return []
-      }
-      if (error instanceof GitbeakerRequestError && error.cause?.description?.includes('404 Tree Not Found')) {
+      if (hasGitbeakerCause(error, 'Not Found') || hasGitbeakerCause(error, '404 Tree Not Found')) {
         return []
       }
       throw error
@@ -479,6 +477,85 @@ export class GitlabClientService {
     const fullPath = `${projectSlug}/${repoName}`
     const repo = await this.getOrCreateProjectGroupRepo(projectSlug, fullPath)
     return this.client.Projects.remove(repo.id)
+  }
+
+  // CI Variables
+  public async setGitlabGroupVariable(
+    groupId: number,
+    key: string,
+    value: string,
+    options: { masked: boolean, protected: boolean, variableType: VariableType },
+  ): Promise<void> {
+    const current = await this.client.GroupVariables.show(groupId, key).catch((error) => {
+      if (isGitbeakerNotFound(error)) return undefined
+      throw error
+    })
+    if (!current) {
+      await this.client.GroupVariables.create(groupId, key, value, {
+        variableType: options.variableType,
+        masked: options.masked,
+        protected: options.protected,
+      })
+      return
+    }
+    if (current.masked === options.masked
+      && current.value === value
+      && current.protected === options.protected
+      && current.variable_type === options.variableType) {
+      return
+    }
+    await this.client.GroupVariables.edit(groupId, key, value, {
+      variableType: options.variableType,
+      masked: options.masked,
+      protected: options.protected,
+      filter: { environment_scope: '*' },
+    })
+  }
+
+  public async setGitlabRepoVariable(
+    repoId: number,
+    key: string,
+    value: string,
+    options: { masked: boolean, protected: boolean, variableType: VariableType, environmentScope: string },
+  ): Promise<void> {
+    const current = await this.client.ProjectVariables.show(repoId, key, { filter: { environment_scope: options.environmentScope } }).catch((error) => {
+      if (isGitbeakerNotFound(error)) return undefined
+      throw error
+    })
+    if (!current) {
+      await this.client.ProjectVariables.create(repoId, key, value, {
+        variableType: options.variableType,
+        masked: options.masked,
+        protected: options.protected,
+        environmentScope: options.environmentScope,
+      })
+      return
+    }
+    if (current.masked === options.masked
+      && current.value === value
+      && current.protected === options.protected
+      && current.variable_type === options.variableType) {
+      return
+    }
+    await this.client.ProjectVariables.edit(repoId, key, value, {
+      variableType: options.variableType,
+      masked: options.masked,
+      protected: options.protected,
+      environmentScope: options.environmentScope,
+      filter: { environment_scope: options.environmentScope },
+    })
+  }
+
+  async readGroupVariable(groupId: number, key: string) {
+    return this.client.GroupVariables.show(groupId, key).catch((error) => {
+      if (isGitbeakerNotFound(error)) return undefined
+      throw error
+    })
+  }
+
+  async readProjectVariables(repoId: number, environmentScope: string) {
+    const all = await this.client.ProjectVariables.all(repoId)
+    return all.filter(variable => variable.environment_scope === environmentScope)
   }
 
   async commitMirror(repoId: number) {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
@@ -2,6 +2,7 @@ import type { MemberSchema, ProjectSchema } from '@gitbeaker/core'
 import type { ProjectWithDetails } from './gitlab-datastore.service'
 import { createHash } from 'node:crypto'
 import { AccessLevel } from '@gitbeaker/core'
+import { GitbeakerRequestError } from '@gitbeaker/requester-utils'
 import { stringify } from 'yaml'
 import { TOPIC_PLUGIN_MANAGED } from './gitlab.constants'
 
@@ -230,4 +231,15 @@ export function daysAgoFromNow(date: Date) {
 
 export function adminRoleFlag(user: ProjectWithDetails['members'][0]['user'], adminRoleId?: string) {
   return adminRoleId ? user.adminRoleIds?.includes(adminRoleId) : undefined
+}
+
+export function isGitbeakerNotFound(error: unknown): error is GitbeakerRequestError {
+  // gitbeaker's typed `cause.description` is a string, but some paths emit a non-string one — key 404 off status, not text.
+  return error instanceof GitbeakerRequestError && error.cause?.response?.status === 404
+}
+
+export function hasGitbeakerCause(error: unknown, substring: string): error is GitbeakerRequestError {
+  return error instanceof GitbeakerRequestError
+    && typeof error.cause?.description === 'string'
+    && error.cause.description.includes(substring)
 }

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.module.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { TerminusModule } from '@nestjs/terminus'
 import { sonarqubeConfigFactory } from '../../config/sonarqube.config'
+import { GitlabModule } from '../gitlab/gitlab.module'
 import { DatabaseModule } from '../infrastructure/database/database.module'
 import { VaultModule } from '../vault/vault.module'
 import { SonarqubeClientService } from './sonarqube-client.service'
@@ -12,7 +13,7 @@ import { SonarqubePluginService } from './sonarqube-plugin.service'
 import { SonarqubeService } from './sonarqube.service'
 
 @Module({
-  imports: [DatabaseModule, TerminusModule, VaultModule, ConfigModule.forFeature(sonarqubeConfigFactory)],
+  imports: [DatabaseModule, TerminusModule, VaultModule, GitlabModule, ConfigModule.forFeature(sonarqubeConfigFactory)],
   providers: [
     SonarqubeHealthService,
     SonarqubeHttpClientService,

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
@@ -20,6 +20,7 @@ import {
 } from './sonarqube-testing.utils'
 import { PLUGIN_NAME, SONARQUBE_PROJECT_QUALIFIER_PROJECT } from './sonarqube.constants'
 import { SonarqubeService } from './sonarqube.service'
+import { GitlabClientService } from '../gitlab/gitlab-client.service'
 
 describe('sonarqubeService', () => {
   let service: SonarqubeService
@@ -27,6 +28,7 @@ describe('sonarqubeService', () => {
   let datastore: DeepMockProxy<SonarqubeDatastoreService>
   let vault: DeepMockProxy<VaultClientService>
   let config: DeepMockProxy<ConfigType<typeof sonarqubeConfigFactory>>
+  let gitlab: DeepMockProxy<GitlabClientService>
 
   beforeEach(async () => {
     client = mockDeep<SonarqubeClientService>({
@@ -57,6 +59,12 @@ describe('sonarqubeService', () => {
     })
     config = mockDeep<ConfigType<typeof sonarqubeConfigFactory>>({
     })
+    gitlab = mockDeep<GitlabClientService>({
+      setGitlabGroupVariable: vi.fn().mockResolvedValue(undefined),
+      setGitlabRepoVariable: vi.fn().mockResolvedValue(undefined),
+      getOrCreateProjectGroup: vi.fn().mockResolvedValue({ id: 42, full_path: 'root', name: 'root' }),
+      getOrCreateProjectGroupRepo: vi.fn().mockResolvedValue({ id: 99 }),
+    })
 
     const moduleRef = await Test.createTestingModule({
       providers: [
@@ -64,6 +72,7 @@ describe('sonarqubeService', () => {
         { provide: SonarqubeClientService, useValue: client },
         { provide: SonarqubeDatastoreService, useValue: datastore },
         { provide: VaultClientService, useValue: vault },
+        { provide: GitlabClientService, useValue: gitlab },
         { provide: sonarqubeConfigFactory.KEY, useValue: config },
       ],
     }).compile()
@@ -164,6 +173,22 @@ describe('sonarqubeService', () => {
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: '/console/security' }))
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: `/${project.slug}/console/developer`, permission: 'issueadmin' }))
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: `/${project.slug}/console/developer`, permission: 'securityhotspotadmin' }))
+    })
+
+    it('should provision GitLab CI variables for each repository and the shared group token', async () => {
+      const project = makeProjectWithDetails({ repositories: [{ internalRepoName: 'repo' }] })
+      const groupId = 42
+      const repoId = 99
+      client.generateUserToken.mockResolvedValue(makeUserToken({ login: project.slug }))
+      vault.readSonarqubeUser.mockResolvedValue(makeVaultSecret({ data: { SONAR_USERNAME: project.slug, SONAR_PASSWORD: 'pw', SONAR_TOKEN: 'tok' } }))
+
+      await service.handleUpsert(project)
+
+      const key = generateProjectKey(project.slug, 'repo')
+      expect(gitlab.setGitlabRepoVariable).toHaveBeenCalledWith(repoId, 'PROJECT_KEY', key, expect.objectContaining({ masked: false, variableType: 'env_var', environmentScope: '*' }))
+      expect(gitlab.setGitlabRepoVariable).toHaveBeenCalledWith(repoId, 'PROJECT_NAME', `${project.slug}-repo`, expect.objectContaining({ masked: false, variableType: 'env_var', environmentScope: '*' }))
+      expect(gitlab.setGitlabRepoVariable).toHaveBeenCalledWith(repoId, 'SONAR_PROJECT_PROPERTIES', expect.stringContaining(`sonar.projectKey=${key}`), expect.objectContaining({ masked: false, variableType: 'file', environmentScope: '*' }))
+      expect(gitlab.setGitlabGroupVariable).toHaveBeenCalledWith(groupId, 'SONAR_TOKEN', 'tok', expect.objectContaining({ masked: true, variableType: 'env_var' }))
     })
 
     it('should not recreate user or write vault when both user and secret exist', async () => {

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
@@ -10,6 +10,7 @@ import { trace } from '@opentelemetry/api'
 import { sonarqubeConfigFactory } from '../../config/sonarqube.config'
 import { generateProjectKey, generateRandomPassword } from '../../utils/crypto.utils'
 import { getAll } from '../../utils/iterable.utils'
+import { GitlabClientService } from '../gitlab/gitlab-client.service'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { capturePluginResult } from '../plugin/plugin.utils'
 import { VaultClientService } from '../vault/vault-client.service'
@@ -61,6 +62,7 @@ export class SonarqubeService implements OnModuleInit {
     @Inject(SonarqubeClientService) private readonly client: SonarqubeClientService,
     @Inject(sonarqubeConfigFactory.KEY) private readonly sonarqubeConfig: ConfigType<typeof sonarqubeConfigFactory>,
     @Inject(VaultClientService) private readonly vault: VaultClientService,
+    @Inject(GitlabClientService) private readonly gitlab: GitlabClientService,
   ) {
     this.logger.log('SonarqubeService initialized')
   }
@@ -257,11 +259,26 @@ export class SonarqubeService implements OnModuleInit {
     span?.setAttribute('project.slug', project.slug)
     span?.setAttribute('repositories.count', project.repositories.length)
 
-    const [readonlyGroupPath, securityGroupPath, existingSonarProjects] = await Promise.all([
+    const [readonlyGroupPath, securityGroupPath, existingSonarProjects, sonarSecret, gitlabGroup] = await Promise.all([
       this.getReadonlyGroupPath(),
       this.getSecurityGroupPath(),
       getAll(this.findProjectsForSlug(project.slug)),
+      this.vault.readSonarqubeUser(project.slug),
+      this.gitlab.getOrCreateProjectGroup(),
     ])
+
+    // SONAR_TOKEN is shared across every repository of the project; expose it once at the group level.
+    if (sonarSecret?.data?.SONAR_TOKEN) {
+      await this.gitlab.setGitlabGroupVariable(
+        gitlabGroup.id,
+        'SONAR_TOKEN',
+        sonarSecret.data.SONAR_TOKEN,
+        { masked: true, protected: false, variableType: 'env_var' },
+      )
+      this.logger.log(`GitLab group CI variable SONAR_TOKEN set (group=${gitlabGroup.full_path})`)
+    } else {
+      this.logger.warn(`Skipping GitLab CI variable provisioning (no SONAR_TOKEN in vault, project=${project.slug})`)
+    }
 
     const orphans = existingSonarProjects.filter(sp => !project.repositories.some(r => r.internalRepoName === sp.repository))
     if (orphans.length) this.logger.log(`Removing ${orphans.length} orphan SonarQube repositories for project ${project.slug}`)
@@ -284,8 +301,35 @@ export class SonarqubeService implements OnModuleInit {
         }
         await this.ensureProjectPermissions(projectKey, project.slug, rolePaths, readonlyGroupPath, securityGroupPath)
         this.logger.verbose(`Ensured permissions on SonarQube repository (key=${projectKey})`)
+        await this.ensureGitlabCiVariables(project, repository, projectKey, sonarSecret)
       }),
     ])
+  }
+
+  private async ensureGitlabCiVariables(
+    project: ProjectWithDetails,
+    repository: ProjectWithDetails['repositories'][number],
+    projectKey: string,
+    sonarSecret: { data: SonarqubeUserSecret } | null,
+  ): Promise<void> {
+    const repo = await this.gitlab.getOrCreateProjectGroupRepo(project.slug, `${project.slug}/${repository.internalRepoName}`)
+    const variables: { key: string, value: string, variableType: 'env_var' | 'file', masked: boolean }[] = [
+      { key: 'PROJECT_KEY', value: projectKey, variableType: 'env_var', masked: false },
+      { key: 'PROJECT_NAME', value: `${project.slug}-${repository.internalRepoName}`, variableType: 'env_var', masked: false },
+      { key: 'SONAR_PROJECT_PROPERTIES', value: `sonar.projectKey=${projectKey}\nsonar.qualitygate.wait=true\n`, variableType: 'file', masked: false },
+    ]
+    if (sonarSecret?.data?.SONAR_TOKEN) {
+      variables.push({ key: 'SONAR_TOKEN', value: sonarSecret.data.SONAR_TOKEN, variableType: 'env_var', masked: true })
+    }
+    await Promise.all(variables.map(async (variable) => {
+      await this.gitlab.setGitlabRepoVariable(repo.id, variable.key, variable.value, {
+        masked: variable.masked,
+        protected: false,
+        variableType: variable.variableType,
+        environmentScope: '*',
+      })
+      this.logger.log(`GitLab CI variable ${variable.key} set (repoId=${repo.id})`)
+    }))
   }
 
   private async ensureProjectPermissions(

--- a/apps/server-nestjs/test/sonarqube.e2e-spec.ts
+++ b/apps/server-nestjs/test/sonarqube.e2e-spec.ts
@@ -1,3 +1,4 @@
+import type { ConfigType } from '@nestjs/config'
 import type { TestingModule } from '@nestjs/testing'
 import { generateProjectKey } from '@cpn-console/hooks'
 import { faker } from '@faker-js/faker'
@@ -17,6 +18,9 @@ import { projectSelect } from '../src/modules/sonarqube/sonarqube-datastore.serv
 import { makeProjectWithDetails } from '../src/modules/sonarqube/sonarqube-testing.utils'
 import { SonarqubeModule } from '../src/modules/sonarqube/sonarqube.module'
 import { SonarqubeService } from '../src/modules/sonarqube/sonarqube.service'
+import { GitlabClientService } from '../src/modules/gitlab/gitlab-client.service'
+import { gitlabConfigFactory } from '../src/config/gitlab.config'
+import { GitlabModule } from '../src/modules/gitlab/gitlab.module'
 import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { VaultModule } from '../src/modules/vault/vault.module'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
@@ -34,6 +38,8 @@ describeWithSonarqube('SonarqubeService (e2e)', () => {
   let sonarqubeService: SonarqubeService
   let sonarqubeClient: SonarqubeClientService
   let vaultService: VaultClientService
+  let gitlabClient: GitlabClientService
+  let gitlabConfig: ConfigType<typeof gitlabConfigFactory>
   let prisma: PrismaService
 
   let ownerId: string
@@ -43,7 +49,7 @@ describeWithSonarqube('SonarqubeService (e2e)', () => {
 
   beforeAll(async () => {
     moduleRef = await Test.createTestingModule({
-      imports: [SonarqubeModule, VaultModule, ConfigModule.forRoot({ envFilePath: getDotenvPaths(), isGlobal: true, load: [baseConfigFactory] }), AuthModule, DatabaseModule, EventsModule, LoggerModule, PermissionModule],
+      imports: [SonarqubeModule, GitlabModule, VaultModule, ConfigModule.forRoot({ envFilePath: getDotenvPaths(), isGlobal: true, load: [baseConfigFactory, gitlabConfigFactory] }), AuthModule, DatabaseModule, EventsModule, LoggerModule, PermissionModule],
     }).compile()
 
     await moduleRef.init()
@@ -51,6 +57,8 @@ describeWithSonarqube('SonarqubeService (e2e)', () => {
     sonarqubeService = moduleRef.get<SonarqubeService>(SonarqubeService)
     sonarqubeClient = moduleRef.get<SonarqubeClientService>(SonarqubeClientService)
     vaultService = moduleRef.get<VaultClientService>(VaultClientService)
+    gitlabClient = moduleRef.get<GitlabClientService>(GitlabClientService)
+    gitlabConfig = moduleRef.get<ConfigType<typeof gitlabConfigFactory>>(gitlabConfigFactory.KEY)
     prisma = moduleRef.get<PrismaService>(PrismaService)
     eventEmitter = moduleRef.get<EventEmitter2>(EventEmitter2)
 
@@ -159,6 +167,28 @@ describeWithSonarqube('SonarqubeService (e2e)', () => {
     expect(vaultSecret?.data?.SONAR_USERNAME).toBe(testProjectSlug)
     expect(vaultSecret?.data?.SONAR_TOKEN).toBeTruthy()
     expect(vaultSecret?.data?.SONAR_PASSWORD).toBeTruthy()
+
+    // SONAR_TOKEN must be exposed at the project GitLab group level so every repo inherits it
+    const sonarGroupPath = `${gitlabConfig.projectRootDir}/${testProjectSlug}`
+    const sonarGroup = (gitlabClient.getGroupByPath
+      ? await gitlabClient.getGroupByPath(sonarGroupPath)
+      : undefined) ?? await gitlabClient.getProjectGroup(testProjectSlug)
+    if (!sonarGroup) throw new Error(`GitLab group ${sonarGroupPath} not found`)
+    const groupVar = await gitlabClient.readGroupVariable(sonarGroup.id, 'SONAR_TOKEN')
+    expect(groupVar?.value).toBe(vaultSecret?.data?.SONAR_TOKEN)
+    expect(groupVar?.masked).toBe(true)
+
+    // Per-repo CI variables must be provisioned for the repository
+    const sonarProjectKey = generateProjectKey(testProjectSlug, testRepoName)
+    const repo = await gitlabClient.getOrCreateProjectGroupRepo(testProjectSlug, `${testProjectSlug}/${testRepoName}`)
+    const repoVars = await gitlabClient.readProjectVariables(repo.id, '*')
+    const expectedRepoVars = ['PROJECT_KEY', 'PROJECT_NAME', 'SONAR_PROJECT_PROPERTIES', 'SONAR_TOKEN']
+    for (const key of expectedRepoVars) {
+      const variable = repoVars.find(v => v.key === key)
+      expect(variable, `repo CI variable ${key} should exist`).toBeTruthy()
+    }
+    expect(repoVars.find(v => v.key === 'PROJECT_KEY')?.value).toBe(sonarProjectKey)
+    expect(repoVars.find(v => v.key === 'SONAR_TOKEN')?.value).toBe(vaultSecret?.data?.SONAR_TOKEN)
   }, SONARQUBE_PROJECT_TIMEOUT)
 
   it('should delete the project from SonarQube and remove vault credentials', async () => {


### PR DESCRIPTION
## Issues liées

Closes #2538

---------

## Quel est le comportement actuel ?

Le module `sonarqube` de `apps/server-nestjs` créait le projet SonarQube, posait les permissions et écrivait le secret Vault (`SONAR_USERNAME`/`SONAR_PASSWORD`/`SONAR_TOKEN`), mais n'approvisionnait **aucune variable CI GitLab** — contrairement au plugin legacy `plugins/sonarqube` qui exécutait `setVariables` (PROJET_KEY=…, PROJECT_NAME=…, SONAR_TOKEN, SONAR_PROJECT_PROPERTIES). Les pipelines GitLab ne disposaient donc pas des variables nécessaires à l'analyse SonarQube.

## Quel est le nouveau comportement ?

- `GitlabClientService` expose deux méthodes idempotentes (`setGitlabGroupVariable`, `setGitlabRepoVariable`) qui créent/mettent à jour/laissent intacte une variable CI selon son état courant.
- `SonarqubeService.ensureProjectRepositories` provisionne désormais, pour chaque dépôt : `PROJECT_KEY`, `PROJECT_NAME`, `SONAR_PROJECT_PROPERTIES` (type fichier), et `SONAR_TOKEN` (masqué) ; `SONAR_TOKEN` est également posé au niveau du groupe projet (partagé entre dépôts). Valeurs calquées sur le `sonar-project.properties` du plugin legacy.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Tests unitaires ajoutés sur les deux nouvelles méthodes (création / mise à jour / already up-to-date).