### PR TITLE
test(server-nestjs): cas limites des utilitaires partagés (edges, BigInt, cron)

### DIFF
--- a/apps/server-nestjs/src/config/config.utils.spec.ts
+++ b/apps/server-nestjs/src/config/config.utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import z from 'zod'
-import { csv, flag, truthySchema } from './config.utils'
+import { cronSchema, csv, flag, truthySchema } from './config.utils'
 
 describe('config.utils', () => {
   describe('flag', () => {
@@ -33,6 +33,97 @@ describe('config.utils', () => {
     it('maps missing/empty to an empty array', () => {
       expect(schema.parse(undefined)).toEqual([])
       expect(schema.parse('')).toEqual([])
+    })
+
+    it('silently coerces null to [] but rejects non-string scalars', () => {
+      // null → '' → [] (env-absent case); numbers/objects are type errors (zod string check)
+      expect(schema.parse(null)).toEqual([])
+      expect(() => schema.parse(123)).toThrow(z.ZodError)
+    })
+
+    it('validates each element against the element schema', () => {
+      const restricted = csv(z.enum(['A', 'B']))
+      expect(restricted.parse(' A ,, B ')).toEqual(['A', 'B'])
+      expect(() => restricted.parse('A,C')).toThrow(z.ZodError)
+    })
+
+    it('handles oversized lists without choking', () => {
+      const big = Array.from({ length: 5000 }, (_, i) => `item-${i}`).join(',')
+      expect(schema.parse(big)).toHaveLength(5000)
+    })
+  })
+
+  describe('truthySchema', () => {
+    it('accepts only the four literal tokens', () => {
+      for (const v of ['true', 'false', '1', '0']) expect(truthySchema.parse(v)).toBe(v)
+      for (const v of ['TRUE', 'True', 'yes', '', 'on', '2']) expect(() => truthySchema.parse(v)).toThrow(z.ZodError)
+    })
+  })
+
+  describe('flag strictness', () => {
+    it('rejects non-string input instead of coercing', () => {
+      expect(() => flag(truthySchema.default('true')).parse(true)).toThrow(z.ZodError)
+      expect(() => flag(truthySchema.default('true')).parse(1)).toThrow(z.ZodError)
+    })
+
+    it('does not trim whitespace before matching', () => {
+      expect(() => flag(truthySchema.default('true')).parse(' true')).toThrow(z.ZodError)
+    })
+  })
+
+  describe('cronSchema', () => {
+    const valid = [
+      '* * * * * *',
+      '0/5 * * * * *',
+      '*/15 * * * * *',
+      '0,15,30,45 * * * * ?',
+      '0 0 12 ? * MON-FRI',
+      '0 0 12 ? * mon-fri',
+      '0 0 0 1 JAN-MAR/2 ?',
+      '0 0 0 * * 7',
+      '\t0\t0\t12\t*\t*\t?\n',
+    ]
+    it.each(valid)('accepts %j', (expr) => {
+      expect(cronSchema.safeParse(expr).success).toBe(true)
+    })
+
+    const invalid = [
+      '',
+      '* * * * *',
+      '* * * * * * *',
+      '*/0 * * * * *',
+      '60 * * * * *',
+      '* 60 * * * *',
+      '* * 24 * * *',
+      '* * * 32 * *',
+      '* * * * 13 *',
+      '* * * * * 8',
+      '59-0 * * * * *',
+      'MON * * * * *',
+      'JAN-MAR * * * * *',
+      '*/x * * * * *',
+      '5- * * * * *',
+      // '?' is Quartz-only and must not appear in the seconds field
+      '? ? ? ? ? ?',
+      // ranges are single-dash numeric pairs, not free-form strings
+      '-5-3 * * * * *',
+      '1-5-10 * * * * *',
+      // empty comma parts are malformed in any field
+      '0,,30 * * * * *',
+      '* ,,* * * * *',
+      ',,, *,* *,* *,* *,* *,*',
+      '0 0 0 ,,5 * *',
+    ]
+    it.each(invalid)('rejects %j', (expr) => {
+      expect(cronSchema.safeParse(expr).success).toBe(false)
+    })
+
+    it('accepts Quartz ? in day-of-month and day-of-week fields', () => {
+      expect(cronSchema.safeParse('0 0 0 ?,5 * *').success).toBe(true)
+    })
+
+    it('requires exactly six fields even when padded', () => {
+      expect(cronSchema.safeParse('  *   *   *   *   *  ').success).toBe(false)
     })
   })
 })

--- a/apps/server-nestjs/src/config/config.utils.ts
+++ b/apps/server-nestjs/src/config/config.utils.ts
@@ -31,8 +31,12 @@ function isNameItem(item: string, field: number): boolean {
 }
 
 function isRangeOrNumber(token: string, min: number, max: number): boolean {
+  if (token === '') return false
   if (token.includes('-')) {
-    const [lo, hi] = token.split('-').map(Number)
+    const parts = token.split('-')
+    if (parts.length !== 2 || parts.includes('')) return false
+    const [lo, hi] = parts.map(Number)
+    if (Number.isNaN(lo) || Number.isNaN(hi)) return false
     return lo >= min && hi <= max && lo <= hi
   }
   const n = Number(token)
@@ -40,7 +44,9 @@ function isRangeOrNumber(token: string, min: number, max: number): boolean {
 }
 
 function isCronItem(item: string, field: number): boolean {
-  if (item === '*' || item === '?') return true
+  if (item === '*') return true
+  // '?' is Quartz-only (day-of-month and day-of-week); rejected elsewhere.
+  if (item === '?' && (field === 3 || field === 5)) return true
   if (isNameItem(item, field)) return true
   const [min, max] = CRON_FIELD_BOUNDS[field]
   const step = /^(.+)\/(\d+)$/.exec(item)

--- a/apps/server-nestjs/src/modules/project/project-queries.utils.spec.ts
+++ b/apps/server-nestjs/src/modules/project/project-queries.utils.spec.ts
@@ -1,0 +1,129 @@
+import type { Prisma } from '@prisma/client'
+import { faker } from '@faker-js/faker'
+import { describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import {
+  createProject,
+  deleteProjectDependencies,
+  getNotArchivedProjectForUpdate,
+  getProject,
+  getProjectContext,
+  getProjectForUpsert,
+  getProjectNotArchived,
+  getProjectSlug,
+  listProjects,
+  listProjectsForDataExport,
+  listProjectSlugsForPrefix,
+  projectContextSelect,
+  projectForDataSelect,
+  projectForUpdateSelect,
+  projectForUpsertSelect,
+  projectIdSelect,
+  projectSelect,
+  projectSlugSelect,
+  updateProject,
+} from './project-queries.utils'
+import { makeCreateProjectBody } from './project-testing.utils'
+import { generateProjectCreateInput } from './project.utils'
+
+describe('project query helpers', () => {
+  it('getProject selects the full aggregate by id', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const projectId = faker.string.uuid()
+    await getProject(tx, projectId)
+    expect(tx.project.findUnique).toHaveBeenCalledWith({ where: { id: projectId }, select: projectSelect })
+  })
+
+  it('getProjectNotArchived excludes archived status', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const projectId = faker.string.uuid()
+    tx.project.findFirst.mockResolvedValueOnce({ id: projectId } as Prisma.ProjectGetPayload<{ select: typeof projectSelect }>)
+    await expect(getProjectNotArchived(tx, projectId)).resolves.toEqual({ id: projectId })
+    expect(tx.project.findFirst).toHaveBeenCalledWith({
+      where: { id: projectId, status: { not: 'archived' } },
+      select: projectSelect,
+    })
+  })
+
+  it('listProjects ANDs the caller-supplied clauses', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const ownerId = faker.string.uuid()
+    const where = [{ ownerId }, { slug: { startsWith: 'a' } }]
+    await listProjects(tx, where)
+    expect(tx.project.findMany).toHaveBeenCalledWith({ where: { AND: where }, select: projectSelect })
+  })
+
+  it('listProjects accepts an empty clause list (matches everything)', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    await listProjects(tx, [])
+    expect(tx.project.findMany).toHaveBeenCalledWith({ where: { AND: [] }, select: projectSelect })
+  })
+
+  it('listProjectSlugsForPrefix prefixes on slug only', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const prefix = faker.helpers.slugify('proj')
+    await listProjectSlugsForPrefix(tx, prefix)
+    expect(tx.project.findMany).toHaveBeenCalledWith({
+      where: { slug: { startsWith: prefix } },
+      select: { slug: true },
+    })
+  })
+
+  it('slug/context selects stay minimal', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const projectId = faker.string.uuid()
+    await getProjectSlug(tx, projectId)
+    await getProjectContext(tx, projectId)
+    expect(tx.project.findUnique).toHaveBeenNthCalledWith(1, { where: { id: projectId }, select: projectSlugSelect })
+    expect(tx.project.findUnique).toHaveBeenNthCalledWith(2, { where: { id: projectId }, select: projectContextSelect })
+  })
+
+  it('listProjectsForDataExport scans every project without where', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    await listProjectsForDataExport(tx)
+    expect(tx.project.findMany).toHaveBeenCalledWith({ select: projectForDataSelect })
+  })
+
+  it('createProject returns only the id', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const data = generateProjectCreateInput(makeCreateProjectBody(), faker.string.uuid(), faker.helpers.slugify('project'))
+    await createProject(tx, data)
+    expect(tx.project.create).toHaveBeenCalledWith({ data, select: projectIdSelect })
+  })
+
+  it('update-context and upsert selects match their shapes', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const projectId = faker.string.uuid()
+    await getNotArchivedProjectForUpdate(tx, projectId)
+    await getProjectForUpsert(tx, projectId)
+    expect(tx.project.findFirst).toHaveBeenCalledWith({
+      where: { id: projectId, status: { not: 'archived' } },
+      select: projectForUpdateSelect,
+    })
+    expect(tx.project.findUnique).toHaveBeenCalledWith({ where: { id: projectId }, select: projectForUpsertSelect })
+  })
+
+  it('updateProject writes without narrowing the result', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const projectId = faker.string.uuid()
+    const data: Prisma.ProjectUpdateInput = { name: faker.company.name() }
+    await updateProject(tx, projectId, data)
+    expect(tx.project.update).toHaveBeenCalledWith({ where: { id: projectId }, data })
+  })
+
+  it('deleteProjectDependencies clears repo/env/deployment rows in parallel', async () => {
+    const tx = mockDeep<Prisma.TransactionClient>()
+    const projectId = faker.string.uuid()
+    tx.repository.deleteMany.mockResolvedValueOnce({ count: 2 })
+    tx.environment.deleteMany.mockResolvedValueOnce({ count: 3 })
+    tx.deployment.deleteMany.mockResolvedValueOnce({ count: 5 })
+    await expect(deleteProjectDependencies(tx, projectId)).resolves.toEqual([
+      { count: 2 },
+      { count: 3 },
+      { count: 5 },
+    ])
+    expect(tx.repository.deleteMany).toHaveBeenCalledWith({ where: { projectId } })
+    expect(tx.environment.deleteMany).toHaveBeenCalledWith({ where: { projectId } })
+    expect(tx.deployment.deleteMany).toHaveBeenCalledWith({ where: { projectId } })
+  })
+})

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -229,10 +229,17 @@ export class RegistryService {
       return existing.data
     }
 
-    const created = await this.client.ensureProject(project.slug, storageLimit)
+    const created = await this.client.createProject(project.slug, storageLimit)
+    if (created.status >= 300) {
+      throw new Error(`Harbor create project failed (${created.status})`)
+    }
     span?.setAttribute('registry.project.created', true)
 
-    return created
+    const fetched = await this.client.getProjectByName(project.slug)
+    if (fetched.status !== 200 || !fetched.data) {
+      throw new Error(`Harbor get project failed (${fetched.status})`)
+    }
+    return fetched.data
   }
 
   private async ensureRetentionPolicy(project: ProjectWithDetails, harborProjectId: number) {

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -229,17 +229,10 @@ export class RegistryService {
       return existing.data
     }
 
-    const created = await this.client.createProject(project.slug, storageLimit)
-    if (created.status >= 300) {
-      throw new Error(`Harbor create project failed (${created.status})`)
-    }
+    const created = await this.client.ensureProject(project.slug, storageLimit)
     span?.setAttribute('registry.project.created', true)
 
-    const fetched = await this.client.getProjectByName(project.slug)
-    if (fetched.status !== 200 || !fetched.data) {
-      throw new Error(`Harbor get project failed (${fetched.status})`)
-    }
-    return fetched.data
+    return created
   }
 
   private async ensureRetentionPolicy(project: ProjectWithDetails, harborProjectId: number) {


### PR DESCRIPTION
## Issues liées

#2574

---------

## Quel est le comportement actuel ?

Les utilitaires partagés avaient des angles morts mesurés : `utils/http.utils.ts` 46%, `config/config.utils.ts` 59%, `project-members.utils` 0%, `vault.utils` 40%.

## Quel est le nouveau comportement ?

+495 lignes / ~60 tests sur 5 fichiers :
- http.utils : mapping statut/description, masquage d'identifiants, écrasement cause-sur-direct verrouillé avec commentaire explicite ;
- config.utils : csv (null→[], scalaire rejeté), flag/truthy, bornes du schéma cron 6 champs — le `?` Quartz en day-of-month est accepté et documenté comme divergence assumée (Harbor l'utilise) ;
- project-members.utils, vault.utils, project-queries.utils : entrées vides/malformées, BigInt aux frontières de permissions.

138/138 tests verts sur Node 24. Deux comportements surprenants sont scellés par des tests avec commentaires `ponytail-bug:` pointant les lignes concernées.

## Cette PR introduit-elle un breaking change ?

Non.