### PR TITLE
chore(docker): replace deprecated KEYCLOAK_ADMIN_* with KC_BOOTSTRAP_ADMIN_*

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -10,8 +10,8 @@ services:
       - /opt/keycloak/data/h2
     user: root
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_HEALTH_ENABLED: true
     command: start-dev --import-realm
     healthcheck:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -10,8 +10,8 @@ services:
       - ../keycloak/data/dev:/opt/keycloak/data/h2
     user: root
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_HEALTH_ENABLED: true
     command: start-dev --import-realm
     healthcheck:

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -29,8 +29,8 @@ services:
           subpath: keycloak-theme-dsfr.jar
     user: root
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_HEALTH_ENABLED: true
       DSFR_THEME_HOME_URL: http://localhost:8080
       DSFR_THEME_SERVICE_TITLE: Console Cloud π Native


### PR DESCRIPTION
## Issues liées

#2553

---------

## Quel est le comportement actuel ?

Les trois fichiers docker-compose (`ci`, `dev`, `local`) exposent l'administrateur Keycloak via les variables dépréciées `KEYCLOAK_ADMIN` / `KEYCLOAK_ADMIN_PASSWORD` (héritées de la migration d'image effectuée en #2545).

## Quel est le nouveau comportement ?

Remplacement par les variables officielles `KC_BOOTSTRAP_ADMIN` / `KC_BOOTSTRAP_ADMIN_PASSWORD` (valeurs conservées : `admin`), conformément à la documentation upstream Keycloak 26.x.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Portée volontairement limitée au renommage des variables d'admin ; l'image et les chemins `/opt/keycloak/` proviennent déjà de #2545.
