### PR TITLE
fix(server-nestjs): protège createUser contre les descriptions GitLab non textuelles

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
@@ -937,6 +937,28 @@ describe('gitlab-client', () => {
       expect(gitlabApi.Users.create).toHaveBeenCalledTimes(1)
     })
 
+    it('should tolerate a non-string cause.description on 409 (regression: .includes is not a function, #2544)', async () => {
+      // GitLab validation errors serialize `message` as an object; gitbeaker copies
+      // it verbatim into cause.description despite typing it as string.
+      const email = 'user@example.com'
+      const username = 'user'
+      const name = 'User Name'
+
+      gitlabApi.Users.create.mockRejectedValueOnce(
+        new GitbeakerRequestError('Error', {
+          cause: {
+            description: { 'project_namespace.name': ['has already been taken'] } as unknown as string,
+            request: new Request('https://gitlab.internal.example/api'),
+            response: new Response(null, { status: 400 }),
+          },
+        }),
+      )
+
+      await expect(service.createUser({ email, username, name }))
+        .rejects.toThrow(GitbeakerRequestError)
+      expect(gitlabApi.Users.all).not.toHaveBeenCalled()
+    })
+
     it('should propagate a non-collision error', async () => {
       const email = 'user@example.com'
       const username = 'user'

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -413,7 +413,7 @@ export class GitlabClientService {
     } catch (error) {
       // GitLab auto-provisions users via OIDC, so a 409 means the user already
       // exists (email index race in getUserByEmail). Return it instead of failing.
-      if (error instanceof GitbeakerRequestError && error.cause?.description?.includes('has already been taken')) {
+      if (hasGitbeakerCause(error, 'has already been taken')) {
         const existing = user.email ? await this.getUserByEmail(user.email) : null
         if (existing) return existing as UserSchema
         throw error


### PR DESCRIPTION
## Issues liées

#2544

---------

## Quel est le comportement actuel ?

`createUser` (`gitlab-client.service.ts:416`) teste encore `error.cause?.description?.includes('has already been taken')` directement. Quand GitLab renvoie une erreur de validation, gitbeaker recopie l'objet `message` JSON tel quel dans `cause.description` (typé `string` à tort) — `.includes is not a function`, le TypeError masque la vraie cause. Les trois sites signalés dans #2544 (`createGroup`, `createSubGroup`, `getOrCreateRepo`) utilisent déjà `hasGitbeakerCause` ; ce quatrième appel frère du même fichier avait été manqué.

## Quel est le nouveau comportement ?

Réutilisation de l'existant : `hasGitbeakerCause(error, 'has already been taken')`, même helper que les trois sites déjà corrigés. Une description non textuelle ne crashe plus — l'erreur d'origine est relancée proprement (pas de rattrapage erroné vers `getUserByEmail`).

Test de régression ajouté au bloc existant `describe('createUser')` : description objet `{ 'project_namespace.name': ['has already been taken'] }` → rejet `GitbeakerRequestError`, sans fallback email.

54/54 tests verts ; tsc sans erreur sur le module.

## Cette PR introduit-elle un breaking change ?

Non.