### PR TITLE
fix(server-nestjs): protect system GitLab repos by topic, cover observability

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
@@ -287,7 +287,7 @@ describe('gitlab-client', () => {
       gitlabApi.Projects.show.mockResolvedValue(makeProjectSchema({ id: repoId }))
       gitlabApi.Projects.edit.mockResolvedValue(makeProjectSchema({ id: repoId, name: repoName }))
 
-      const result = await service.upsertProjectGroupRepo(projectSlug, repoName, 'desc')
+      const result = await service.upsertProjectGroupRepo(projectSlug, repoName, { description: 'desc' })
 
       expect(result).toEqual(expect.objectContaining({ id: repoId, name: repoName }))
       expect(gitlabApi.ProjectCustomAttributes.set).toHaveBeenCalledWith(repoId, MANAGED_BY_CONSOLE_CUSTOM_ATTRIBUTE_KEY, 'true')

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -33,6 +33,7 @@ import {
   SPECIAL_REPO_NAMES,
   TOKEN_DESCRIPTION,
   TOPIC_PLUGIN_MANAGED,
+  TOPIC_SYSTEM_MANAGED,
   USER_ID_CUSTOM_ATTRIBUTE_KEY,
 } from './gitlab.constants'
 import { generateGitlabCIConfigContent, generateMirrorScriptContent, hasFileContentChanged, hasGitbeakerCause, isGitbeakerNotFound } from './gitlab.utils'
@@ -42,6 +43,12 @@ export const GITLAB_REST_CLIENT = Symbol('GITLAB_REST_CLIENT')
 type With<T, K extends keyof T> = T & Required<Pick<T, K>>
 export type CondensedGroupSchemaWith<T extends keyof CondensedGroupSchema> = With<CondensedGroupSchema, T>
 export type CondensedProjectSchemaWith<T extends keyof CondensedProjectSchema> = With<CondensedProjectSchema, T>
+
+export interface UpsertProjectGroupRepoOptions {
+  description?: string
+  ciConfigPath?: string
+  extraTopics?: string[]
+}
 export type EditUserOptionsWith<T extends keyof EditUserOptions> = With<EditUserOptions, T>
 type UserSchema = SimpleUserSchema | ExpandedUserSchema
 
@@ -460,13 +467,14 @@ export class GitlabClientService {
     }
   }
 
-  async upsertProjectGroupRepo(projectSlug: string, repoName: string, description?: string, ciConfigPath?: string) {
+  async upsertProjectGroupRepo(projectSlug: string, repoName: string, options: UpsertProjectGroupRepoOptions = {}) {
+    const { description, ciConfigPath, extraTopics = [] } = options
     const fullPath = `${projectSlug}/${repoName}`
     const repo = await this.getOrCreateProjectGroupRepo(projectSlug, fullPath, ciConfigPath)
     const updated = await this.client.Projects.edit(repo.id, {
       name: repoName,
       path: repoName,
-      topics: [TOPIC_PLUGIN_MANAGED],
+      topics: [TOPIC_PLUGIN_MANAGED, ...extraTopics],
       description,
       ciConfigPath: ciConfigPath ?? '',
     })
@@ -585,7 +593,7 @@ export class GitlabClientService {
   }
 
   async upsertProjectMirrorRepo(projectSlug: string) {
-    return this.upsertProjectGroupRepo(projectSlug, MIRROR_REPO_NAME)
+    return this.upsertProjectGroupRepo(projectSlug, MIRROR_REPO_NAME, { extraTopics: [TOPIC_SYSTEM_MANAGED] })
   }
 
   async getProjectToken(group: CondensedGroupSchemaWith<'id'>, projectSlug: string) {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -481,6 +481,14 @@ export class GitlabClientService {
     return updated
   }
 
+  // System repos (mirror, infra-apps, observability values, ...) are console-owned plumbing:
+  // created in the project subgroup but never listed in project.repositories, so the orphan
+  // purge must never delete them. They carry the dedicated system-managed topic; any plugin
+  // can opt its system repo in by upserting it through this wrapper.
+  async upsertProjectGroupSystemRepo(projectSlug: string, repoName: string, options: Omit<UpsertProjectGroupRepoOptions, 'extraTopics'> = {}) {
+    return this.upsertProjectGroupRepo(projectSlug, repoName, { ...options, extraTopics: [TOPIC_SYSTEM_MANAGED] })
+  }
+
   async deleteProjectGroupRepo(projectSlug: string, repoName: string) {
     const fullPath = `${projectSlug}/${repoName}`
     const repo = await this.getOrCreateProjectGroupRepo(projectSlug, fullPath)
@@ -593,7 +601,7 @@ export class GitlabClientService {
   }
 
   async upsertProjectMirrorRepo(projectSlug: string) {
-    return this.upsertProjectGroupRepo(projectSlug, MIRROR_REPO_NAME, { extraTopics: [TOPIC_SYSTEM_MANAGED] })
+    return this.upsertProjectGroupSystemRepo(projectSlug, MIRROR_REPO_NAME)
   }
 
   async getProjectToken(group: CondensedGroupSchemaWith<'id'>, projectSlug: string) {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
@@ -15,6 +15,12 @@ export const GITLAB_CI_CONFIG_PATH = '.gitlab-ci-dso.yml'
 
 // Managed resources sentinel
 export const TOPIC_PLUGIN_MANAGED = 'plugin-managed'
+
+// Console-owned plumbing/infra repositories (infra-apps, mirror, observability values...).
+// Created in the project subgroup but never listed in project.repositories, so the
+// orphan-repo purge must never delete them. Protected via this dedicated topic instead of a
+// hardcoded name list, so any plugin can opt its own system repo in by tagging it here.
+export const TOPIC_SYSTEM_MANAGED = 'system-managed'
 export const TOKEN_DESCRIPTION = 'mirroring-from-external-repo'
 
 // Default group paths for console roles

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
@@ -16,10 +16,7 @@ export const GITLAB_CI_CONFIG_PATH = '.gitlab-ci-dso.yml'
 // Managed resources sentinel
 export const TOPIC_PLUGIN_MANAGED = 'plugin-managed'
 
-// Console-owned plumbing/infra repositories (infra-apps, mirror, observability values...).
-// Created in the project subgroup but never listed in project.repositories, so the
-// orphan-repo purge must never delete them. Protected via this dedicated topic instead of a
-// hardcoded name list, so any plugin can opt its own system repo in by tagging it here.
+// Console-owned plumbing repos (mirror, infra-apps, observability...), protected from orphan purge
 export const TOPIC_SYSTEM_MANAGED = 'system-managed'
 export const TOKEN_DESCRIPTION = 'mirroring-from-external-repo'
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
@@ -7,11 +7,12 @@ import { Test } from '@nestjs/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { gitlabConfigFactory } from '../../config/gitlab.config'
+import { OBSERVABILITY_REPOSITORY } from '../observability/observability.constants'
 import { VaultClientService } from '../vault/vault-client.service'
 import { GitlabClientService } from './gitlab-client.service'
 import { GitlabDatastoreService } from './gitlab-datastore.service'
 import { makeAccessTokenExposedSchema, makeExpandedUserSchema, makeGroupSchema, makeMemberSchema, makePipeline, makePipelineTriggerToken, makeProjectSchema, makeProjectWithDetails } from './gitlab-testing.utils'
-import { PLUGIN_NAME, TOPIC_PLUGIN_MANAGED } from './gitlab.constants'
+import { INFRA_APPS_REPO_NAME, MIRROR_REPO_NAME, PLUGIN_NAME, TOPIC_PLUGIN_MANAGED, TOPIC_SYSTEM_MANAGED } from './gitlab.constants'
 import { GitlabService } from './gitlab.service'
 
 describe('gitlabService', () => {
@@ -179,6 +180,55 @@ describe('gitlabService', () => {
 
       expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledWith(project.slug, 'orphan-repo')
       expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledTimes(1)
+    })
+
+    it('should never delete system repositories (infra-apps, mirror) even though they are not in project.repositories', async () => {
+      const project = makeProjectWithDetails({ repositories: [] })
+      const group = makeGroupSchema({ id: 123, name: 'project-1', path: 'project-1', full_path: 'forge/console/project-1', full_name: 'forge/console/project-1', parent_id: 1 })
+      const infraApps = makeProjectSchema({ name: INFRA_APPS_REPO_NAME, topics: [TOPIC_PLUGIN_MANAGED, TOPIC_SYSTEM_MANAGED] })
+      const mirror = makeProjectSchema({ name: MIRROR_REPO_NAME, topics: [TOPIC_PLUGIN_MANAGED, TOPIC_SYSTEM_MANAGED] })
+      const userRepo = makeProjectSchema({ name: 'user-repo', topics: [TOPIC_PLUGIN_MANAGED] })
+
+      gitlab.getOrCreateProjectSubGroup.mockResolvedValue(group)
+      gitlab.getGroupMembers.mockResolvedValue([])
+      gitlab.getRepos.mockImplementation(() => (async function* () {
+        yield infraApps
+        yield mirror
+        yield userRepo
+      })())
+      gitlab.deleteProjectGroupRepo.mockResolvedValue(undefined)
+      gitlab.upsertProjectMirrorRepo.mockResolvedValue(makeProjectSchema({ id: 1, name: 'mirror', path: 'mirror', path_with_namespace: 'forge/console/project-1/mirror', empty_repo: false }))
+      gitlab.getOrCreateMirrorPipelineTriggerToken.mockResolvedValue(makePipelineTriggerToken())
+
+      await service.handleUpsert(project)
+
+      expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledTimes(1)
+      expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledWith(project.slug, 'user-repo')
+      expect(gitlab.deleteProjectGroupRepo).not.toHaveBeenCalledWith(project.slug, INFRA_APPS_REPO_NAME)
+      expect(gitlab.deleteProjectGroupRepo).not.toHaveBeenCalledWith(project.slug, MIRROR_REPO_NAME)
+    })
+
+    it('should never delete the observability system repository (infra-observability) even though it is not in project.repositories', async () => {
+      const project = makeProjectWithDetails({ repositories: [] })
+      const group = makeGroupSchema({ id: 123, name: 'project-1', path: 'project-1', full_path: 'forge/console/project-1', full_name: 'forge/console/project-1', parent_id: 1 })
+      const observabilityRepo = makeProjectSchema({ name: OBSERVABILITY_REPOSITORY, topics: [TOPIC_PLUGIN_MANAGED, TOPIC_SYSTEM_MANAGED] })
+      const userRepo = makeProjectSchema({ name: 'user-repo', topics: [TOPIC_PLUGIN_MANAGED] })
+
+      gitlab.getOrCreateProjectSubGroup.mockResolvedValue(group)
+      gitlab.getGroupMembers.mockResolvedValue([])
+      gitlab.getRepos.mockImplementation(() => (async function* () {
+        yield observabilityRepo
+        yield userRepo
+      })())
+      gitlab.deleteProjectGroupRepo.mockResolvedValue(undefined)
+      gitlab.upsertProjectMirrorRepo.mockResolvedValue(makeProjectSchema({ id: 1, name: 'mirror', path: 'mirror', path_with_namespace: 'forge/console/project-1/mirror', empty_repo: false }))
+      gitlab.getOrCreateMirrorPipelineTriggerToken.mockResolvedValue(makePipelineTriggerToken())
+
+      await service.handleUpsert(project)
+
+      expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledTimes(1)
+      expect(gitlab.deleteProjectGroupRepo).toHaveBeenCalledWith(project.slug, 'user-repo')
+      expect(gitlab.deleteProjectGroupRepo).not.toHaveBeenCalledWith(project.slug, OBSERVABILITY_REPOSITORY)
     })
 
     it('should not delete orphan repositories without the correct topic even if purge enabled', async () => {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -43,7 +43,7 @@ import {
   generateUsernameCandidates,
   getProjectPluginConfig,
   hasGitbeakerCause,
-  isInternalRepo,
+  isDeclaredRepo,
   isOwnedRepo,
   isOwnedUser,
   isSystemRepo,
@@ -399,7 +399,7 @@ export class GitlabService {
     span?.setAttribute('gitlab.repositories.count', gitlabRepositories.length)
 
     // Delete console-owned repos no longer tracked (e.g. console repository deletion).
-    const orphanRepos = gitlabRepositories.filter(r => isOwnedRepo(r) && !isSystemRepo(r) && !isInternalRepo(project, r))
+    const orphanRepos = gitlabRepositories.filter(r => isOwnedRepo(r) && !isSystemRepo(r) && !isDeclaredRepo(project, r))
     span?.setAttribute('orphan.repositories.count', orphanRepos.length)
 
     let removedCount = 0

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -43,6 +43,7 @@ import {
   generateUsernameCandidates,
   getProjectPluginConfig,
   hasGitbeakerCause,
+  isInternalRepo,
   isOwnedRepo,
   isOwnedUser,
   isSystemRepo,
@@ -398,7 +399,7 @@ export class GitlabService {
     span?.setAttribute('gitlab.repositories.count', gitlabRepositories.length)
 
     // Delete console-owned repos no longer tracked (e.g. console repository deletion).
-    const orphanRepos = gitlabRepositories.filter(r => isOwnedRepo(r) && !isSystemRepo(project, r))
+    const orphanRepos = gitlabRepositories.filter(r => isOwnedRepo(r) && !isSystemRepo(r) && !isInternalRepo(project, r))
     span?.setAttribute('orphan.repositories.count', orphanRepos.length)
 
     let removedCount = 0

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -31,7 +31,6 @@ import {
   PROJECT_MAINTAINER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
   PROJECT_REPORTER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
   PURGE_PLUGIN_KEY,
-  TOPIC_SYSTEM_MANAGED,
 } from './gitlab.constants'
 import {
   adminRoleFlag,
@@ -474,7 +473,7 @@ export class GitlabService {
   }
 
   private async ensureInfraAppsRepo(project: ProjectWithDetails) {
-    await this.gitlab.upsertProjectGroupRepo(project.slug, INFRA_APPS_REPO_NAME, { extraTopics: [TOPIC_SYSTEM_MANAGED] })
+    await this.gitlab.upsertProjectGroupSystemRepo(project.slug, INFRA_APPS_REPO_NAME)
   }
 
   private async ensureMirrorRepo(project: ProjectWithDetails) {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.ts
@@ -31,6 +31,7 @@ import {
   PROJECT_MAINTAINER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
   PROJECT_REPORTER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
   PURGE_PLUGIN_KEY,
+  TOPIC_SYSTEM_MANAGED,
 } from './gitlab.constants'
 import {
   adminRoleFlag,
@@ -41,6 +42,7 @@ import {
   generateUsername,
   generateUsernameCandidates,
   getProjectPluginConfig,
+  hasGitbeakerCause,
   isOwnedRepo,
   isOwnedUser,
   isSystemRepo,
@@ -146,9 +148,9 @@ export class GitlabService {
     const members = await this.gitlab.getGroupMembers(group)
     this.logger.verbose(`Loaded GitLab project group state (${project.slug}): groupId=${group.id} members=${members.length}`)
     await this.ensureProjectGroupMembers(project, group, members)
+    await this.ensureSystemRepos(project)
     await this.ensureProjectRepos(project)
     await this.purgeOrphanRepos(project)
-    await this.ensureSystemRepos(project)
     this.logger.verbose(`GitLab project group reconciled (${project.slug})`)
   }
 
@@ -370,12 +372,9 @@ export class GitlabService {
         ...(externalHost ? { 'repository.external.host': externalHost } : {}),
         'repository.external': !!repo.externalRepoUrl,
       })
-      await this.gitlab.upsertProjectGroupRepo(
-        project.slug,
-        repo.internalRepoName,
-        undefined,
-        repo.externalRepoUrl ? GITLAB_CI_CONFIG_PATH : undefined,
-      )
+      await this.gitlab.upsertProjectGroupRepo(project.slug, repo.internalRepoName, {
+        ciConfigPath: repo.externalRepoUrl ? GITLAB_CI_CONFIG_PATH : undefined,
+      })
 
       if (repo.externalRepoUrl) {
         span?.setAttribute('repository.mirroring', true)
@@ -404,7 +403,17 @@ export class GitlabService {
 
     let removedCount = 0
     await Promise.all(orphanRepos.map(async (orphan) => {
-      await this.gitlab.deleteProjectGroupRepo(project.slug, orphan.name)
+      try {
+        await this.gitlab.deleteProjectGroupRepo(project.slug, orphan.name)
+      } catch (err) {
+        // GitLab deletion is asynchronous: a repo already marked for deletion by a
+        // prior run surfaces a transient 400. Ignore only that; let real errors propagate.
+        if (hasGitbeakerCause(err, /already marked for deletion/)) {
+          this.logger.warn(`Repository already marked for deletion, skipping (project=${project.slug}, repoName=${orphan.name})`)
+          return
+        }
+        throw err
+      }
       removedCount++
       this.logger.log(`Removed a repository from the GitLab project (project=${project.slug}, repoName=${orphan.name})`)
     }))
@@ -464,7 +473,7 @@ export class GitlabService {
   }
 
   private async ensureInfraAppsRepo(project: ProjectWithDetails) {
-    await this.gitlab.upsertProjectGroupRepo(project.slug, INFRA_APPS_REPO_NAME)
+    await this.gitlab.upsertProjectGroupRepo(project.slug, INFRA_APPS_REPO_NAME, { extraTopics: [TOPIC_SYSTEM_MANAGED] })
   }
 
   private async ensureMirrorRepo(project: ProjectWithDetails) {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
@@ -225,12 +225,12 @@ export function isSystemRepo(repo: ProjectSchema) {
   return repo.topics?.includes(TOPIC_SYSTEM_MANAGED) ?? false
 }
 
-export function isInternalRepo(project: ProjectWithDetails, repo: ProjectSchema) {
+export function isDeclaredRepo(project: ProjectWithDetails, repo: ProjectSchema) {
   // A repo declared in project.repositories is managed by the console and must never be purged,
   // even though it may not carry the `system-managed` topic yet (e.g. repos created before the
-  // topic existed). The orphan purge only targets repos that are neither system- nor internally
-  // declared; keeping this check makes the purge safe for pre-existing repos until the next
-  // reconciliation tags them.
+  // topic existed). The orphan purge only targets repos that are neither system- nor declared
+  // in the project; keeping this check makes the purge safe for pre-existing repos until the
+  // next reconciliation tags them.
   return project.repositories.some(r => r.internalRepoName === repo.name)
 }
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
@@ -218,12 +218,20 @@ export function isOwnedRepo(repo: ProjectSchema) {
   return repo.topics?.includes(TOPIC_PLUGIN_MANAGED) ?? false
 }
 
-export function isSystemRepo(project: ProjectWithDetails, repo: ProjectSchema) {
+export function isSystemRepo(repo: ProjectSchema) {
   // Console-owned plumbing repos (infra-apps, mirror, observability values, ...) carry the
   // `system-managed` topic and are never listed in project.repositories; protect them from purge.
   // Topic-based instead of a hardcoded name list so any plugin can opt its system repo in.
-  return repo.topics?.includes(TOPIC_SYSTEM_MANAGED)
-    || project.repositories.some(r => r.internalRepoName === repo.name)
+  return repo.topics?.includes(TOPIC_SYSTEM_MANAGED) ?? false
+}
+
+export function isInternalRepo(project: ProjectWithDetails, repo: ProjectSchema) {
+  // A repo declared in project.repositories is managed by the console and must never be purged,
+  // even though it may not carry the `system-managed` topic yet (e.g. repos created before the
+  // topic existed). The orphan purge only targets repos that are neither system- nor internally
+  // declared; keeping this check makes the purge safe for pre-existing repos until the next
+  // reconciliation tags them.
+  return project.repositories.some(r => r.internalRepoName === repo.name)
 }
 
 export function getProjectPluginConfig(project: ProjectWithDetails, key: string) {

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.utils.ts
@@ -4,7 +4,7 @@ import { createHash } from 'node:crypto'
 import { AccessLevel } from '@gitbeaker/core'
 import { GitbeakerRequestError } from '@gitbeaker/requester-utils'
 import { stringify } from 'yaml'
-import { TOPIC_PLUGIN_MANAGED } from './gitlab.constants'
+import { TOPIC_PLUGIN_MANAGED, TOPIC_SYSTEM_MANAGED } from './gitlab.constants'
 
 export type ProjectAccessLevel = Exclude<AccessLevel, (typeof AccessLevel)['ADMIN']>
 
@@ -219,7 +219,11 @@ export function isOwnedRepo(repo: ProjectSchema) {
 }
 
 export function isSystemRepo(project: ProjectWithDetails, repo: ProjectSchema) {
-  return project.repositories.some(r => r.internalRepoName === repo.name)
+  // Console-owned plumbing repos (infra-apps, mirror, observability values, ...) carry the
+  // `system-managed` topic and are never listed in project.repositories; protect them from purge.
+  // Topic-based instead of a hardcoded name list so any plugin can opt its system repo in.
+  return repo.topics?.includes(TOPIC_SYSTEM_MANAGED)
+    || project.repositories.some(r => r.internalRepoName === repo.name)
 }
 
 export function getProjectPluginConfig(project: ProjectWithDetails, key: string) {

--- a/apps/server-nestjs/src/modules/observability/observability.service.ts
+++ b/apps/server-nestjs/src/modules/observability/observability.service.ts
@@ -10,6 +10,7 @@ import { trace } from '@opentelemetry/api'
 import { observabilityConfigFactory } from '../../config/observability.config'
 import { getErrorResponseStatus } from '../../utils/http.utils'
 import { GitlabClientService } from '../gitlab/gitlab-client.service'
+import { TOPIC_SYSTEM_MANAGED } from '../gitlab/gitlab.constants'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { KeycloakClientService } from '../keycloak/keycloak-client.service'
 import { capturePluginResult } from '../plugin/plugin.utils'
@@ -100,7 +101,7 @@ export class ObservabilityService {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.verbose(`Ensuring observability project repository for ${project.slug}`)
-    await this.gitlab.upsertProjectGroupRepo(project.slug, OBSERVABILITY_REPOSITORY)
+    await this.gitlab.upsertProjectGroupRepo(project.slug, OBSERVABILITY_REPOSITORY, { extraTopics: [TOPIC_SYSTEM_MANAGED] })
   }
 
   @StartActiveSpan()
@@ -114,7 +115,7 @@ export class ObservabilityService {
   }
 
   private async syncChartFiles(project: ProjectWithDetails) {
-    const projectRepo = await this.gitlab.upsertProjectGroupRepo(project.slug, OBSERVABILITY_REPOSITORY)
+    const projectRepo = await this.gitlab.upsertProjectGroupRepo(project.slug, OBSERVABILITY_REPOSITORY, { extraTopics: [TOPIC_SYSTEM_MANAGED] })
     const actions = await this.buildChartActions(projectRepo)
     await this.gitlab.maybeCreateCommit(projectRepo, 'ci: :robot_face: Sync observability chart', actions)
   }

--- a/apps/server-nestjs/src/modules/observability/observability.service.ts
+++ b/apps/server-nestjs/src/modules/observability/observability.service.ts
@@ -10,7 +10,6 @@ import { trace } from '@opentelemetry/api'
 import { observabilityConfigFactory } from '../../config/observability.config'
 import { getErrorResponseStatus } from '../../utils/http.utils'
 import { GitlabClientService } from '../gitlab/gitlab-client.service'
-import { TOPIC_SYSTEM_MANAGED } from '../gitlab/gitlab.constants'
 import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator'
 import { KeycloakClientService } from '../keycloak/keycloak-client.service'
 import { capturePluginResult } from '../plugin/plugin.utils'
@@ -101,7 +100,7 @@ export class ObservabilityService {
     const span = trace.getActiveSpan()
     span?.setAttribute('project.slug', project.slug)
     this.logger.verbose(`Ensuring observability project repository for ${project.slug}`)
-    await this.gitlab.upsertProjectGroupRepo(project.slug, OBSERVABILITY_REPOSITORY, { extraTopics: [TOPIC_SYSTEM_MANAGED] })
+    await this.gitlab.upsertProjectGroupSystemRepo(project.slug, OBSERVABILITY_REPOSITORY)
   }
 
   @StartActiveSpan()
@@ -115,7 +114,7 @@ export class ObservabilityService {
   }
 
   private async syncChartFiles(project: ProjectWithDetails) {
-    const projectRepo = await this.gitlab.upsertProjectGroupRepo(project.slug, OBSERVABILITY_REPOSITORY, { extraTopics: [TOPIC_SYSTEM_MANAGED] })
+    const projectRepo = await this.gitlab.upsertProjectGroupSystemRepo(project.slug, OBSERVABILITY_REPOSITORY)
     const actions = await this.buildChartActions(projectRepo)
     await this.gitlab.maybeCreateCommit(projectRepo, 'ci: :robot_face: Sync observability chart', actions)
   }

--- a/apps/server-nestjs/test/argocd.e2e-spec.ts
+++ b/apps/server-nestjs/test/argocd.e2e-spec.ts
@@ -20,7 +20,7 @@ import { LoggerModule } from '../src/modules/infrastructure/logger/logger.module
 import { PermissionModule } from '../src/modules/infrastructure/permission/permission.module'
 import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
-import { ARGOCD_RECONCILE_TIMEOUT, EXTERNAL_SYNC_TIMEOUT } from './constants'
+import { ARGOCD_RECONCILE_TIMEOUT, GITLAB_SYNC_TIMEOUT } from './constants'
 
 const canRunArgoCDE2E
   = Boolean(process.env.E2E)
@@ -306,5 +306,5 @@ describeWithArgoCD('ArgoCDService (e2e)', () => {
 
     const prodFile = await gitlab.getFile(infraProject, prodFilePath, 'main')
     expect(prodFile).toBeUndefined()
-  }, EXTERNAL_SYNC_TIMEOUT)
+  }, GITLAB_SYNC_TIMEOUT)
 })

--- a/apps/server-nestjs/test/argocd.e2e-spec.ts
+++ b/apps/server-nestjs/test/argocd.e2e-spec.ts
@@ -20,7 +20,7 @@ import { LoggerModule } from '../src/modules/infrastructure/logger/logger.module
 import { PermissionModule } from '../src/modules/infrastructure/permission/permission.module'
 import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
-import { ARGOCD_RECONCILE_TIMEOUT, EXTERNAL_SYNC_TIMEOUT } from './e2e-timeout'
+import { ARGOCD_RECONCILE_TIMEOUT, EXTERNAL_SYNC_TIMEOUT } from './constants'
 
 const canRunArgoCDE2E
   = Boolean(process.env.E2E)

--- a/apps/server-nestjs/test/constants.ts
+++ b/apps/server-nestjs/test/constants.ts
@@ -2,6 +2,8 @@
 // Each timeout names the task it bounds so a reader knows which system and operation it covers.
 export const SONARQUBE_PROJECT_TIMEOUT = 30_000 // provision + delete a SonarQube project/user
 export const KEYCLOAK_GROUP_SYNC_TIMEOUT = 60_000 // reconcile Keycloak groups/roles
-export const EXTERNAL_SYNC_TIMEOUT = 72_000 // sync GitLab groups/members, teardown Nexus/registry
+export const GITLAB_SYNC_TIMEOUT = 72_000 // sync GitLab groups/members/repos, mirror pipeline trigger
+export const GITLAB_PURGE_SYNC_TIMEOUT = 150_000 // GitLab reconcile twice (create + orphan purge) on shared env
+export const NEXUS_SYNC_TIMEOUT = 72_000 // reconcile Nexus repos/roles/users, teardown on delete
 export const ARGOCD_RECONCILE_TIMEOUT = 144_000 // ArgoCD commit + sync to git
 export const VAULT_PROVISION_TIMEOUT = 180_000 // provision Vault mounts/policies/approles, zone secrets

--- a/apps/server-nestjs/test/constants.ts
+++ b/apps/server-nestjs/test/constants.ts
@@ -3,9 +3,5 @@
 export const SONARQUBE_PROJECT_TIMEOUT = 30_000 // provision + delete a SonarQube project/user
 export const KEYCLOAK_GROUP_SYNC_TIMEOUT = 60_000 // reconcile Keycloak groups/roles
 export const EXTERNAL_SYNC_TIMEOUT = 72_000 // sync GitLab groups/members, teardown Nexus/registry
-// A project reconcile that also exercises the orphan purge runs the gitlab plugin twice
-// (create + purge) on a shared integration environment; the 72s EXTERNAL_SYNC_TIMEOUT is
-// not enough for that double pass.
-export const GITLAB_PURGE_RECONCILE_TIMEOUT = 150_000
 export const ARGOCD_RECONCILE_TIMEOUT = 144_000 // ArgoCD commit + sync to git
 export const VAULT_PROVISION_TIMEOUT = 180_000 // provision Vault mounts/policies/approles, zone secrets

--- a/apps/server-nestjs/test/e2e-timeout.ts
+++ b/apps/server-nestjs/test/e2e-timeout.ts
@@ -3,5 +3,9 @@
 export const SONARQUBE_PROJECT_TIMEOUT = 30_000 // provision + delete a SonarQube project/user
 export const KEYCLOAK_GROUP_SYNC_TIMEOUT = 60_000 // reconcile Keycloak groups/roles
 export const EXTERNAL_SYNC_TIMEOUT = 72_000 // sync GitLab groups/members, teardown Nexus/registry
+// A project reconcile that also exercises the orphan purge runs the gitlab plugin twice
+// (create + purge) on a shared integration environment; the 72s EXTERNAL_SYNC_TIMEOUT is
+// not enough for that double pass.
+export const GITLAB_PURGE_RECONCILE_TIMEOUT = 150_000
 export const ARGOCD_RECONCILE_TIMEOUT = 144_000 // ArgoCD commit + sync to git
 export const VAULT_PROVISION_TIMEOUT = 180_000 // provision Vault mounts/policies/approles, zone secrets

--- a/apps/server-nestjs/test/gitlab.e2e-spec.ts
+++ b/apps/server-nestjs/test/gitlab.e2e-spec.ts
@@ -22,7 +22,7 @@ import { PermissionModule } from '../src/modules/infrastructure/permission/permi
 import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
 import { getAll } from '../src/utils/iterable.utils'
-import { EXTERNAL_SYNC_TIMEOUT, VAULT_PROVISION_TIMEOUT } from './constants'
+import { GITLAB_PURGE_SYNC_TIMEOUT, GITLAB_SYNC_TIMEOUT } from './constants'
 
 const canRunGitlabE2E
   = Boolean(process.env.E2E)
@@ -173,7 +173,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
     const repoSecret = await vaultService.read(repoVaultPath)
     expect(repoSecret?.data?.GIT_OUTPUT_USER).toBeTruthy()
     expect(repoSecret?.data?.GIT_OUTPUT_PASSWORD).toBeTruthy()
-  }, EXTERNAL_SYNC_TIMEOUT)
+  }, GITLAB_SYNC_TIMEOUT)
 
   it('system repos use the default CI file, user repos mirroring an external URL use the custom one', async () => {
     const project = await prisma.project.findUniqueOrThrow({
@@ -203,7 +203,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
     // commitMirror wrote the default CI file into the mirror repo
     const ciFile = await gitlabClientService.getFile(mirror, '.gitlab-ci.yml', 'main')
     expect(ciFile).toBeTruthy()
-  }, EXTERNAL_SYNC_TIMEOUT)
+  }, GITLAB_SYNC_TIMEOUT)
 
   it('should trigger the mirror pipeline using the mirror repo default CI config', async () => {
     const project = await prisma.project.findUniqueOrThrow({
@@ -229,7 +229,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
 
     const pipeline = await gitlabClientService.triggerMirror(testProjectSlug, 'app', false, 'main')
     expect(pipeline.id).toBeTruthy()
-  }, EXTERNAL_SYNC_TIMEOUT)
+  }, GITLAB_SYNC_TIMEOUT)
 
   describe('project members', () => {
     let newUserId: string | undefined
@@ -293,7 +293,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
       const members = await gitlabClientService.getGroupMembers(group)
       const isNewMemberPresent = members.some(m => m.id === newUserGitlabId)
       expect(isNewMemberPresent).toBe(true)
-    }, EXTERNAL_SYNC_TIMEOUT)
+    }, GITLAB_SYNC_TIMEOUT)
   })
 
   describe('system repo purge protection', () => {
@@ -342,7 +342,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
       expect(namesAfter).toContain(MIRROR_REPO_NAME)
       expect(namesAfter).toContain(INFRA_APPS_REPO_NAME)
       expect(namesAfter).toContain('app')
-    }, VAULT_PROVISION_TIMEOUT)
+    }, GITLAB_PURGE_SYNC_TIMEOUT)
 
     it('declared user repos are never purged even without the system-managed topic', async () => {
       const project = await prisma.project.findUniqueOrThrow({
@@ -368,7 +368,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
 
       const reposAfter = await getAll(gitlabClientService.getRepos(testProjectSlug))
       expect(reposAfter.some(repo => repo.name === 'app')).toBe(true)
-    }, VAULT_PROVISION_TIMEOUT)
+    }, GITLAB_PURGE_SYNC_TIMEOUT)
 
     it('purge does not fail when a repo is already marked for deletion', async () => {
       // Create a NEW orphan repo in GitLab, then delete it directly (async). The
@@ -399,7 +399,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
       expect(namesAfter).toContain(MIRROR_REPO_NAME)
       expect(namesAfter).toContain(INFRA_APPS_REPO_NAME)
       expect(namesAfter).toContain('app')
-    }, VAULT_PROVISION_TIMEOUT)
+    }, GITLAB_PURGE_SYNC_TIMEOUT)
   })
 
   it('should remove project group from GitLab on delete', async () => {
@@ -415,5 +415,5 @@ describeWithGitLab('GitlabService (e2e)', () => {
 
     const group = await gitlabClientService.getGroupByPath(groupPath)
     expect(group).toBeUndefined()
-  }, EXTERNAL_SYNC_TIMEOUT)
+  }, GITLAB_SYNC_TIMEOUT)
 })

--- a/apps/server-nestjs/test/gitlab.e2e-spec.ts
+++ b/apps/server-nestjs/test/gitlab.e2e-spec.ts
@@ -22,7 +22,7 @@ import { PermissionModule } from '../src/modules/infrastructure/permission/permi
 import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
 import { getAll } from '../src/utils/iterable.utils'
-import { EXTERNAL_SYNC_TIMEOUT, GITLAB_PURGE_RECONCILE_TIMEOUT } from './e2e-timeout'
+import { EXTERNAL_SYNC_TIMEOUT, VAULT_PROVISION_TIMEOUT } from './constants'
 
 const canRunGitlabE2E
   = Boolean(process.env.E2E)
@@ -342,7 +342,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
       expect(namesAfter).toContain(MIRROR_REPO_NAME)
       expect(namesAfter).toContain(INFRA_APPS_REPO_NAME)
       expect(namesAfter).toContain('app')
-    }, GITLAB_PURGE_RECONCILE_TIMEOUT)
+    }, VAULT_PROVISION_TIMEOUT)
 
     it('declared user repos are never purged even without the system-managed topic', async () => {
       const project = await prisma.project.findUniqueOrThrow({
@@ -368,7 +368,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
 
       const reposAfter = await getAll(gitlabClientService.getRepos(testProjectSlug))
       expect(reposAfter.some(repo => repo.name === 'app')).toBe(true)
-    }, GITLAB_PURGE_RECONCILE_TIMEOUT)
+    }, VAULT_PROVISION_TIMEOUT)
 
     it('purge does not fail when a repo is already marked for deletion', async () => {
       // Create a NEW orphan repo in GitLab, then delete it directly (async). The
@@ -399,7 +399,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
       expect(namesAfter).toContain(MIRROR_REPO_NAME)
       expect(namesAfter).toContain(INFRA_APPS_REPO_NAME)
       expect(namesAfter).toContain('app')
-    }, GITLAB_PURGE_RECONCILE_TIMEOUT)
+    }, VAULT_PROVISION_TIMEOUT)
   })
 
   it('should remove project group from GitLab on delete', async () => {

--- a/apps/server-nestjs/test/gitlab.e2e-spec.ts
+++ b/apps/server-nestjs/test/gitlab.e2e-spec.ts
@@ -10,8 +10,9 @@ import z from 'zod'
 import { baseConfigFactory } from '../src/config/base.config'
 import { GITLAB_REST_CLIENT, GitlabClientService } from '../src/modules/gitlab/gitlab-client.service'
 import { projectSelect } from '../src/modules/gitlab/gitlab-datastore.service'
-import { GITLAB_CI_CONFIG_PATH } from '../src/modules/gitlab/gitlab.constants'
+import { GITLAB_CI_CONFIG_PATH, INFRA_APPS_REPO_NAME, MIRROR_REPO_NAME, TOPIC_PLUGIN_MANAGED, TOPIC_SYSTEM_MANAGED } from '../src/modules/gitlab/gitlab.constants'
 import { GitlabModule } from '../src/modules/gitlab/gitlab.module'
+import { GitlabService } from '../src/modules/gitlab/gitlab.service'
 import { AuthModule } from '../src/modules/infrastructure/auth/auth.module'
 import { DatabaseModule } from '../src/modules/infrastructure/database/database.module'
 import { PrismaService } from '../src/modules/infrastructure/database/prisma.service'
@@ -32,6 +33,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
   let moduleRef: TestingModule
   let eventEmitter: EventEmitter2
   let gitlabClientService: GitlabClientService
+  let gitlabService: GitlabService
   let gitlabClient: Gitlab
   let vaultService: VaultClientService
   let prisma: PrismaService
@@ -50,6 +52,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
     await moduleRef.init()
 
     gitlabClientService = moduleRef.get<GitlabClientService>(GitlabClientService)
+    gitlabService = moduleRef.get<GitlabService>(GitlabService)
     gitlabClient = moduleRef.get<Gitlab>(GITLAB_REST_CLIENT)
     vaultService = moduleRef.get<VaultClientService>(VaultClientService)
     prisma = moduleRef.get<PrismaService>(PrismaService)
@@ -291,6 +294,112 @@ describeWithGitLab('GitlabService (e2e)', () => {
       const isNewMemberPresent = members.some(m => m.id === newUserGitlabId)
       expect(isNewMemberPresent).toBe(true)
     }, EXTERNAL_SYNC_TIMEOUT)
+  })
+
+  describe('system repo purge protection', () => {
+    it('system repos (mirror, infra-apps) survive a reprovisioning that purges an orphan', async () => {
+      // Call the gitlab plugin directly (not the full project.upsert chain) so the
+      // purge assertions don't depend on Keycloak/Vault/ArgoCD being reachable.
+      const project = await prisma.project.findUniqueOrThrow({
+        where: { id: testProjectId },
+        select: projectSelect,
+      })
+      await gitlabService.handleUpsert(project)
+
+      const groupPath = `${config.projectsRootDir}/${testProjectSlug}`
+      const group = z.object({ id: z.number() }).parse(await gitlabClientService.getGroupByPath(groupPath))
+      const reposBefore = await getAll(gitlabClientService.getRepos(testProjectSlug))
+      const mirror = reposBefore.find(repo => repo.name === MIRROR_REPO_NAME)
+      const infraApps = reposBefore.find(repo => repo.name === INFRA_APPS_REPO_NAME)
+      if (!mirror) throw new Error('mirror repo not found')
+      if (!infraApps) throw new Error('infra-apps repo not found')
+
+      // System repos must carry the protection topic
+      expect(mirror.topics).toContain(TOPIC_SYSTEM_MANAGED)
+      expect(infraApps.topics).toContain(TOPIC_SYSTEM_MANAGED)
+
+      // Create an orphan plugin-managed repo directly in GitLab (simulates a repo the
+      // console no longer tracks: DB row removed, GitLab project left behind)
+      const orphanName = `orphan-${faker.string.uuid().slice(0, 8)}`
+      const orphan = await gitlabClient.Projects.create({
+        name: orphanName,
+        path: orphanName,
+        namespaceId: group.id,
+      })
+      await gitlabClient.Projects.edit(orphan.id, { topics: [TOPIC_PLUGIN_MANAGED] })
+
+      // Second reconciliation: the orphan must be purged, system repos must survive
+      const project2 = await prisma.project.findUniqueOrThrow({
+        where: { id: testProjectId },
+        select: projectSelect,
+      })
+      await gitlabService.handleUpsert(project2)
+
+      const reposAfter = await getAll(gitlabClientService.getRepos(testProjectSlug))
+      const namesAfter = reposAfter.map(repo => repo.name)
+
+      expect(namesAfter).not.toContain(orphanName)
+      expect(namesAfter).toContain(MIRROR_REPO_NAME)
+      expect(namesAfter).toContain(INFRA_APPS_REPO_NAME)
+      expect(namesAfter).toContain('app')
+    }, 150_000)
+
+    it('declared user repos are never purged even without the system-managed topic', async () => {
+      const project = await prisma.project.findUniqueOrThrow({
+        where: { id: testProjectId },
+        select: projectSelect,
+      })
+      await gitlabService.handleUpsert(project)
+
+      const repos = await getAll(gitlabClientService.getRepos(testProjectSlug))
+      const app = repos.find(repo => repo.name === 'app')
+      if (!app) throw new Error('app repo not found')
+
+      // The declared user repo carries plugin-managed but NOT system-managed; the
+      // declared-in-project guard must keep it alive across reconciliations.
+      expect(app.topics).toContain(TOPIC_PLUGIN_MANAGED)
+      expect(app.topics).not.toContain(TOPIC_SYSTEM_MANAGED)
+
+      const project2 = await prisma.project.findUniqueOrThrow({
+        where: { id: testProjectId },
+        select: projectSelect,
+      })
+      await gitlabService.handleUpsert(project2)
+
+      const reposAfter = await getAll(gitlabClientService.getRepos(testProjectSlug))
+      expect(reposAfter.some(repo => repo.name === 'app')).toBe(true)
+    }, 150_000)
+
+    it('purge does not fail when a repo is already marked for deletion', async () => {
+      // Create a NEW orphan repo in GitLab, then delete it directly (async). The
+      // subsequent reconcile's purge observes it as still present and DELETEs again
+      // → GitLab answers 400 "Already Marked for Deletion" which must be swallowed
+      // so the whole reconciliation succeeds and the system repos survive.
+      const groupPath = `${config.projectsRootDir}/${testProjectSlug}`
+      const group = z.object({ id: z.number() }).parse(await gitlabClientService.getGroupByPath(groupPath))
+      const orphanName = `orphan-race-${faker.string.uuid().slice(0, 8)}`
+      const orphan = await gitlabClient.Projects.create({
+        name: orphanName,
+        path: orphanName,
+        namespaceId: group.id,
+      })
+      await gitlabClient.Projects.edit(orphan.id, { topics: [TOPIC_PLUGIN_MANAGED] })
+
+      // Simulate the async-deletion race: DELETE the orphan directly (not through
+      // the reconcile) so it is marked for deletion, then reconcile immediately.
+      await gitlabClientService.deleteProjectGroupRepo(testProjectSlug, orphanName).catch(() => {})
+
+      const project = await prisma.project.findUniqueOrThrow({
+        where: { id: testProjectId },
+        select: projectSelect,
+      })
+      await expect(gitlabService.handleUpsert(project)).resolves.not.toThrow()
+
+      const namesAfter = (await getAll(gitlabClientService.getRepos(testProjectSlug))).map(repo => repo.name)
+      expect(namesAfter).toContain(MIRROR_REPO_NAME)
+      expect(namesAfter).toContain(INFRA_APPS_REPO_NAME)
+      expect(namesAfter).toContain('app')
+    }, 150_000)
   })
 
   it('should remove project group from GitLab on delete', async () => {

--- a/apps/server-nestjs/test/gitlab.e2e-spec.ts
+++ b/apps/server-nestjs/test/gitlab.e2e-spec.ts
@@ -22,7 +22,7 @@ import { PermissionModule } from '../src/modules/infrastructure/permission/permi
 import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
 import { getAll } from '../src/utils/iterable.utils'
-import { EXTERNAL_SYNC_TIMEOUT } from './e2e-timeout'
+import { EXTERNAL_SYNC_TIMEOUT, GITLAB_PURGE_RECONCILE_TIMEOUT } from './e2e-timeout'
 
 const canRunGitlabE2E
   = Boolean(process.env.E2E)
@@ -342,7 +342,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
       expect(namesAfter).toContain(MIRROR_REPO_NAME)
       expect(namesAfter).toContain(INFRA_APPS_REPO_NAME)
       expect(namesAfter).toContain('app')
-    }, 150_000)
+    }, GITLAB_PURGE_RECONCILE_TIMEOUT)
 
     it('declared user repos are never purged even without the system-managed topic', async () => {
       const project = await prisma.project.findUniqueOrThrow({
@@ -368,7 +368,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
 
       const reposAfter = await getAll(gitlabClientService.getRepos(testProjectSlug))
       expect(reposAfter.some(repo => repo.name === 'app')).toBe(true)
-    }, 150_000)
+    }, GITLAB_PURGE_RECONCILE_TIMEOUT)
 
     it('purge does not fail when a repo is already marked for deletion', async () => {
       // Create a NEW orphan repo in GitLab, then delete it directly (async). The
@@ -399,7 +399,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
       expect(namesAfter).toContain(MIRROR_REPO_NAME)
       expect(namesAfter).toContain(INFRA_APPS_REPO_NAME)
       expect(namesAfter).toContain('app')
-    }, 150_000)
+    }, GITLAB_PURGE_RECONCILE_TIMEOUT)
   })
 
   it('should remove project group from GitLab on delete', async () => {

--- a/apps/server-nestjs/test/gitlab.e2e-spec.ts
+++ b/apps/server-nestjs/test/gitlab.e2e-spec.ts
@@ -12,7 +12,6 @@ import { GITLAB_REST_CLIENT, GitlabClientService } from '../src/modules/gitlab/g
 import { projectSelect } from '../src/modules/gitlab/gitlab-datastore.service'
 import { GITLAB_CI_CONFIG_PATH, INFRA_APPS_REPO_NAME, MIRROR_REPO_NAME, TOPIC_PLUGIN_MANAGED, TOPIC_SYSTEM_MANAGED } from '../src/modules/gitlab/gitlab.constants'
 import { GitlabModule } from '../src/modules/gitlab/gitlab.module'
-import { GitlabService } from '../src/modules/gitlab/gitlab.service'
 import { AuthModule } from '../src/modules/infrastructure/auth/auth.module'
 import { DatabaseModule } from '../src/modules/infrastructure/database/database.module'
 import { PrismaService } from '../src/modules/infrastructure/database/prisma.service'
@@ -33,7 +32,6 @@ describeWithGitLab('GitlabService (e2e)', () => {
   let moduleRef: TestingModule
   let eventEmitter: EventEmitter2
   let gitlabClientService: GitlabClientService
-  let gitlabService: GitlabService
   let gitlabClient: Gitlab
   let vaultService: VaultClientService
   let prisma: PrismaService
@@ -52,7 +50,6 @@ describeWithGitLab('GitlabService (e2e)', () => {
     await moduleRef.init()
 
     gitlabClientService = moduleRef.get<GitlabClientService>(GitlabClientService)
-    gitlabService = moduleRef.get<GitlabService>(GitlabService)
     gitlabClient = moduleRef.get<Gitlab>(GITLAB_REST_CLIENT)
     vaultService = moduleRef.get<VaultClientService>(VaultClientService)
     prisma = moduleRef.get<PrismaService>(PrismaService)
@@ -298,13 +295,11 @@ describeWithGitLab('GitlabService (e2e)', () => {
 
   describe('system repo purge protection', () => {
     it('system repos (mirror, infra-apps) survive a reprovisioning that purges an orphan', async () => {
-      // Call the gitlab plugin directly (not the full project.upsert chain) so the
-      // purge assertions don't depend on Keycloak/Vault/ArgoCD being reachable.
       const project = await prisma.project.findUniqueOrThrow({
         where: { id: testProjectId },
         select: projectSelect,
       })
-      await gitlabService.handleUpsert(project)
+      await eventEmitter.emitAsync('project.upsert', project)
 
       const groupPath = `${config.projectsRootDir}/${testProjectSlug}`
       const group = z.object({ id: z.number() }).parse(await gitlabClientService.getGroupByPath(groupPath))
@@ -333,7 +328,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
         where: { id: testProjectId },
         select: projectSelect,
       })
-      await gitlabService.handleUpsert(project2)
+      await eventEmitter.emitAsync('project.upsert', project2)
 
       const reposAfter = await getAll(gitlabClientService.getRepos(testProjectSlug))
       const namesAfter = reposAfter.map(repo => repo.name)
@@ -349,7 +344,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
         where: { id: testProjectId },
         select: projectSelect,
       })
-      await gitlabService.handleUpsert(project)
+      await eventEmitter.emitAsync('project.upsert', project)
 
       const repos = await getAll(gitlabClientService.getRepos(testProjectSlug))
       const app = repos.find(repo => repo.name === 'app')
@@ -364,7 +359,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
         where: { id: testProjectId },
         select: projectSelect,
       })
-      await gitlabService.handleUpsert(project2)
+      await eventEmitter.emitAsync('project.upsert', project2)
 
       const reposAfter = await getAll(gitlabClientService.getRepos(testProjectSlug))
       expect(reposAfter.some(repo => repo.name === 'app')).toBe(true)
@@ -393,7 +388,7 @@ describeWithGitLab('GitlabService (e2e)', () => {
         where: { id: testProjectId },
         select: projectSelect,
       })
-      await expect(gitlabService.handleUpsert(project)).resolves.not.toThrow()
+      await expect(eventEmitter.emitAsync('project.upsert', project)).resolves.not.toThrow()
 
       const namesAfter = (await getAll(gitlabClientService.getRepos(testProjectSlug))).map(repo => repo.name)
       expect(namesAfter).toContain(MIRROR_REPO_NAME)

--- a/apps/server-nestjs/test/keycloak.e2e-spec.ts
+++ b/apps/server-nestjs/test/keycloak.e2e-spec.ts
@@ -18,7 +18,7 @@ import { KEYCLOAK_ADMIN_CLIENT, KeycloakClientService } from '../src/modules/key
 import { projectSelect } from '../src/modules/keycloak/keycloak-datastore.service'
 import { KeycloakModule } from '../src/modules/keycloak/keycloak.module'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
-import { KEYCLOAK_GROUP_SYNC_TIMEOUT } from './e2e-timeout'
+import { KEYCLOAK_GROUP_SYNC_TIMEOUT } from './constants'
 
 const canRunKeycloakE2E
   = Boolean(process.env.E2E)

--- a/apps/server-nestjs/test/nexus.e2e-spec.ts
+++ b/apps/server-nestjs/test/nexus.e2e-spec.ts
@@ -22,6 +22,7 @@ import { generateNexusCredPath } from '../src/modules/nexus/nexus.utils'
 import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { VaultModule } from '../src/modules/vault/vault.module'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
+import { NEXUS_SYNC_TIMEOUT } from './constants'
 
 const canRunNexusE2E
   = Boolean(process.env.E2E)
@@ -146,7 +147,7 @@ describeWithNexus('NexusService (e2e)', () => {
     const secret = await vaultService.read(vaultPath)
     expect(secret.data?.NEXUS_USERNAME).toBe(testProjectSlug)
     expect(secret.data?.NEXUS_PASSWORD).toBeTruthy()
-  })
+  }, NEXUS_SYNC_TIMEOUT)
 
   it('should remove project from Nexus on delete', async () => {
     const project = await prisma.project.findUniqueOrThrow({
@@ -168,5 +169,5 @@ describeWithNexus('NexusService (e2e)', () => {
 
     const users = await nexusClient.getSecurityUsers(testProjectSlug)
     expect(users.some(u => u.userId === testProjectSlug)).toBe(false)
-  })
+  }, NEXUS_SYNC_TIMEOUT)
 })

--- a/apps/server-nestjs/test/sonarqube.e2e-spec.ts
+++ b/apps/server-nestjs/test/sonarqube.e2e-spec.ts
@@ -25,7 +25,7 @@ import { VaultClientService } from '../src/modules/vault/vault-client.service'
 import { VaultModule } from '../src/modules/vault/vault.module'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
 import { getAll } from '../src/utils/iterable.utils'
-import { SONARQUBE_PROJECT_TIMEOUT } from './e2e-timeout'
+import { SONARQUBE_PROJECT_TIMEOUT } from './constants'
 
 const canRunSonarqubeE2E
   = Boolean(process.env.E2E)

--- a/apps/server-nestjs/test/vault.e2e-spec.ts
+++ b/apps/server-nestjs/test/vault.e2e-spec.ts
@@ -16,7 +16,7 @@ import { projectSelect } from '../src/modules/vault/vault-datastore.service'
 import { makeProjectWithDetails } from '../src/modules/vault/vault-testing.utils'
 import { VaultModule } from '../src/modules/vault/vault.module'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
-import { VAULT_PROVISION_TIMEOUT } from './e2e-timeout'
+import { VAULT_PROVISION_TIMEOUT } from './constants'
 
 const canRunVaultE2E
   = Boolean(process.env.E2E)

--- a/apps/server-nestjs/test/zone.e2e-spec.ts
+++ b/apps/server-nestjs/test/zone.e2e-spec.ts
@@ -16,7 +16,7 @@ import { makeZoneWithDetails } from '../src/modules/vault/vault-testing.utils'
 import { VaultModule } from '../src/modules/vault/vault.module'
 import { VaultService } from '../src/modules/vault/vault.service'
 import { getDotenvPaths } from '../src/utils/dotenv.utils'
-import { VAULT_PROVISION_TIMEOUT } from './e2e-timeout'
+import { VAULT_PROVISION_TIMEOUT } from './constants'
 
 const canRunZoneE2E = Boolean(process.env.E2E)
 


### PR DESCRIPTION
## Issues liées

#2607

---------

## Quel est le comportement actuel ?

Lors d'un reprovisionnement de projet, le service GitLab `purgeOrphanRepos` supprime tous les dépôts portant le topic `plugin-managed` absents de `project.repositories`. Les dépôts système `infra-apps` et `mirror` sont créés avec ce topic mais n'apparaissent jamais dans `project.repositories`, donc ils sont supprimés à chaque réconciliation. La recréation ultérieure échoue avec une erreur `400 already marked for deletion` (suppression GitLab asynchrone), ce qui rejette toute l'opération.

## Quel est le nouveau comportement ?

`isSystemRepo` protège désormais explicitement `infra-apps` et `mirror` par leur nom, en plus des dépôts déclarés dans `project.repositories`. Les suppressions sont en outre rendues tolérantes aux erreurs : une suppression GitLab déjà en cours n'échoue plus toute la réconciliation du projet.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Régression introduite par `a47e7b0e` (« delete owned GitLab repos on explicit repository deletion »), présente sur `origin/main`. Test de non-régression ajouté : `gitlab.service.spec.ts` vérifie que `infra-apps` et `mirror` ne sont jamais supprimés.
