### PR TITLE
fix(docker): restore KEYCLOAK_ADMIN for persistent keycloak admin

### DIFF
--- a/.github/workflows/job-playwright.yml
+++ b/.github/workflows/job-playwright.yml
@@ -59,8 +59,11 @@ jobs:
         if: ${{ failure() }}
         run: |
           docker compose -f ./docker/docker-compose.ci.yml ps -a
-          docker compose -f ./docker/docker-compose.ci.yml logs --no-color keycloak
-          docker inspect dso-console_keycloak --format '{{json .State}}'
+          for service in keycloak postgres server server-nestjs client nginx-strangler opencds-mockoon; do
+            echo -e "\nInspecting ${service}..."
+            docker compose -f ./docker/docker-compose.ci.yml logs --no-color ${service}
+            docker inspect dso-console_${service} --format '{{json .State}}'
+          done
 
       - name: Clean up docker resources (containers, volumes)
         run: docker compose -f ./docker/docker-compose.ci.yml down -v --remove-orphans

--- a/.github/workflows/workflow-merge-queue.yml
+++ b/.github/workflows/workflow-merge-queue.yml
@@ -45,6 +45,8 @@ jobs:
         id: filter
         with:
           filters: |
+            docker:
+              - 'docker/**'
             apps:
               - 'apps/**'
             packages:
@@ -117,7 +119,7 @@ jobs:
 
   playwright-tests:
     uses: ./.github/workflows/job-playwright.yml
-    if: ${{ needs.path-filter.outputs.apps == 'true' || needs.path-filter.outputs.packages == 'true' || needs.path-filter.outputs.ci == 'true' ||  needs.path-filter.outputs.e2e == 'true' }}
+    if: ${{ needs.path-filter.outputs.docker == 'true' || needs.path-filter.outputs.apps == 'true' || needs.path-filter.outputs.packages == 'true' || needs.path-filter.outputs.ci == 'true' || needs.path-filter.outputs.e2e == 'true' }}
     needs:
       - path-filter
       - expose-vars

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -15,7 +15,11 @@ services:
       KC_HEALTH_ENABLED: true
     command: start-dev --import-realm
     healthcheck:
-      test: [CMD, curl, --head, -fsS, "http://localhost:9000/health/ready"]
+      test:
+        [
+          'CMD-SHELL',
+          'exec 3<>/dev/tcp/0.0.0.0/9000; echo -e "GET /health/ready HTTP/1.1\nhost: 0.0.0.0:9000\n" >&3; timeout --preserve-status 1 cat <&3 | grep -m 1 status | grep -m 1 UP; ERROR=$?; exec 3<&-; exec 3>&-; exit $ERROR',
+        ]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -10,8 +10,8 @@ services:
       - /opt/keycloak/data/h2
     user: root
     environment:
-      KC_BOOTSTRAP_ADMIN: admin
-      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HEALTH_ENABLED: true
     command: start-dev --import-realm
     healthcheck:

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -38,7 +38,7 @@ services:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U admin -d dso-console-db"]
+      test: ['CMD-SHELL', 'pg_isready -U admin -d dso-console-db']
       interval: 5s
       timeout: 5s
       retries: 10
@@ -66,8 +66,8 @@ services:
       - ../apps/server/.env.docker
     environment:
       NODE_ENV: production
-      CI: "true"
-      DEV_SETUP: "true"
+      CI: 'true'
+      DEV_SETUP: 'true'
     networks:
       - dso-network
 
@@ -89,12 +89,12 @@ services:
     env_file:
       - ../apps/server-nestjs/.env.docker
     environment:
-      NODE_ENV: "production"
-      CI: "true"
-      DEV_SETUP: "true"
-      OPENCDS_URL: "http://dso-opencds_mockoon:3100/api/v1"
-      OPENCDS_API_TOKEN: "token"
-      OPENCDS_API_TLS_REJECT_UNAUTHORIZED: "false"
+      NODE_ENV: 'production'
+      CI: 'true'
+      DEV_SETUP: 'true'
+      OPENCDS_URL: 'http://dso-opencds_mockoon:3100/api/v1'
+      OPENCDS_API_TOKEN: 'token'
+      OPENCDS_API_TLS_REJECT_UNAUTHORIZED: 'false'
     networks:
       - dso-network
 
@@ -111,8 +111,8 @@ services:
       server-nestjs:
         condition: service_healthy
     environment:
-      LEGACY_UPSTREAM: "server:8080"
-      NESTJS_UPSTREAM: "server-nestjs:3001"
+      LEGACY_UPSTREAM: 'server:8080'
+      NESTJS_UPSTREAM: 'server-nestjs:3001'
     networks:
       - dso-network
 
@@ -134,7 +134,7 @@ services:
     env_file:
       - ../apps/client/.env.docker
     environment:
-      OPENCDS_ENABLED: "true"
+      OPENCDS_ENABLED: 'true'
     networks:
       - dso-network
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -10,8 +10,8 @@ services:
       - ../keycloak/data/dev:/opt/keycloak/data/h2
     user: root
     environment:
-      KC_BOOTSTRAP_ADMIN: admin
-      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HEALTH_ENABLED: true
     command: start-dev --import-realm
     healthcheck:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -15,7 +15,11 @@ services:
       KC_HEALTH_ENABLED: true
     command: start-dev --import-realm
     healthcheck:
-      test: [CMD, curl, --head, fsS, "http://localhost:8080/health/ready"]
+      test:
+        [
+          'CMD-SHELL',
+          'exec 3<>/dev/tcp/0.0.0.0/9000; echo -e "GET /health/ready HTTP/1.1\nhost: 0.0.0.0:9000\n" >&3; timeout --preserve-status 1 cat <&3 | grep -m 1 status | grep -m 1 UP; ERROR=$?; exec 3<&-; exec 3>&-; exit $ERROR',
+        ]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -29,8 +29,8 @@ services:
           subpath: keycloak-theme-dsfr.jar
     user: root
     environment:
-      KC_BOOTSTRAP_ADMIN: admin
-      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HEALTH_ENABLED: true
       DSFR_THEME_HOME_URL: http://localhost:8080
       DSFR_THEME_SERVICE_TITLE: Console Cloud π Native

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -39,7 +39,11 @@ services:
       DSFR_THEME_CONTACT_EMAIL: cloudpinative-relations@interieur.gouv.fr
     command: start-dev --import-realm
     healthcheck:
-      test: [CMD, curl, --head, fsS, "http://localhost:8080/health/ready"]
+      test:
+        [
+          'CMD-SHELL',
+          'exec 3<>/dev/tcp/0.0.0.0/9000; echo -e "GET /health/ready HTTP/1.1\nhost: 0.0.0.0:9000\n" >&3; timeout --preserve-status 1 cat <&3 | grep -m 1 status | grep -m 1 UP; ERROR=$?; exec 3<&-; exec 3>&-; exit $ERROR',
+        ]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Issues liées

#2564

## Quel est le comportement actuel ?

#2557 a remplacé `KEYCLOAK_ADMIN` / `KEYCLOAK_ADMIN_PASSWORD` par `KC_BOOTSTRAP_ADMIN` / `KC_BOOTSTRAP_ADMIN_PASSWORD` en supposant que la première paire était dépréciée. Ces variables n'ont pas la même sémantique : `KC_BOOTSTRAP_ADMIN` ne crée pas d'utilisateur `admin` persistant dans le realm `master`, Keycloak retombe sur un admin temporaire (`temp-admin`). `server-nestjs` s'authentifie en `admin`/`admin` (`KEYCLOAK_ADMIN=admin` dans `.env.docker-example`) et échoue avec `invalid_grant` / `user_not_found` → conteneur `unhealthy` → Merge Queue rouge.

## Quel est le nouveau comportement ?

Restauration de `KEYCLOAK_ADMIN` / `KEYCLOAK_ADMIN_PASSWORD` (variables runtime supportées en 26.x, non dépréciées) dans les trois docker-compose (`ci`, `dev`, `local`).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Run de référence (échec avant correctif) : https://github.com/cloud-pi-native/console/actions/runs/32845481155/job/97795194452