### PR TITLE
fix(ci): dump docker compose state on failure and fix keycloak healthcheck

### DIFF
--- a/.github/workflows/job-playwright.yml
+++ b/.github/workflows/job-playwright.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Run Playwright tests
         run: pnpm --dir playwright exec playwright test --grep @e2e --shard=${{ matrix.shard }}/4 --reporter=blob
 
+      - name: Dump docker compose state on failure
+        if: ${{ failure() }}
+        run: |
+          docker compose -f ./docker/docker-compose.ci.yml ps -a
+          docker compose -f ./docker/docker-compose.ci.yml logs --no-color keycloak
+          docker inspect dso-console_keycloak --format '{{json .State}}'
+
       - name: Clean up docker resources (containers, volumes)
         run: docker compose -f ./docker/docker-compose.ci.yml down -v --remove-orphans
 

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -16,7 +16,7 @@ services:
     entrypoint: /opt/bitnami/keycloak/bin/kc.sh
     command: start-dev --import-realm
     healthcheck:
-      test: [CMD, curl, --head, -fsS, "http://localhost:8080/health/ready"]
+      test: [CMD, curl, --head, -fsS, "http://localhost:9000/health/ready"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -16,7 +16,7 @@ services:
     entrypoint: /opt/bitnami/keycloak/bin/kc.sh
     command: start-dev --import-realm
     healthcheck:
-      test: [CMD, curl, --head, fsS, "http://localhost:8080/health/ready"]
+      test: [CMD, curl, --head, -fsS, "http://localhost:8080/health/ready"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Issues liées

#2541
#2543

---------

## Quel est le comportement actuel ?

Le run de merge-queue 32459083785 (PR #2537) échoue de façon intermittente sur les shards Playwright : les 4 shards (`strategy.matrix.shard: [1,2,3,4]`, `runs-on: runner-playwright`) démarrent chacun leur propre stack complète, JVM Keycloak 26 incluse, en parallèle sur un même runner. Keycloak dépasse alors le budget du healthcheck et `docker compose up` avorte avec le conteneur `dso-console_keycloak` en `Error`. En cas d'échec, aucun log docker n'est remonté : le diagnostic est impossible depuis CI.

Par ailleurs, le healthcheck Keycloak de `docker-compose.ci.yml` cible le mauvais port (`8080` au lieu de `9000`) — cf. #2543 — : il ne valide jamais la santé réelle du conteneur.

## Quel est le nouveau comportement ?

- Bloc `Dump docker compose state on failure` (step `if: failure()`) : `docker compose ps -a`, `logs --no-color keycloak`, et `docker inspect dso-console_keycloak` (`OOMKilled`/`ExitCode`) — pour trancher OOM vs timeout directement depuis l'échec CI.
- Correction du healthcheck Keycloak dans `docker-compose.ci.yml` : port `8080` → `9000` (corrige #2543) et drapeau `fsS` → `-fsS` (typo).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Discussion liée : #2540. Run de référence : https://github.com/cloud-pi-native/console/actions/runs/32459083785
