### PR TITLE
fix(client): corrige le lien footer de version en 404 pour les déploiements PR

### DIFF
--- a/apps/client/src/App.vue
+++ b/apps/client/src/App.vue
@@ -20,16 +20,35 @@ const adminRoleStore = useAdminRoleStore()
 
 const isLoggedIn = ref<boolean | undefined>(keycloak.authenticated)
 
+const REPO_URL = 'https://github.com/cloud-pi-native/console'
 const rawAppVersion = process.env.APP_VERSION
-const appVersion = rawAppVersion ? `v${rawAppVersion}` : 'vpr-dev'
-// ponytail: APP_VERSION is a semver release tag (9.24.4) or a PR deploy label (pr-2565); map to tag/PR, else releases index
-const appVersionUrl = !rawAppVersion
-  ? 'https://github.com/cloud-pi-native/console/releases'
-  : /^pr-\d+$/.test(rawAppVersion)
-    ? `https://github.com/cloud-pi-native/console/pull/${rawAppVersion.slice(3)}`
-    : /^\d+\.\d+\.\d+/.test(rawAppVersion)
-      ? `https://github.com/cloud-pi-native/console/releases/tag/v${rawAppVersion}`
-      : 'https://github.com/cloud-pi-native/console/releases'
+
+function isPullRequestPreview(version: string): boolean {
+  return /^pr-\d+$/.test(version)
+}
+function isDeployedCommit(version: string): boolean {
+  return /^[0-9a-f]{7,40}$/.test(version.replace(/^sha-/, ''))
+}
+function isReleaseTag(version: string): boolean {
+  return /^v?\d+\.\d+\.\d+/.test(version)
+}
+
+function appVersionLabel(version: string | undefined): string {
+  if (!version) return 'pr-dev'
+  if (isReleaseTag(version)) return version.startsWith('v') ? version : `v${version}`
+  return version
+}
+
+function appVersionUrlFor(version: string | undefined): string {
+  if (!version) return `${REPO_URL}/releases`
+  if (isPullRequestPreview(version)) return `${REPO_URL}/pull/${version.slice(3)}`
+  if (isDeployedCommit(version)) return `${REPO_URL}/commit/${version.replace(/^sha-/, '')}`
+  if (isReleaseTag(version)) return `${REPO_URL}/releases/tag/v${version.replace(/^v/, '')}`
+  return `${REPO_URL}/releases`
+}
+
+const appVersion = appVersionLabel(rawAppVersion)
+const appVersionUrl = appVersionUrlFor(rawAppVersion)
 
 const quickLinks = computed(() => [{
   label: isLoggedIn.value ? 'Se déconnecter' : 'Se connecter',

--- a/apps/client/src/App.vue
+++ b/apps/client/src/App.vue
@@ -20,7 +20,16 @@ const adminRoleStore = useAdminRoleStore()
 
 const isLoggedIn = ref<boolean | undefined>(keycloak.authenticated)
 
-const appVersion: string = process.env.APP_VERSION ? `v${process.env.APP_VERSION}` : 'vpr-dev'
+const rawAppVersion = process.env.APP_VERSION
+const appVersion = rawAppVersion ? `v${rawAppVersion}` : 'vpr-dev'
+// ponytail: APP_VERSION is a semver release tag (9.24.4) or a PR deploy label (pr-2565); map to tag/PR, else releases index
+const appVersionUrl = !rawAppVersion
+  ? 'https://github.com/cloud-pi-native/console/releases'
+  : /^pr-\d+$/.test(rawAppVersion)
+    ? `https://github.com/cloud-pi-native/console/pull/${rawAppVersion.slice(3)}`
+    : /^\d+\.\d+\.\d+/.test(rawAppVersion)
+      ? `https://github.com/cloud-pi-native/console/releases/tag/v${rawAppVersion}`
+      : 'https://github.com/cloud-pi-native/console/releases'
 
 const quickLinks = computed(() => [{
   label: isLoggedIn.value ? 'Se déconnecter' : 'Se connecter',
@@ -107,7 +116,7 @@ watch(userStore, async () => {
           </a>
           <a
             data-testid="appVersionUrl"
-            :href="`https://github.com/cloud-pi-native/console/releases/tag/${appVersion}`"
+            :href="appVersionUrl"
             title="accéder au code source"
           >
             {{ appVersion }}


### PR DESCRIPTION
## Issues liées

#2566

---------

## Quel est le comportement actuel ?

Le footer client lie toujours la version à `https://github.com/cloud-pi-native/console/releases/tag/${appVersion}`.
En déploiement CI/merge-queue, `APP_VERSION` vaut `pr-<num>` (affiché `vpr-<num>`), étiquette jamais publiée en release : la page renvoie une 404.

## Quel est le nouveau comportement ?

Le lien est résolu selon la nature de `APP_VERSION` :
- étiquette de PR (`pr-<num>`) → `https://github.com/cloud-pi-native/console/pull/<num>`
- tag semver (`9.24.4`) → `https://github.com/cloud-pi-native/console/releases/tag/v9.24.4`
- sinon (local `vpr-dev`, valeur inconnue) → index `https://github.com/cloud-pi-native/console/releases`

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Modification isolée à `apps/client/src/App.vue` (un seul fichier, 11 ajouts / 2 suppressions).
Le commit `system-settings.controller.ts` présent dans le working tree a été volontairement exclu de cette PR.