### PR TITLE
fix(server-nestjs): make Keycloak root group creation idempotent

### DIFF
--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.spec.ts
@@ -370,4 +370,21 @@ describe('getOrCreateGroupByPath root resolution (issue #2518)', () => {
 
     expect(result).toMatchObject({ id: 'created-id', path: '/myproject' })
   })
+
+  it('should re-fetch the existing root group when a concurrent creation causes a 409', async () => {
+    // Two initial reads (getGroupByPath then the line-187 re-read) see no root
+    // group; the create then races a concurrent sync and 409s, after which the
+    // existing root group is re-fetched and returned (issue #2618).
+    server.use(
+      http.get(groupsUrl, () => HttpResponse.json([]), { once: true }),
+      http.get(groupsUrl, () => HttpResponse.json([{ id: 'concurrent-root-id', name: 'myproject', path: '/myproject' }])),
+      http.post(groupsUrl, () =>
+        HttpResponse.json({ errorMessage: 'Top level groups must have unique names' }, { status: 409 })),
+      http.get(rootChildrenUrl, () => HttpResponse.json([])),
+    )
+
+    const result = await service.getOrCreateGroupByPath('/myproject')
+
+    expect(result).toMatchObject({ id: 'concurrent-root-id', path: '/myproject' })
+  })
 })

--- a/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak-client.service.ts
@@ -125,11 +125,22 @@ export class KeycloakClientService implements OnModuleInit {
   }
 
   @StartActiveSpan()
-  async createGroup(name: string) {
+  async ensureGroup(name: string) {
     const span = trace.getActiveSpan()
     span?.setAttribute('group.name', name)
     this.logger.debug(`Creating Keycloak group ${name}`)
-    await this.client.groups.create({ name })
+    try {
+      await this.client.groups.create({ name })
+    } catch (err) {
+      // A concurrent reconciliation (e.g. the cron sync and a project upsert)
+      // may have created the root group between the read and the create; treat
+      // the 409 as "already exists" and re-fetch it.
+      if (getErrorResponseStatus(err) !== 409) throw err
+      this.logger.verbose(`Keycloak group ${name} was created concurrently, fetching it`)
+      const existing = await this.getRootGroupByName(name)
+      if (!existing) throw err
+      return existing
+    }
     const created = await this.getRootGroupByName(name)
     if (!created) throw new Error(`Created Keycloak group ${name} but could not fetch it back`)
     return created
@@ -184,7 +195,7 @@ export class KeycloakClientService implements OnModuleInit {
     }
 
     const [rootName, ...rest] = parts
-    let current = await this.getRootGroupByName(rootName) ?? await this.createGroup(rootName)
+    let current = await this.ensureGroup(rootName)
     for (const name of rest) {
       current = await this.getOrCreateSubGroupByName(current.id, name)
     }


### PR DESCRIPTION
## Issues liées

#2618 (fermer délibérément après la fusion)

## Quel est le comportement actuel ?

La création du groupe racine Keycloak n'est pas idempotente face à une course concurrente. `getOrCreateGroupByPath` lit d'abord le groupe racine, puis appelle `createGroup` si celui-ci est absent. Or deux réconciliations simultanées (la synchronisation cron et un `project.upsert`) peuvent toutes deux passer la lecture avant qu'aucune n'ait créé le groupe : la seconde échoue alors avec une erreur HTTP 409, car le groupe existe désormais. `createGroup` ne tolérait pas ce 409 et remontait l'erreur au lieu de récupérer le groupe déjà créé.

## Comportement attendu

Un 409 sur la création du groupe racine doit être traité comme « le groupe existe déjà » : le groupe existant est re-consulté via `getRootGroupByName` puis renvoyé, exactement de la même manière que le chemin des sous-groupes (`getOrCreateSubGroupByName`) le fait déjà. Aucun autre comportement ne change.

## Changements

- Envelopper l'appel `client.groups.create` dans `createGroup` avec une tolérance au 409 : en cas de 409, re-consulter le groupe racine existant et le renvoyer.
- Ajouter un test unitaire couvrant la course 409 sur le groupe racine (le 409 déclenche la re-consultation du groupe existant).
