### PR TITLE
fix(server-nestjs): resolve Keycloak root group by path, not name

### DIFF
--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
@@ -310,3 +310,64 @@ describe('deleteGroup', () => {
     await expect(service.deleteGroup('gone-id')).resolves.toBeUndefined()
   })
 })
+
+describe('getOrCreateGroupByPath root resolution (issue #2518)', () => {
+  let module: TestingModule
+  let service: KeycloakClientService
+
+  const groupsUrl = `${keycloakUrl}/admin/realms/${projectRealm}/groups`
+  const rootChildrenUrl = `${keycloakUrl}/admin/realms/${projectRealm}/groups/root-id/children`
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  beforeEach(async () => {
+    module = await createKeycloakClientServiceTestingModule().compile()
+    service = module.get(KeycloakClientService)
+    useTokenEndpoint()
+    await module.init()
+  })
+  afterEach(async () => {
+    await module.close()
+    server.resetHandlers()
+  })
+  afterAll(() => server.close())
+
+  it('should resolve the root group by exact path, not a same-named subgroup elsewhere', async () => {
+    // A subgroup at a different path shares the slug name; the name-fallback
+    // must not pick it up as the project root (was the #2518 bug).
+    server.use(
+      http.get(groupsUrl, () => HttpResponse.json([
+        { id: 'wrong-id', name: 'myproject', path: '/console/other/myproject' },
+        { id: 'root-id', name: 'myproject', path: '/myproject' },
+      ])),
+      http.get(rootChildrenUrl, () => HttpResponse.json([])),
+    )
+
+    const result = await service.getOrCreateGroupByPath('/myproject')
+
+    expect(result).toMatchObject({ id: 'root-id', path: '/myproject' })
+  })
+
+  it('should create the root group when only a wrong-path subgroup matches the name', async () => {
+    let created = false
+    server.use(
+      http.get(groupsUrl, () => HttpResponse.json(
+        created
+          ? [{ id: 'created-id', name: 'myproject', path: '/myproject' }]
+          : [{ id: 'wrong-id', name: 'myproject', path: '/console/other/myproject' }],
+      )),
+      http.post(groupsUrl, async ({ request }) => {
+        expect(await request.json()).toEqual({ name: 'myproject' })
+        created = true
+        return new HttpResponse(null, {
+          status: 201,
+          headers: { location: `${keycloakUrl}/admin/realms/${projectRealm}/groups/created-id` },
+        })
+      }),
+      http.get(rootChildrenUrl, () => HttpResponse.json([])),
+    )
+
+    const result = await service.getOrCreateGroupByPath('/myproject')
+
+    expect(result).toMatchObject({ id: 'created-id', path: '/myproject' })
+  })
+})

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
@@ -84,7 +84,7 @@ export class KeycloakClientService implements OnModuleInit {
 
   private async getRootGroupByName(name: string): Promise<GroupRepresentationWithIdNamePath | undefined> {
     const candidates = await this.client.groups.find({ search: name, briefRepresentation: false }) ?? []
-    const match = candidates.find(g => g.path === `/${name}`) ?? candidates.find(g => g.name === name)
+    const match = candidates.find(g => g.path === `/${name}`)
     const parsed = groupSchema.safeParse(match)
     return parsed.success ? parsed.data : undefined
   }
@@ -185,7 +185,7 @@ export class KeycloakClientService implements OnModuleInit {
     }
 
     const [rootName, ...rest] = parts
-    let current = await this.getGroupByName(rootName) ?? await this.createGroup(rootName)
+    let current = await this.getRootGroupByName(rootName) ?? await this.createGroup(rootName)
     for (const name of rest) {
       current = await this.getOrCreateSubGroupByName(current.id, name)
     }


### PR DESCRIPTION
## Issues liées

Closes #2518

---

## Comportement actuel

Lors de l'ajout d'un repo d'infrastructure, l'événement `project.upsert` déclenche `KeycloakService.syncProject` -> `getOrCreateGroupByPath('/<slug>')`. Deux défauts dans `KeycloakClientService` :

1. `getRootGroupByName` : le fallback `?? candidates.find(g => g.name === name)` sur `groups.find({ search })` (recherche par sous-chaîne à toutes les profondeurs) peut retourner un **sous-groupe à un autre chemin** (ex. `/console/other/myproject`) au lieu du groupe racine `/<slug>`.
2. `getOrCreateGroupByPath` : le segment racine appelait `getGroupByName` (recherche large par nom) au lieu de `getRootGroupByName` (recherche par path).

L'ID de groupe erroné alimente ensuite `getGroupMembers` -> `listMembers` -> Keycloak répond « Could not find group by id ».

## Nouveau comportement

1. `getRootGroupByName` ne match plus que par path exact `/<name>` (groupes racine uniquement) — suppression du fallback par nom.
2. `getOrCreateGroupByPath` utilise `getRootGroupByName` pour le segment racine avant création.

2 tests unitaires couvrent : réutilisation du groupe racine existant (match par path malgré un sous-groupe au mauvais chemin de même nom), et création du groupe racine quand seule une sous-groupe au mauvais chemin correspond.

## Breaking change

Non.
