### PR TITLE
chore(docker): migrate keycloak to official quay.io image

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -1,19 +1,18 @@
 services:
   keycloak:
     restart: unless-stopped
-    image: docker.io/bitnamilegacy/keycloak:26.1.3-debian-12-r0
+    image: quay.io/keycloak/keycloak:26.1.3
     container_name: dso-console_keycloak
     ports:
       - 8090:8080
     volumes:
-      - ../keycloak/realms:/opt/bitnami/keycloak/data/import
-      - /opt/bitnami/keycloak/data/h2
+      - ../keycloak/realms:/opt/keycloak/data/import
+      - /opt/keycloak/data/h2
     user: root
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HEALTH_ENABLED: true
-    entrypoint: /opt/bitnami/keycloak/bin/kc.sh
     command: start-dev --import-realm
     healthcheck:
       test: [CMD, curl, --head, -fsS, "http://localhost:9000/health/ready"]

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,19 +1,18 @@
 services:
   keycloak:
     restart: unless-stopped
-    image: docker.io/bitnamilegacy/keycloak:26.1.3-debian-12-r0
+    image: quay.io/keycloak/keycloak:26.1.3
     container_name: dso-console_keycloak
     ports:
       - 8090:8080
     volumes:
-      - ../keycloak/realms:/opt/bitnami/keycloak/data/import
-      - ../keycloak/data/dev:/opt/bitnami/keycloak/data/h2
+      - ../keycloak/realms:/opt/keycloak/data/import
+      - ../keycloak/data/dev:/opt/keycloak/data/h2
     user: root
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HEALTH_ENABLED: true
-    entrypoint: /opt/bitnami/keycloak/bin/kc.sh
     command: start-dev --import-realm
     healthcheck:
       test: [CMD, curl, --head, fsS, "http://localhost:8080/health/ready"]

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -12,7 +12,7 @@ services:
 
   keycloak:
     restart: unless-stopped
-    image: docker.io/bitnamilegacy/keycloak:26.1.3-debian-12-r0
+    image: quay.io/keycloak/keycloak:26.1.3
     container_name: dso-console_keycloak
     depends_on:
       keycloak-fetch-theme:
@@ -20,11 +20,11 @@ services:
     ports:
       - 127.0.0.1:8090:8080
     volumes:
-      - ../keycloak/realms:/opt/bitnami/keycloak/data/import
-      - ../keycloak/data/dev:/opt/bitnami/keycloak/data/h2
+      - ../keycloak/realms:/opt/keycloak/data/import
+      - ../keycloak/data/dev:/opt/keycloak/data/h2
       - type: volume
         source: dso-keycloak-dsfr-theme
-        target: /opt/bitnami/keycloak/providers/keycloak-theme-dsfr.jar
+        target: /opt/keycloak/providers/keycloak-theme-dsfr.jar
         volume:
           subpath: keycloak-theme-dsfr.jar
     user: root
@@ -37,7 +37,6 @@ services:
       DSFR_THEME_BRAND_TOP: Ministère<br/>de l'Intérieur</br>et des Outre-Mer
       DSFR_THEME_TOS_URL:
       DSFR_THEME_CONTACT_EMAIL: cloudpinative-relations@interieur.gouv.fr
-    entrypoint: /opt/bitnami/keycloak/bin/kc.sh
     command: start-dev --import-realm
     healthcheck:
       test: [CMD, curl, --head, fsS, "http://localhost:8080/health/ready"]


### PR DESCRIPTION
## Issues liées

#2543

---------

## Quel est le comportement actuel ?

Les trois fichiers docker-compose (`ci`, `dev`, `local`) utilisent l'image `docker.io/bitnamilegacy/keycloak:26.1.3-debian-12-r0` — le miroir legacy Bitnami, à durée de vie limitée et non maintenu. Les chemins internes pointent vers `/opt/bitnami/keycloak/`.

## Quel est le nouveau comportement ?

Migration vers l'image officielle `quay.io/keycloak/keycloak:26.1.3` :
- image + chemins `/opt/bitnami/keycloak/` → `/opt/keycloak/`
- suppression de l'override `entrypoint` (l'image officielle embarque déjà `kc.sh`)
- `KEYCLOAK_ADMIN`/`KEYCLOAK_ADMIN_PASSWORD` conservés (dépréciés mais fonctionnels en 26.x ; migration `KC_BOOTSTRAP_ADMIN_*` possible en suivi)

Validé en local : boot + import du realm `dso` + `/health/ready` sur :9000 → 200 avec l'image officielle.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Stackée sur #2542 (correctif port healthcheck). Issue racine : #2543.
