### PR TITLE
fix(client): guard syncRepository against cleared selectedRepo after await

### DIFF
--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -120,15 +120,16 @@ async function deleteRepo(repoId: Repo['id']) {
 }
 
 async function syncRepository() {
-  if (!selectedRepo.value) return
+  const repo = selectedRepo.value
+  if (!repo) return
   if (!isAllSyncing.value && !branchName.value) branchName.value = defaultBranchName
   await props.project.Repositories.sync(
-    selectedRepo.value.id,
+    repo.id,
     isAllSyncing.value
       ? { syncAllBranches: true }
       : { syncAllBranches: false, branchName: branchName.value },
   )
-  snackbarStore.setMessage(`Travail de synchronisation lancé pour le dépôt ${selectedRepo.value.internalRepoName}`)
+  snackbarStore.setMessage(`Travail de synchronisation lancé pour le dépôt ${repo.internalRepoName}`)
 }
 
 // Add locale-specific relative date/time formatting rules.


### PR DESCRIPTION
## Issues liées

Issues numéro:
- #2602

---------

## Quel est le comportement actuel ?
Le snackbar affiche `can't access property "internalRepoName", h.value is undefined` au lancement d'une synchronisation de dépôt si la modale est fermée pendant l'appel (save / delete / reload) : `selectedRepo` est vidé, et `syncRepository()` lit `selectedRepo.value.internalRepoName` après l'await de `Repositories.sync(...)`.

## Quel est le nouveau comportement ?
`syncRepository()` fige `const repo = selectedRepo.value` avant l'await et utilise cette référence pour `.id` et `.internalRepoName`. Aucun accès post-await sur une référence volatile ; plus de TypeError en snackbar.

## Cette PR introduit-elle un breaking change ?
Non.

## Autres informations
Fichier modifié : `apps/client/src/components/ProjectResources.vue` — `syncRepository()`
