### PR TITLE
fix(server-nestjs): make Registry create paths idempotent

### DIFF
--- a/apps/server-nestjs/src/modules/registry/registry-client.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.ts
@@ -1,5 +1,5 @@
 import type { RegistryQuery, RegistryResponse } from './registry-http-client.service'
-import { Inject, Injectable } from '@nestjs/common'
+import { HttpStatus, Inject, Injectable } from '@nestjs/common'
 import { RegistryHttpClientService } from './registry-http-client.service'
 import { ROBOT_LIST_PAGE_SIZE } from './registry.constants'
 
@@ -115,8 +115,8 @@ export class RegistryClientService {
     })
   }
 
-  async createProject(projectName: string, storageLimit: number) {
-    return this.http.fetch('projects', {
+  async ensureProject(projectName: string, storageLimit: number): Promise<HarborProject> {
+    const created = await this.http.fetch('projects', {
       method: 'POST',
       body: {
         project_name: projectName,
@@ -124,6 +124,15 @@ export class RegistryClientService {
         storage_limit: storageLimit,
       },
     })
+    if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
+      throw new Error(`Harbor create project failed (${created.status})`)
+    }
+    // 409: project already exists (concurrent reconcile) — fall through to get
+    const fetched = await this.getProjectByName(projectName)
+    if (fetched.status !== HttpStatus.OK || !fetched.data) {
+      throw new Error(`Harbor get project failed (${fetched.status})`)
+    }
+    return fetched.data
   }
 
   async deleteProjectByName(projectName: string) {
@@ -157,12 +166,16 @@ export class RegistryClientService {
     })
   }
 
-  async addGroupMember(projectName: string, body: HarborGroupMemberRequest) {
-    return this.http.fetch(`projects/${encodeURIComponent(projectName)}/members`, {
+  async ensureGroupMember(projectName: string, body: HarborGroupMemberRequest) {
+    const created = await this.http.fetch(`projects/${encodeURIComponent(projectName)}/members`, {
       method: 'POST',
       headers: { 'X-Is-Resource-Name': 'true' },
       body,
     })
+    if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
+      throw new Error(`Harbor create member failed (${created.status})`)
+    }
+    // 409: member already exists (concurrent reconcile) — no-op
   }
 
   async removeGroupMember(projectName: string, memberId: number) {
@@ -178,11 +191,17 @@ export class RegistryClientService {
     })
   }
 
-  async createRobot(body: HarborRobotCreateRequest) {
-    return this.http.fetch<HarborRobotCreated>('robots', {
+  // 409 → robot already exists, secret unrecoverable; caller rotates for a fresh secret.
+  async ensureRobot(body: HarborRobotCreateRequest): Promise<HarborRobotCreated | null> {
+    const created = await this.http.fetch<HarborRobotCreated>('robots', {
       method: 'POST',
       body,
     })
+    if (created.status === HttpStatus.CONFLICT) return null
+    if (created.status >= HttpStatus.BAD_REQUEST || !created.data) {
+      throw new Error(`Harbor create robot failed (${created.status})`)
+    }
+    return created.data
   }
 
   async deleteRobot(robotId: number): Promise<RegistryResponse> {
@@ -198,6 +217,23 @@ export class RegistryClientService {
     return Number.isFinite(retentionId) ? retentionId : null
   }
 
+  // 409 → already exists; re-read id and update instead.
+  async ensureRetention(projectName: string, body: HarborRetentionPolicy) {
+     const created = await this.createRetention(body)
+     if (created.status === HttpStatus.CONFLICT) {
+       const racedId = await this.getRetentionId(projectName)
+       if (racedId) {
+         const result = await this.updateRetention(racedId, body)
+         if (result.status >= HttpStatus.BAD_REQUEST) {
+           throw new Error(`Harbor retention policy failed (${result.status})`)
+         }
+       }
+       return
+     }
+     if (created.status >= HttpStatus.BAD_REQUEST) {
+       throw new Error(`Harbor retention policy failed (${created.status})`)
+     }
+   }
   async createRetention(body: HarborRetentionPolicy) {
     return this.http.fetch('retentions', {
       method: 'POST',

--- a/apps/server-nestjs/src/modules/registry/registry-client.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.ts
@@ -127,7 +127,6 @@ export class RegistryClientService {
     if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
       throw new Error(`Harbor create project failed (${created.status})`)
     }
-    // 409: project already exists (concurrent reconcile) — fall through to get
     const fetched = await this.getProjectByName(projectName)
     if (fetched.status !== HttpStatus.OK || !fetched.data) {
       throw new Error(`Harbor get project failed (${fetched.status})`)
@@ -175,7 +174,6 @@ export class RegistryClientService {
     if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
       throw new Error(`Harbor create member failed (${created.status})`)
     }
-    // 409: member already exists (concurrent reconcile) — no-op
   }
 
   async removeGroupMember(projectName: string, memberId: number) {
@@ -191,7 +189,6 @@ export class RegistryClientService {
     })
   }
 
-  // 409 → robot already exists, secret unrecoverable; caller rotates for a fresh secret.
   async ensureRobot(body: HarborRobotCreateRequest): Promise<HarborRobotCreated | null> {
     const created = await this.http.fetch<HarborRobotCreated>('robots', {
       method: 'POST',
@@ -217,7 +214,6 @@ export class RegistryClientService {
     return Number.isFinite(retentionId) ? retentionId : null
   }
 
-  // 409 → already exists; re-read id and update instead.
   async ensureRetention(projectName: string, body: HarborRetentionPolicy) {
      const created = await this.createRetention(body)
      if (created.status === HttpStatus.CONFLICT) {


### PR DESCRIPTION
## Issues liées

#2620 (fermer délibérément après la fusion)

---------

## Quel est le comportement actuel ?

Lors d'une synchronisation concurrente (cron + événement), deux appels peuvent tenter de créer la même ressource Harbor en parallèle. Le POST perdant reçoit une erreur 409 (conflit) et la synchronisation échoue avec une erreur.

Quatre chemins de création sont concernés : la création de projet, l'ajout d'un membre de groupe, la création d'un robot et la création d'une stratégie de rétention. Chacun était protégé par un GET d'existence préalable dans la couche métier, mais sous une course cette garde ne suffisait pas.

## Comportement attendu

L'idempotence est encapsulée dans le service client (`registry-client.service.ts`) sous un motif `ensure*` create-first : on tente la création ; si la ressource existe déjà (409), on la met à jour puis on relit l'état courant. La synchronisation devient idempotente face à la course.

## Changements

- `registry-client.service.ts` expose `ensureProject`, `ensureGroupMember`, `ensureRobot` et `ensureRetention` : chaque méthode tente la création, puis réconcilie sur un 409.
- Création de projet : un 409 est toléré, la ressource est relue puis retournée.
- Ajout de membre de groupe : un 409 est ignoré, le membre existe désormais.
- Création de robot : un 409 renvoie `null`, la couche métier déclenche une rotation pour obtenir un secret frais.
- Stratégie de rétention : un 409 déclenche une relecture puis une mise à jour.
- La couche métier (`registry.service.ts`) est simplifiée : elle appelle les méthodes `ensure*` et ne gère plus les statuts 409 elle-même.
- Ajout de tests unitaires (client et service) couvrant les collisions sur la création de projet, de robot et le retour de l'existant.
