### PR TITLE
fix(server-nestjs): add SystemConfigModule import in alphabetical order

### DIFF
--- a/apps/server-nestjs/src/main.module.ts
+++ b/apps/server-nestjs/src/main.module.ts
@@ -17,6 +17,7 @@ import { ProjectSecretsModule } from './modules/project-secrets/project-secrets.
 import { ProjectServicesModule } from './modules/project-services/project-services.module'
 import { ProjectModule } from './modules/project/project.module'
 import { RepositoryModule } from './modules/repository/repository.module'
+import { SystemConfigModule } from './modules/system-config/system-config.module'
 import { SystemSettingsModule } from './modules/system-settings/system-settings.module'
 import { VersionModule } from './modules/version/version.module'
 import { getDotenvPaths } from './utils/dotenv.utils'
@@ -44,6 +45,7 @@ import { getDotenvPaths } from './utils/dotenv.utils'
     ProjectServicesModule,
     RepositoryModule,
     ScheduleModule.forRoot(),
+    SystemConfigModule,
     SystemSettingsModule,
     VersionModule,
   ],


### PR DESCRIPTION
## What

Add `SystemConfigModule` to `MainModule` imports, in alphabetical position between `RepositoryModule` and `SystemSettingsModule`.

## Why

The system-config module registration (PR #2436) added the import but out of order. This keeps the module list sorted to match the directory layout.

## Related

- https://github.com/cloud-pi-native/console/issues/2208