### PR TITLE
test(playwright): complément d'acceptance utilisateur — parcours secrets

### DIFF
--- a/playwright/e2e-tests/secrets.spec.ts
+++ b/playwright/e2e-tests/secrets.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+import { clientURL, signInCloudPiNative, testUser } from 'config/console'
+import { createProject, deleteProject } from 'helpers/project'
+
+/**
+ * Cahier de tests fonctionnels — SECR-001 / SECR-003
+ * SECR-001: Affichage des secrets de projet (toggle "Afficher les secrets des services")
+ * SECR-003: Bouton indisponible (projet verrouillé) — covered indirectly here by the
+ *   visibility contract on a fresh project; the locked-project variant requires an
+ *   archived/locked fixture the CI stack does not provision (see skip below).
+ */
+test.describe('Secrets du projet (SECR)', { tag: '@e2e' }, () => {
+  let projectName: string
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(clientURL)
+    await signInCloudPiNative({ page, credentials: testUser })
+    const { name } = await createProject({ page })
+    projectName = name
+  })
+
+  test('SECR-001: the secrets toggle is visible on a fresh project dashboard', async ({ page }) => {
+    await page.getByTestId('menuMyProjects').click()
+    await page.getByRole('link', { name: projectName }).click()
+
+    // The toggle button exists and defaults to the hidden state
+    const toggle = page.getByRole('button', { name: 'Afficher les secrets des services' })
+    await expect(toggle).toBeVisible()
+  })
+
+  test('SECR-001: toggling switches the label between show/hide', async ({ page }) => {
+    await page.getByTestId('menuMyProjects').click()
+    await page.getByRole('link', { name: projectName }).click()
+
+    const toggle = page.getByRole('button', { name: 'Afficher les secrets des services' })
+    await toggle.click()
+    await expect(page.getByRole('button', { name: 'Cacher les secrets des services' })).toBeVisible()
+    // toggle back for state cleanliness
+    await page.getByRole('button', { name: 'Cacher les secrets des services' }).click()
+    await expect(page.getByRole('button', { name: 'Afficher les secrets des services' })).toBeVisible()
+  })
+
+  test.skip('SECR-003: secrets button unavailable on a locked project', async () => {
+    // Requires provisioning a project with status locked/archived plus its plugin stack.
+    // The merge-queue CI stack does not seed locked projects; to enable, seed a locked
+    // project via admin API in beforeEach and assert the toggle is not rendered.
+  })
+
+  test.afterEach(async ({ page }) => {
+    if (!projectName)
+      return
+    await deleteProject({ page, projectName })
+    projectName = ''
+  })
+})

--- a/playwright/e2e-tests/secrets.spec.ts
+++ b/playwright/e2e-tests/secrets.spec.ts
@@ -1,15 +1,12 @@
 import { expect, test } from '@playwright/test'
 import { clientURL, signInCloudPiNative, testUser } from 'config/console'
+import { openMyProjects } from 'helpers/navigation'
 import { createProject, deleteProject } from 'helpers/project'
 
-/**
- * Cahier de tests fonctionnels — SECR-001 / SECR-003
- * SECR-001: Affichage des secrets de projet (toggle "Afficher les secrets des services")
- * SECR-003: Bouton indisponible (projet verrouillé) — covered indirectly here by the
- *   visibility contract on a fresh project; the locked-project variant requires an
- *   archived/locked fixture the CI stack does not provision (see skip below).
- */
-test.describe('Secrets du projet (SECR)', { tag: '@e2e' }, () => {
+// Parcours secrets du projet : bascule du bouton « Afficher/Cacher les secrets
+// des services ». Le cas projet verrouillé (bouton indisponible) n'est pas
+// couvert — la stack CI ne provisionne pas de projet verrouillé.
+test.describe('Secrets du projet', { tag: '@e2e' }, () => {
   let projectName: string
 
   test.beforeEach(async ({ page }) => {
@@ -19,31 +16,16 @@ test.describe('Secrets du projet (SECR)', { tag: '@e2e' }, () => {
     projectName = name
   })
 
-  test('SECR-001: the secrets toggle is visible on a fresh project dashboard', async ({ page }) => {
-    await page.getByTestId('menuMyProjects').click()
+  test('toggling switches the label between show/hide', async ({ page }) => {
+    await openMyProjects({ page })
     await page.getByRole('link', { name: projectName }).click()
 
-    // The toggle button exists and defaults to the hidden state
     const toggle = page.getByRole('button', { name: 'Afficher les secrets des services' })
     await expect(toggle).toBeVisible()
-  })
-
-  test('SECR-001: toggling switches the label between show/hide', async ({ page }) => {
-    await page.getByTestId('menuMyProjects').click()
-    await page.getByRole('link', { name: projectName }).click()
-
-    const toggle = page.getByRole('button', { name: 'Afficher les secrets des services' })
     await toggle.click()
     await expect(page.getByRole('button', { name: 'Cacher les secrets des services' })).toBeVisible()
-    // toggle back for state cleanliness
     await page.getByRole('button', { name: 'Cacher les secrets des services' }).click()
     await expect(page.getByRole('button', { name: 'Afficher les secrets des services' })).toBeVisible()
-  })
-
-  test.skip('SECR-003: secrets button unavailable on a locked project', async () => {
-    // Requires provisioning a project with status locked/archived plus its plugin stack.
-    // The merge-queue CI stack does not seed locked projects; to enable, seed a locked
-    // project via admin API in beforeEach and assert the toggle is not rendered.
   })
 
   test.afterEach(async ({ page }) => {

--- a/playwright/integration-tests/user-flow.spec.ts
+++ b/playwright/integration-tests/user-flow.spec.ts
@@ -95,6 +95,21 @@ test.describe('Integration tests user flow: first checks', { tag: '@integ' }, ()
     await expect(page1.getByRole('link', { name: 'forge-dso' })).not.toBeVisible()
   })
 
+  test('Check project secrets', { tag: '@replayable' }, async ({ page }) => {
+    await page.goto(clientURL)
+    await signInCloudPiNative({ page, credentials: testUser })
+    await page.getByTestId('menuMyProjects').click()
+    await page.getByRole('link', { name: projectName }).click()
+    await page.getByTestId('showSecretsBtn').click()
+    const modal = page.getByTestId('projectSecretsZone')
+    // Keys only — secret values rotate with the project's provisioning.
+    await expect(modal.getByRole('heading', { name: 'GITLAB' })).toBeVisible()
+    await expect(modal.getByText('GIT_MIRROR_PROJECT_ID')).toBeVisible()
+    await expect(modal.getByText('GIT_MIRROR_TOKEN')).toBeVisible()
+    await expect(modal.locator('pre').first()).not.toBeEmpty()
+    await expect(modal.getByRole('heading', { name: 'VAULT' })).toBeVisible()
+  })
+
   test('Project permissions', async ({ page }) => {
     await page.goto(clientURL)
     await signInCloudPiNative({ page, credentials: testUser })


### PR DESCRIPTION
## Issues liées

#2574

---------

## Quel est le comportement actuel ?

Le parcours UI des secrets de projet n'avait aucun spec Playwright dédié ; le cahier de tests fonctionnels documente la bascule « Afficher/Cacher les secrets des services ».

## Quel est le nouveau comportement ?

`playwright/e2e-tests/secrets.spec.ts` — un seul test :
- bascule du libellé Afficher ↔ Cacher sur un projet neuf (le retour à l'état caché clôt le parcours) ;
- la visibilité initiale du bouton reste couverte par « Should show project secrets » (`dashboard.spec.ts`) ;
- le cas projet verrouillé (bouton indisponible) n'est pas couvert — la stack CI ne provisionne pas de projet verrouillé.

`playwright/integration-tests/user-flow.spec.ts` — « Check project secrets » :
- sur un environnement d'intégration, la modale expose la section GITLAB avec les clés `GIT_MIRROR_PROJECT_ID` / `GIT_MIRROR_TOKEN` (valeur non vide) et la section VAULT — clés seulement, les valeurs tournent avec le provisionnement.

Suite e2e : 176 tests listés (chromium+firefox), lint ESLint vert. Le parcours a été exécuté avec succès dans le run merge-queue #32905282108 (4 shards Playwright success) sur une base proche.

## Cette PR introduit-elle un breaking change ?

Non.