### PR TITLE
fix(server-nestjs): supprimer les dépôts GitLab orphelins appartenant à la console

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
@@ -156,7 +156,10 @@ describe('gitlabService', () => {
       expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledTimes(1)
     })
 
-    it('should not delete orphan repositories if purge disabled', async () => {
+    it('should delete owned orphan repositories even when purge is disabled', async () => {
+      // Aligns with the legacy Fastify server: an explicit repository deletion drops the
+      // DB row and relies on this reconciliation to remove the GitLab project. The opt-in
+      // `purge` gate must not block that path, so owned orphans are always deleted.
       const project = makeProjectWithDetails({
         repositories: [],
       })
@@ -168,12 +171,14 @@ describe('gitlabService', () => {
       gitlab.getRepos.mockImplementation(() => (async function* () {
         yield orphanRepo
       })())
+      gitlab.deleteProjectGroupRepo.mockResolvedValue(undefined)
       gitlab.upsertProjectMirrorRepo.mockResolvedValue(makeProjectSchema({ id: 1, name: 'mirror', path: 'mirror', path_with_namespace: 'forge/console/project-1/mirror', empty_repo: false }))
       gitlab.getOrCreateMirrorPipelineTriggerToken.mockResolvedValue(makePipelineTriggerToken())
 
       await service.handleUpsert(project)
 
-      expect(gitlab.deleteProjectGroupRepo).not.toHaveBeenCalled()
+      expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledWith(project.slug, 'orphan-repo')
+      expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledTimes(1)
     })
 
     it('should not delete orphan repositories without the correct topic even if purge enabled', async () => {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -398,28 +398,18 @@ export class GitlabService {
     const gitlabRepositories = await getAll(this.gitlab.getRepos(project.slug))
     span?.setAttribute('gitlab.repositories.count', gitlabRepositories.length)
 
+    // Delete console-owned repos no longer tracked (e.g. console repository deletion).
     const orphanRepos = gitlabRepositories.filter(r => isOwnedRepo(r) && !isSystemRepo(project, r))
     span?.setAttribute('orphan.repositories.count', orphanRepos.length)
 
-    if (specificallyEnabled(getProjectPluginConfig(project, PURGE_PLUGIN_KEY))) {
-      span?.setAttribute('purge.enabled', true)
-      let removedCount = 0
-      await Promise.all(orphanRepos.map(async (orphan) => {
-        await this.gitlab.deleteProjectGroupRepo(project.slug, orphan.name)
-        removedCount++
-        this.logger.log(`Removed a repository from the GitLab project (project=${project.slug}, repoName=${orphan.name})`)
-      }))
+    let removedCount = 0
+    await Promise.all(orphanRepos.map(async (orphan) => {
+      await this.gitlab.deleteProjectGroupRepo(project.slug, orphan.name)
+      removedCount++
+      this.logger.log(`Removed a repository from the GitLab project (project=${project.slug}, repoName=${orphan.name})`)
+    }))
 
-      span?.setAttribute('orphan.repositories.removed.count', removedCount)
-    } else {
-      span?.setAttribute('purge.enabled', false)
-      let warnedCount = 0
-      for (const orphan of orphanRepos) {
-        warnedCount++
-        this.logger.warn(`Repository is in GitLab but not in the project definition (purge disabled, project=${project.slug}, repoName=${orphan.name})`)
-      }
-      span?.setAttribute('managed.repositories.warned.count', warnedCount)
-    }
+    span?.setAttribute('orphan.repositories.removed.count', removedCount)
   }
 
   @StartActiveSpan()


### PR DESCRIPTION
## Issues liées

#2533 — symptôme aval : les secrets Vault `-mirror` des dépôts orphelins ne sont jamais détruits (conséquence directe de ce bug).

---------

## Quel est le comportement actuel ?

La suppression d'un dépôt depuis la console client renvoie `204`, mais le dépôt GitLab correspondant reste présent. La réconciliation `purgeOrphanRepos` ne supprimait les dépôts orphelins appartenant à la console (topic `plugin-managed`) que lorsque le flag `purge` était explicitement activé ; par défaut elle se contentait de journaliser un avertissement.

## Quel est le nouveau comportement ?

`purgeOrphanRepos` supprime désormais de façon inconditionnelle tout dépôt GitLab orphelin portant le topic `plugin-managed`, indépendamment du flag `purge`. Cela aligne la réécriture NestJS sur le comportement du serveur Fastify historique (`plugins/gitlab/src/repositories.ts` → `ensureRepositories`, suppression inconditionnelle des excédents). Le flag `purge` conserve son rôle de garde-fou pour le reste de la réconciliation d'ambiance (membres, etc.). Les dépôts système (`mirror`, `infra-apps`) ne sont pas concernés car ils ne portent pas le topic `plugin-managed`.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

- Contrôleur concerné : `apps/server-nestjs/src/modules/repository/repository.controller.ts` → `RepositoryService.deleteRepository` (suppression de la ligne DB puis `project.upsert`).
- Le chemin legacy `apps/server` (Fastify, figé) n'est plus celui qui sert l'API v2 `RepositoriesV2`, d'où la correction dans `apps/server-nestjs`.
- Tests : `gitlab.service.spec.ts` mis à jour — le cas « purge désactivé » attend désormais la suppression.
