### PR TITLE
fix(server-nestjs): make Registry create paths idempotent

### DIFF
--- a/apps/server-nestjs/src/modules/registry/registry-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.spec.ts
@@ -57,7 +57,7 @@ describe('registryService', () => {
     expect(service).toBeDefined()
   })
 
-  it('should send basic auth and JSON body on createProject', async () => {
+  it('should send basic auth and JSON body on ensureProject', async () => {
     server.use(
       http.post(`${harborUrl}/api/v2.0/projects`, async ({ request }) => {
         expect(request.method).toBe('POST')
@@ -72,9 +72,15 @@ describe('registryService', () => {
         })
         return HttpResponse.json({}, { status: HttpStatus.CREATED })
       }),
+      http.get(`${harborUrl}/api/v2.0/projects/:projectName`, async ({ request, params }) => {
+        expect(request.headers.get('authorization')).toBe(basicAuth)
+        expect(params.projectName).toBe('myproj')
+        return HttpResponse.json({ project_id: 123, metadata: {} })
+      }),
     )
 
-    await service.createProject('myproj', -1)
+    const result = await service.ensureProject('myproj', -1)
+    expect(result).toEqual({ project_id: 123, metadata: {} })
   })
 
   it('should send X-Is-Resource-Name on getProjectByName', async () => {

--- a/apps/server-nestjs/src/modules/registry/registry-client.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.ts
@@ -1,5 +1,5 @@
 import type { RegistryQuery, RegistryResponse } from './registry-http-client.service'
-import { Inject, Injectable } from '@nestjs/common'
+import { HttpStatus, Inject, Injectable } from '@nestjs/common'
 import { RegistryHttpClientService } from './registry-http-client.service'
 import { ROBOT_LIST_PAGE_SIZE } from './registry.constants'
 
@@ -115,8 +115,8 @@ export class RegistryClientService {
     })
   }
 
-  async createProject(projectName: string, storageLimit: number) {
-    return this.http.fetch('projects', {
+  async ensureProject(projectName: string, storageLimit: number): Promise<HarborProject> {
+    const created = await this.http.fetch('projects', {
       method: 'POST',
       body: {
         project_name: projectName,
@@ -124,6 +124,15 @@ export class RegistryClientService {
         storage_limit: storageLimit,
       },
     })
+    if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
+      throw new Error(`Harbor create project failed (${created.status})`)
+    }
+    // 409: project already exists (concurrent reconcile) — fall through to get
+    const fetched = await this.getProjectByName(projectName)
+    if (fetched.status !== HttpStatus.OK || !fetched.data) {
+      throw new Error(`Harbor get project failed (${fetched.status})`)
+    }
+    return fetched.data
   }
 
   async deleteProjectByName(projectName: string) {
@@ -157,12 +166,16 @@ export class RegistryClientService {
     })
   }
 
-  async addGroupMember(projectName: string, body: HarborGroupMemberRequest) {
-    return this.http.fetch(`projects/${encodeURIComponent(projectName)}/members`, {
+  async ensureGroupMember(projectName: string, body: HarborGroupMemberRequest) {
+    const created = await this.http.fetch(`projects/${encodeURIComponent(projectName)}/members`, {
       method: 'POST',
       headers: { 'X-Is-Resource-Name': 'true' },
       body,
     })
+    if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
+      throw new Error(`Harbor create member failed (${created.status})`)
+    }
+    // 409: member already exists (concurrent reconcile) — no-op
   }
 
   async removeGroupMember(projectName: string, memberId: number) {
@@ -178,11 +191,17 @@ export class RegistryClientService {
     })
   }
 
-  async createRobot(body: HarborRobotCreateRequest) {
-    return this.http.fetch<HarborRobotCreated>('robots', {
+  // 409 → robot already exists, secret unrecoverable; caller rotates for a fresh secret.
+  async ensureRobot(body: HarborRobotCreateRequest): Promise<HarborRobotCreated | null> {
+    const created = await this.http.fetch<HarborRobotCreated>('robots', {
       method: 'POST',
       body,
     })
+    if (created.status === HttpStatus.CONFLICT) return null
+    if (created.status >= HttpStatus.BAD_REQUEST || !created.data) {
+      throw new Error(`Harbor create robot failed (${created.status})`)
+    }
+    return created.data
   }
 
   async deleteRobot(robotId: number): Promise<RegistryResponse> {
@@ -198,6 +217,23 @@ export class RegistryClientService {
     return Number.isFinite(retentionId) ? retentionId : null
   }
 
+  // 409 → already exists; re-read id and update instead.
+  async ensureRetention(projectName: string, body: HarborRetentionPolicy) {
+     const created = await this.createRetention(body)
+     if (created.status === HttpStatus.CONFLICT) {
+       const racedId = await this.getRetentionId(projectName)
+       if (racedId) {
+         const result = await this.updateRetention(racedId, body)
+         if (result.status >= HttpStatus.BAD_REQUEST) {
+           throw new Error(`Harbor retention policy failed (${result.status})`)
+         }
+       }
+       return
+     }
+     if (created.status >= HttpStatus.BAD_REQUEST) {
+       throw new Error(`Harbor retention policy failed (${created.status})`)
+     }
+   }
   async createRetention(body: HarborRetentionPolicy) {
     return this.http.fetch('retentions', {
       method: 'POST',

--- a/apps/server-nestjs/src/modules/registry/registry-client.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.ts
@@ -127,7 +127,6 @@ export class RegistryClientService {
     if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
       throw new Error(`Harbor create project failed (${created.status})`)
     }
-    // 409: project already exists (concurrent reconcile) — fall through to get
     const fetched = await this.getProjectByName(projectName)
     if (fetched.status !== HttpStatus.OK || !fetched.data) {
       throw new Error(`Harbor get project failed (${fetched.status})`)
@@ -175,7 +174,6 @@ export class RegistryClientService {
     if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
       throw new Error(`Harbor create member failed (${created.status})`)
     }
-    // 409: member already exists (concurrent reconcile) — no-op
   }
 
   async removeGroupMember(projectName: string, memberId: number) {
@@ -191,7 +189,6 @@ export class RegistryClientService {
     })
   }
 
-  // 409 → robot already exists, secret unrecoverable; caller rotates for a fresh secret.
   async ensureRobot(body: HarborRobotCreateRequest): Promise<HarborRobotCreated | null> {
     const created = await this.http.fetch<HarborRobotCreated>('robots', {
       method: 'POST',
@@ -217,7 +214,6 @@ export class RegistryClientService {
     return Number.isFinite(retentionId) ? retentionId : null
   }
 
-  // 409 → already exists; re-read id and update instead.
   async ensureRetention(projectName: string, body: HarborRetentionPolicy) {
      const created = await this.createRetention(body)
      if (created.status === HttpStatus.CONFLICT) {

--- a/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
@@ -13,7 +13,7 @@ import { VaultClientService } from '../vault/vault-client.service'
 import { makeVaultSecret } from '../vault/vault-testing.utils'
 import { RegistryClientService } from './registry-client.service'
 import { RegistryDatastoreService } from './registry-datastore.service'
-import { makeCreatedResponse, makeNoContent, makeOkResponse, makeProjectWithDetails } from './registry-testing.utils'
+import { makeNoContent, makeOkResponse, makeProjectWithDetails } from './registry-testing.utils'
 import {
   PLUGIN_NAME,
   REGISTRY_CONFIG_KEY_PUBLISH_PROJECT_ROBOT,
@@ -36,10 +36,10 @@ describe('registryService', () => {
       getProjectByName: vi.fn().mockResolvedValue(makeOkResponse({ project_id: 123, metadata: {} })),
       listQuotas: vi.fn().mockResolvedValue(makeOkResponse([{ ref: { id: 123 }, hard: { storage: -1 } }])),
       getRetentionId: vi.fn().mockResolvedValue(null),
-      createRetention: vi.fn().mockResolvedValue(makeCreatedResponse(null)),
+      ensureRetention: vi.fn(),
       getGroupMembers: vi.fn().mockResolvedValue(makeOkResponse([])),
       getProjectRobots: vi.fn(async function* () {}),
-      addGroupMember: vi.fn().mockResolvedValue(makeCreatedResponse(null)),
+      ensureGroupMember: vi.fn(),
       removeGroupMember: vi.fn().mockResolvedValue(makeNoContent()),
       deleteProjectByName: vi.fn().mockResolvedValue(makeNoContent()),
     })
@@ -109,9 +109,9 @@ describe('registryService', () => {
         { groupName: `/${project.slug}/console/admin`, roleId: 2 },
       ]
 
-      expect(client.addGroupMember).toHaveBeenCalledTimes(expected.length)
+      expect(client.ensureGroupMember).toHaveBeenCalledTimes(expected.length)
       for (const e of expected) {
-        expect(client.addGroupMember).toHaveBeenCalledWith(project.slug, {
+        expect(client.ensureGroupMember).toHaveBeenCalledWith(project.slug, {
           role_id: e.roleId,
           member_group: {
             group_name: e.groupName,
@@ -130,7 +130,7 @@ describe('registryService', () => {
       await service.handleUpsert(project)
 
       expect(client.removeGroupMember).toHaveBeenCalledWith(project.slug, 10)
-      expect(client.addGroupMember).toHaveBeenCalledWith(project.slug, {
+      expect(client.ensureGroupMember).toHaveBeenCalledWith(project.slug, {
         role_id: 2,
         member_group: {
           group_name: `/${project.slug}/console/admin`,
@@ -141,11 +141,10 @@ describe('registryService', () => {
 
     it('returns a KO result when project admin membership creation fails', async () => {
       const project = makeProjectWithDetails()
-      client.addGroupMember.mockImplementation(async (_projectName, body) => {
+      client.ensureGroupMember.mockImplementation(async (_projectName, body) => {
         if (body.member_group.group_name === `/${project.slug}/console/admin` && body.role_id === 2) {
-          return { status: HttpStatus.BAD_REQUEST, data: null }
+          throw new Error('Harbor create member failed (400)')
         }
-        return { status: HttpStatus.CREATED, data: null }
       })
 
       await expect(service.handleUpsert(project)).resolves.toEqual({
@@ -155,7 +154,7 @@ describe('registryService', () => {
         }),
       })
 
-      expect(client.addGroupMember).toHaveBeenCalledWith(project.slug, {
+      expect(client.ensureGroupMember).toHaveBeenCalledWith(project.slug, {
         role_id: 2,
         member_group: {
           group_name: `/${project.slug}/console/admin`,
@@ -186,7 +185,7 @@ describe('registryService', () => {
       expect(vault.read).toHaveBeenCalledWith(`forge/${project.slug}/REGISTRY/ro-robot`)
       expect(vault.read).toHaveBeenCalledWith(`forge/${project.slug}/REGISTRY/rw-robot`)
       expect(client.getProjectRobots).not.toHaveBeenCalled()
-      expect(client.createRobot).not.toHaveBeenCalled()
+      expect(client.ensureRobot).not.toHaveBeenCalled()
       expect(client.deleteRobot).not.toHaveBeenCalled()
       expect(vault.write).not.toHaveBeenCalled()
     })
@@ -218,12 +217,12 @@ describe('registryService', () => {
         yield { id: 11, name: `robot$${project.slug}+ro-robot` }
       })
       client.deleteRobot.mockResolvedValue(makeNoContent())
-      client.createRobot.mockResolvedValue(makeCreatedResponse({ id: 22, name: `robot$${project.slug}+ro-robot`, secret: 'newsecret' }))
+      client.ensureRobot.mockResolvedValue({ id: 22, name: `robot$${project.slug}+ro-robot`, secret: 'newsecret' })
 
       await service.handleUpsert(project)
 
       expect(client.deleteRobot).toHaveBeenCalledWith(11)
-      expect(client.createRobot).toHaveBeenCalledWith(expect.objectContaining({ name: 'ro-robot' }))
+      expect(client.ensureRobot).toHaveBeenCalledWith(expect.objectContaining({ name: 'ro-robot' }))
       expect(vault.write).toHaveBeenCalledWith(expect.objectContaining({
         HOST: 'harbor.example',
         USERNAME: `robot$${project.slug}+ro-robot`,
@@ -259,12 +258,12 @@ describe('registryService', () => {
         yield { id: 11, name: `robot$${project.slug}+ro-robot` }
       })
       client.deleteRobot.mockResolvedValue(makeNoContent())
-      client.createRobot.mockResolvedValue(makeCreatedResponse({ id: 22, name: `robot$${project.slug}+ro-robot`, secret: 'newsecret' }))
+      client.ensureRobot.mockResolvedValue({ id: 22, name: `robot$${project.slug}+ro-robot`, secret: 'newsecret' })
 
       await service.handleUpsert(project)
 
       expect(client.deleteRobot).toHaveBeenCalledWith(11)
-      expect(client.createRobot).toHaveBeenCalledWith(expect.objectContaining({ name: 'ro-robot' }))
+      expect(client.ensureRobot).toHaveBeenCalledWith(expect.objectContaining({ name: 'ro-robot' }))
       expect(vault.write).toHaveBeenCalledWith(expect.objectContaining({
         HOST: 'harbor.example',
         USERNAME: `robot$${project.slug}+ro-robot`,

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -229,17 +229,9 @@ export class RegistryService {
       return existing.data
     }
 
-    const created = await this.client.createProject(project.slug, storageLimit)
-    if (created.status >= 300) {
-      throw new Error(`Harbor create project failed (${created.status})`)
-    }
+    const created = await this.client.ensureProject(project.slug, storageLimit)
     span?.setAttribute('registry.project.created', true)
-
-    const fetched = await this.client.getProjectByName(project.slug)
-    if (fetched.status !== 200 || !fetched.data) {
-      throw new Error(`Harbor get project failed (${fetched.status})`)
-    }
-    return fetched.data
+    return created
   }
 
   private async ensureRetentionPolicy(project: ProjectWithDetails, harborProjectId: number) {

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -80,13 +80,13 @@ export class RegistryService {
   }
 
   private async createProjectRobot(project: ProjectWithDetails, robotName: string, access: HarborAccess[]) {
-    const created = await this.client.createRobot(
+    const created = await this.client.ensureRobot(
       generateRobotPermissions(project, robotName, access),
     )
-    if (created.status >= 300 || !created.data) {
-      throw new Error(`Harbor create robot failed (${created.status})`)
+    if (!created) {
+      throw new Error(`Harbor robot already exists (${robotName})`)
     }
-    return created.data
+    return created
   }
 
   private async rotateRobot(project: ProjectWithDetails, harborProjectId: number, robotName: string, access: HarborAccess[]) {
@@ -173,10 +173,7 @@ export class RegistryService {
         group_type: 3,
       },
     }
-    const created = await this.client.addGroupMember(projectSlug, body)
-    if (created.status >= 300) {
-      throw new Error(`Harbor create member failed (${created.status})`)
-    }
+    await this.client.ensureGroupMember(projectSlug, body)
     span?.setAttribute('registry.member.created', true)
   }
 
@@ -245,14 +242,7 @@ export class RegistryService {
       harborRuleCount: this.harborConfig.ruleCount,
       harborRetentionCron: this.harborConfig.retentionCron,
     })
-    const retentionId = await this.client.getRetentionId(project.slug)
-    span?.setAttribute('registry.retention.exists', !!retentionId)
-    const result = retentionId
-      ? await this.client.updateRetention(retentionId, policy)
-      : await this.client.createRetention(policy)
-    if (result.status >= 300) {
-      throw new Error(`Harbor retention policy failed (${result.status})`)
-    }
+    await this.client.ensureRetention(project.slug, policy)
   }
 
   @StartActiveSpan()

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -79,7 +79,7 @@ export class RegistryService {
     return find(this.client.getProjectRobots(harborProjectId), r => r?.name === fullName)
   }
 
-  private async createProjectRobot(project: ProjectWithDetails, robotName: string, access: HarborAccess[]) {
+  private async ensureProjectRobot(project: ProjectWithDetails, robotName: string, access: HarborAccess[]) {
     const created = await this.client.ensureRobot(
       generateRobotPermissions(project, robotName, access),
     )
@@ -94,7 +94,7 @@ export class RegistryService {
     if (existing?.id) {
       await this.client.deleteRobot(existing.id)
     }
-    return this.createProjectRobot(project, robotName, access)
+    return this.ensureProjectRobot(project, robotName, access)
   }
 
   private async ensureRobotSecret(project: ProjectWithDetails, harborProjectId: number, robotName: string, access: HarborAccess[]) {
@@ -127,7 +127,7 @@ export class RegistryService {
     const existing = await this.getRobot(project, harborProjectId, robotName)
     const created = existing
       ? await this.rotateRobot(project, harborProjectId, robotName, access)
-      : await this.createProjectRobot(project, robotName, access)
+      : await this.ensureProjectRobot(project, robotName, access)
     const fullName = generateRobotFullName(project, robotName)
     const secret = generateVaultRobotSecret(this.host, fullName, created.secret)
     await this.vault.write(secret, vaultPath)


### PR DESCRIPTION
## Issues liées

#2620 (fermer délibérément après la fusion)

---------

## Quel est le comportement actuel ?

Lors d'une synchronisation concurrente (cron + événement), deux appels peuvent tenter de créer la même ressource Harbor en parallèle. Le POST perdant reçoit une erreur 409 (conflit) et la synchronisation échoue avec une erreur.

Quatre chemins de création sont concernés : la création de projet, l'ajout d'un membre de groupe, la création d'un robot et la création d'une stratégie de rétention. Chacun était protégé par un GET d'existence préalable dans la couche métier, mais sous une course cette garde ne suffisait pas.

## Comportement attendu

L'idempotence est encapsulée dans le service client (`registry-client.service.ts`) sous un motif `ensure*` create-first : on tente la création ; si la ressource existe déjà (409), on la met à jour puis on relit l'état courant. La synchronisation devient idempotente face à la course.

## Changements

- `registry-client.service.ts` expose `ensureProject`, `ensureGroupMember`, `ensureRobot` et `ensureRetention` : chaque méthode tente la création, puis réconcilie sur un 409.
- Création de projet : un 409 est toléré, la ressource est relue puis retournée.
- Ajout de membre de groupe : un 409 est ignoré, le membre existe désormais.
- Création de robot : un 409 renvoie `null`, la couche métier déclenche une rotation pour obtenir un secret frais.
- Stratégie de rétention : un 409 déclenche une relecture puis une mise à jour.
- La couche métier (`registry.service.ts`) est simplifiée : elle appelle les méthodes `ensure*` et ne gère plus les statuts 409 elle-même.
- Ajout de tests unitaires (client et service) couvrant les collisions sur la création de projet, de robot et le retour de l'existant.

