### PR TITLE
Avoid footer link icon appearing over snackbar

### DIFF
--- a/apps/client/src/main.css
+++ b/apps/client/src/main.css
@@ -62,6 +62,12 @@ body,
   margin-right: 25px;
 }
 
+/* Fixes footer "open a new tab" icon from appearing over the snackback */
+.dso-footer .fr-footer__content-link::after {
+  position: relative;
+  z-index: -1;
+}
+
 .danger-zone {
   border-bottom: solid var(--border-plain-warning);
   margin-top: 2rem;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ catalogs:
       specifier: ^1.14.4
       version: 1.14.4
     '@gouvminint/vue-dsfr':
-      specifier: ^8.15.0
-      version: 8.15.0
+      specifier: ^8.19.0
+      version: 8.19.0
     '@himenon/argocd-typescript-openapi':
       specifier: ^1.2.2
       version: 1.2.2
@@ -446,7 +446,7 @@ importers:
         version: 1.14.4
       '@gouvminint/vue-dsfr':
         specifier: catalog:runtime
-        version: 8.15.0(@iconify/vue@4.3.0(vue@3.5.30(typescript@5.9.3)))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 8.19.0(@iconify/vue@4.3.0(vue@3.5.30(typescript@5.9.3)))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@iconify-json/ri':
         specifier: catalog:runtime
         version: 1.2.10
@@ -2694,14 +2694,14 @@ packages:
     resolution: {integrity: sha512-Ca17apmTyAF2tMFwMcLwQN7fTlbfMFeyYSLUIUmjoSg1XVF4vDDkbvvKBpWJWaoTLDSFZBbvvHzcDyxw9wSkLA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  '@gouvminint/vue-dsfr@8.15.0':
-    resolution: {integrity: sha512-e9q7xJeWpGLLFmbe8YCeZ3bgsBM4LWMMiRVmde5DeAfILXewPh3uFKGMphWVKVKnz3tnxrgYM0GoGOn3I9FoYQ==}
-    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
+  '@gouvminint/vue-dsfr@8.19.0':
+    resolution: {integrity: sha512-E1lpfIdFlFnX8MG9zDmkxcmyoX4sJktgSlFiV1cMcIfnJhjiUiwYXVXZs86a6usyiAYQkDALkB6dG8twIMaIMQ==}
+    engines: {node: ^24.15.0 || >=26.0.0, pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
-      '@iconify/vue': ^4.2.0
+      '@iconify/vue': ^5.0.0
       vue: ^3.5.27
-      vue-router: ^4.6.4
+      vue-router: ^5.0.3
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
@@ -6317,8 +6317,8 @@ packages:
       focus-trap: ^7.0.0
       vue: ^3.0.0
 
-  focus-trap@7.8.0:
-    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+  focus-trap@8.2.2:
+    resolution: {integrity: sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -8704,8 +8704,8 @@ packages:
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
 
-  tabbable@6.4.0:
-    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -10958,12 +10958,12 @@ snapshots:
 
   '@gouvfr/dsfr@1.14.4': {}
 
-  '@gouvminint/vue-dsfr@8.15.0(@iconify/vue@4.3.0(vue@3.5.30(typescript@5.9.3)))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@gouvminint/vue-dsfr@8.19.0(@iconify/vue@4.3.0(vue@3.5.30(typescript@5.9.3)))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@gouvfr/dsfr': 1.14.4
       '@iconify/vue': 4.3.0(vue@3.5.30(typescript@5.9.3))
-      focus-trap: 7.8.0
-      focus-trap-vue: 4.1.0(focus-trap@7.8.0)(vue@3.5.30(typescript@5.9.3))
+      focus-trap: 8.2.2
+      focus-trap-vue: 4.1.0(focus-trap@8.2.2)(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
       vue-router: 4.6.4(vue@3.5.30(typescript@5.9.3))
 
@@ -15292,14 +15292,14 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  focus-trap-vue@4.1.0(focus-trap@7.8.0)(vue@3.5.30(typescript@5.9.3)):
+  focus-trap-vue@4.1.0(focus-trap@8.2.2)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
-      focus-trap: 7.8.0
+      focus-trap: 8.2.2
       vue: 3.5.30(typescript@5.9.3)
 
-  focus-trap@7.8.0:
+  focus-trap@8.2.2:
     dependencies:
-      tabbable: 6.4.0
+      tabbable: 6.5.0
 
   follow-redirects@1.16.0: {}
 
@@ -18121,7 +18121,7 @@ snapshots:
 
   systeminformation@5.33.1: {}
 
-  tabbable@6.4.0: {}
+  tabbable@6.5.0: {}
 
   table@6.9.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -74,7 +74,7 @@ catalogs:
     "@gitbeaker/requester-utils": ^40.6.0
     "@gitbeaker/rest": ^40.6.0
     "@gouvfr/dsfr": ^1.14.4
-    "@gouvminint/vue-dsfr": ^8.15.0
+    "@gouvminint/vue-dsfr": ^8.19.0
     "@himenon/argocd-typescript-openapi": ^1.2.2
     "@iconify-json/ri": ^1.2.10
     "@iconify/vue": ^4.3.0


### PR DESCRIPTION
Closes #2560 

Résultat:
<img width="1436" height="157" alt="image" src="https://github.com/user-attachments/assets/9dff6caa-2633-450a-9188-25b8c347a7c0" />

Par contre quand on fait clic-droit sur un lien, ça fait disparaître l'icône haha :sweat_smile: 
<img width="460" height="157" alt="image" src="https://github.com/user-attachments/assets/a737a73d-179b-491c-a0e0-8f2055eadca0" />

On va dire que c'est un compromis acceptable, hein !