### PR TITLE
fix(server-nestjs): surface post-creation repository sync failure

### DIFF
--- a/apps/server-nestjs/src/modules/repository/repository.service.spec.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.service.spec.ts
@@ -186,13 +186,28 @@ describe('repositoryService', () => {
       expect(appEvents.emitRepositoryEvent).not.toHaveBeenCalled()
     })
 
-    it('still returns the repository when the post-creation mirror sync fails', async () => {
+    // Legacy parity: v1 returned 422 when the post-creation sync failed. The DB row
+    // stays committed — the sync is replayable via the dedicated endpoint.
+    it('rejects with 422 when the post-creation mirror sync fails', async () => {
       const repository = makeRepository({ id: repositoryId, projectId, internalRepoName: validCreateRepository.internalRepoName })
       datastore.hasRepositoryWithName.mockResolvedValue(false)
       datastore.createRepository.mockResolvedValue(repository)
       vault.writeGitlabMirrorCreds.mockResolvedValue(undefined)
       appEvents.emitProjectEvent.mockResolvedValue({})
-      appEvents.emitRepositoryEvent.mockRejectedValue(new Error('mirror unreachable'))
+      appEvents.emitRepositoryEvent.mockResolvedValue({
+        gitlab: { status: 'KO', message: 'Unable to find mirror repository', executionTime: 1, error: new Error('boom') },
+      })
+
+      await expect(service.createRepository(projectId, projectSlug, validCreateRepository, userId, requestId))
+        .rejects.toThrow(UnprocessableEntityException)
+    })
+
+    it('still returns the repository when no sync plugin is enabled (empty results)', async () => {
+      const repository = makeRepository({ id: repositoryId, projectId, internalRepoName: validCreateRepository.internalRepoName })
+      datastore.hasRepositoryWithName.mockResolvedValue(false)
+      datastore.createRepository.mockResolvedValue(repository)
+      appEvents.emitProjectEvent.mockResolvedValue({})
+      appEvents.emitRepositoryEvent.mockResolvedValue({})
 
       const result = await service.createRepository(projectId, projectSlug, validCreateRepository, userId, requestId)
 

--- a/apps/server-nestjs/src/modules/repository/repository.service.ts
+++ b/apps/server-nestjs/src/modules/repository/repository.service.ts
@@ -58,17 +58,20 @@ export class RepositoryService {
     )
 
     // Legacy parity: a repository declared with an external source is mirrored right
-    // away, so the first sync doesn't wait for a manual trigger. v1 awaits this sync but
-    // discards its outcome — the creation itself succeeded, and the mirror pipeline is a
-    // downstream effect whose failure is reported in the admin log, not in the response.
+    // away, so the first sync doesn't wait for a manual trigger, and a failed sync
+    // surfaces as 422 (business.ts returned Unprocessable422 in v1). The DB row stays
+    // committed — the sync is replayable via the dedicated endpoint.
     if (repositoryToCreate.externalRepoUrl) {
-      await this.syncRepositoryMirror(
+      const results = await this.syncRepositoryMirror(
         { projectId, projectSlug, internalRepoName: repository.internalRepoName, syncAllBranches: true },
         userId,
         requestId,
-      ).catch((error: unknown) => {
-        this.logger.error(`repository.sync after creation failed (repositoryId=${repository.id})`, error instanceof Error ? error.stack : String(error))
-      })
+      )
+      if (!Object.keys(results).length) {
+        this.logger.warn(`repository.sync after creation had no listener (repositoryId=${repository.id}): no sync plugin is enabled`)
+      } else if (getFailedPlugins(results).length) {
+        throw new UnprocessableEntityException('Echec des services à la synchronisation du dépôt')
+      }
     }
 
     return repository


### PR DESCRIPTION
## Issues liées

#2519

---------

## Quel est le comportement actuel ?

À la création d'un dépôt avec URL externe, l'échec de la synchronisation post-création est avalé : un simple `logger.error`, la requête répond 201 et l'utilisateur ne voit rien. Le legacy renvoyait un 422 (`apps/server/src/resources/repository/business.ts`).

## Quel est le nouveau comportement ?

L'échec de la sync post-création remonte à l'appelant en 422 (parité legacy), la ligne en base restant committée — la sync est rejouable via la route dédiée. Un événement sans destinataire (aucun plugin de sync activé) reste non bloquant mais est journalisé en avertissement.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Investigation détaillée dans les commentaires de #2519.