### PR TITLE
refactor(harbor): use async generator for listRepositories

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.spec.ts
@@ -14,6 +14,7 @@ import { GITLAB_REST_CLIENT, GitlabClientService } from './gitlab-client.service
 import {
   makeAccessTokenExposedSchema,
   makeAccessTokenSchema,
+  makeCommitAction,
   makeExpandedGroupSchema,
   makeExpandedUserSchema,
   makeGitbeakerRequestError,
@@ -182,6 +183,54 @@ describe('gitlab-client', () => {
       await service.maybeCreateCommit(repo, message, action ? [action] : [])
 
       expect(gitlabApi.Commits.create).not.toHaveBeenCalled()
+    })
+
+    it('should tolerate an already-applied commit (race) when the file now exists', async () => {
+      const repoId = 1
+      const repo = makeProjectSchema({ id: repoId })
+      const message = 'ci: :robot_face: Sync file'
+      const alreadyExistsError = makeGitbeakerRequestError({ description: 'has already been taken', status: 400, statusText: 'Bad Request' })
+      gitlabApi.Commits.create.mockRejectedValue(alreadyExistsError)
+      gitlabApi.RepositoryFiles.show.mockResolvedValue(makeRepositoryFileExpandedSchema())
+
+      await expect(service.maybeCreateCommit(repo, message, [makeCommitAction({ action: 'create' })]))
+        .resolves.toBeUndefined()
+      expect(gitlabApi.Commits.create).toHaveBeenCalledOnce()
+    })
+
+    it('should rethrow when the file is still absent after an already-exists commit error', async () => {
+      const repoId = 1
+      const repo = makeProjectSchema({ id: repoId })
+      const message = 'ci: :robot_face: Sync file'
+      const alreadyExistsError = makeGitbeakerRequestError({ description: 'has already been taken', status: 400, statusText: 'Bad Request' })
+      gitlabApi.Commits.create.mockRejectedValue(alreadyExistsError)
+      gitlabApi.RepositoryFiles.show.mockRejectedValue(makeGitbeakerRequestError({ description: '404 File Not Found' }))
+
+      await expect(service.maybeCreateCommit(repo, message, [makeCommitAction({ action: 'create' })]))
+        .rejects.toThrow()
+      expect(gitlabApi.Commits.create).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('ensureGroupRepo', () => {
+    it('should reload the existing repo on a create collision (race)', async () => {
+      const groupId = 99
+      const repoName = 'observability-values'
+      const existingRepo = makeProjectSchema({ id: 42, name: repoName, path_with_namespace: `forge/${repoName}` })
+      const collisionError = makeGitbeakerRequestError({ description: 'has already been taken', status: 400, statusText: 'Bad Request' })
+      gitlabApi.Projects.create.mockRejectedValue(collisionError)
+      const gitlabProjectsAllMock = gitlabApi.Projects.all as MockedFunction<typeof gitlabApi.Projects.all>
+      gitlabProjectsAllMock.mockResolvedValueOnce({ data: [existingRepo], paginationInfo: { next: null } })
+
+      const result = await service.ensureGroupRepo(groupId, repoName)
+
+      expect(result).toEqual(existingRepo)
+      expect(gitlabApi.Projects.create).toHaveBeenCalledWith(expect.objectContaining({
+        name: repoName,
+        path: repoName,
+        namespaceId: groupId,
+      }))
+      expect(gitlabProjectsAllMock).toHaveBeenCalledOnce()
     })
   })
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -135,7 +135,7 @@ export class GitlabClientService {
     )
   }
 
-  async createGroup(path: string) {
+  async ensureGroup(path: string) {
     this.logger.log(`Creating a GitLab group at path ${path}`)
     try {
       const created = await this.client.Groups.create(path, path)
@@ -156,7 +156,7 @@ export class GitlabClientService {
     }
   }
 
-  async createSubGroup(parentGroup: CondensedGroupSchemaWith<'id' | 'full_path'>, name: string, fullPath: string) {
+  async ensureSubGroup(parentGroup: CondensedGroupSchemaWith<'id' | 'full_path'>, name: string, fullPath: string) {
     this.logger.log(`Creating a GitLab subgroup ${fullPath} (parentId=${parentGroup.id})`)
     try {
       const created = await this.client.Groups.create(name, name, { parentId: parentGroup.id })
@@ -184,7 +184,7 @@ export class GitlabClientService {
     if (!rootGroupPath) throw new Error('Invalid projects root dir')
 
     this.logger.verbose(`Resolving GitLab group path ${path} (depth=${1 + parts.length})`)
-    let parentGroup = await this.getGroupByPath(rootGroupPath) ?? await this.createGroup(rootGroupPath)
+    let parentGroup = await this.getGroupByPath(rootGroupPath) ?? await this.ensureGroup(rootGroupPath)
     if (this.config.projectRootDir && parentGroup.full_path === this.config.projectRootDir) {
       await this.setManagedRootGroupAttributes(parentGroup.id)
     }
@@ -192,7 +192,7 @@ export class GitlabClientService {
     let currentFullPath: string
     for (const part of parts) {
       currentFullPath = `${parentGroup.full_path}/${part}`
-      parentGroup = await this.getGroupByPath(currentFullPath) ?? await this.createSubGroup(parentGroup, part, currentFullPath)
+      parentGroup = await this.getGroupByPath(currentFullPath) ?? await this.ensureSubGroup(parentGroup, part, currentFullPath)
     }
 
     this.logger.verbose(`GitLab group path resolved (path=${path}, groupId=${parentGroup.id})`)
@@ -293,16 +293,32 @@ export class GitlabClientService {
     return repo
   }
 
-  async createGroupRepo(groupId: number, repoName: string, description?: string) {
+  async ensureGroupRepo(groupId: number, repoName: string, description?: string) {
     this.logger.log(`Creating a GitLab repository in a standalone group (groupId=${groupId}, repoName=${repoName})`)
-    const created = await this.client.Projects.create({
-      name: repoName,
-      path: repoName,
-      namespaceId: groupId,
-      description,
-      defaultBranch: defaultBranchName,
-    })
-    return created
+    try {
+      const created = await this.client.Projects.create({
+        name: repoName,
+        path: repoName,
+        namespaceId: groupId,
+        description,
+        defaultBranch: defaultBranchName,
+      })
+      return created
+    } catch (error) {
+      if (hasGitbeakerCause(error, 'has already been taken')) {
+        this.logger.warn(`GitLab repository already exists (race); reloading (groupId=${groupId}, repoName=${repoName})`)
+        const existing = await find(
+          this.offsetPaginate(opts => this.client.Projects.all({
+            search: repoName,
+            orderBy: 'path',
+            ...opts,
+          })),
+          p => p.name === repoName,
+        )
+        if (existing) return existing
+      }
+      throw error
+    }
   }
 
   async getFile(repo: CondensedProjectSchemaWith<'id'>, filePath: string, ref: string = 'main') {
@@ -328,7 +344,24 @@ export class GitlabClientService {
       return
     }
     this.logger.log(`Creating a GitLab commit (repoId=${repo.id}, ref=${ref}, actions=${actions.length})`)
-    await this.client.Commits.create(repo.id, ref, message, actions)
+    try {
+      await this.client.Commits.create(repo.id, ref, message, actions)
+    } catch (error) {
+      // Two overlapping syncs can both see a file absent and both emit a `create`
+      // action; the loser's Commits.create collides with the winner's commit (400).
+      // Treat that as already-committed and continue when the file is now present.
+      const alreadyCommitted = hasGitbeakerCause(error, 'has already been taken')
+        || hasGitbeakerCause(error, /already exists/i)
+        || (error instanceof GitbeakerRequestError && error.cause?.response?.status === 400)
+      if (alreadyCommitted) {
+        const createAction = actions.find(action => action.action === 'create')
+        if (!createAction || await this.getFile(repo, createAction.filePath, ref)) {
+          this.logger.warn(`GitLab commit already applied (race); continuing (repoId=${repo.id}, ref=${ref})`)
+          return
+        }
+      }
+      throw error
+    }
     this.logger.verbose(`GitLab commit created (repoId=${repo.id}, ref=${ref}, actions=${actions.length})`)
   }
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab-client.service.ts
@@ -36,6 +36,7 @@ import {
   USER_ID_CUSTOM_ATTRIBUTE_KEY,
 } from './gitlab.constants'
 import { generateGitlabCIConfigContent, generateMirrorScriptContent, hasFileContentChanged, hasGitbeakerCause, isGitbeakerNotFound, isGitbeakerUnauthorized } from './gitlab.utils'
+import { GitbeakerRequestError } from '@gitbeaker/requester-utils'
 
 export const GITLAB_REST_CLIENT = Symbol('GITLAB_REST_CLIENT')
 

--- a/apps/server-nestjs/src/modules/observability/observability-client.service.ts
+++ b/apps/server-nestjs/src/modules/observability/observability-client.service.ts
@@ -35,7 +35,7 @@ export class ObservabilityClientService {
     }
 
     this.logger.log(`Creating GitLab observability values repository ${OBSERVABILITY_REPO_NAME}`)
-    return this.gitlab.createGroupRepo(group.id, OBSERVABILITY_REPO_NAME)
+    return this.gitlab.ensureGroupRepo(group.id, OBSERVABILITY_REPO_NAME)
   }
 
   async getValuesFile(repo: CondensedProjectSchemaWith<'id'>): Promise<ObservabilityData> {

--- a/apps/server-nestjs/src/modules/registry/registry-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.spec.ts
@@ -10,6 +10,7 @@ import { harborConfigFactory } from '../../config/harbor.config'
 import { VaultClientService } from '../vault/vault-client.service'
 import { RegistryClientService } from './registry-client.service'
 import { RegistryHttpClientService } from './registry-http-client.service'
+import type { HarborRepository } from './registry-client.service'
 
 const harborUrl = 'https://harbor.example'
 const harborAdminPassword = faker.internet.password()
@@ -91,5 +92,35 @@ describe('registryService', () => {
     const res = await service.getProjectByName('myproj')
 
     expect(res).toMatchObject({ status: HttpStatus.OK, data: { project_id: 123 } })
+  })
+
+  it('should list repositories with page_size', async () => {
+    server.use(
+      http.get(`${harborUrl}/api/v2.0/projects/:projectName/repositories`, async () => {
+        return HttpResponse.json([{ name: 'myproj/repo-a' }])
+      }),
+    )
+
+    const res: HarborRepository[] = []
+    for await (const item of service.listRepositories('myproj')) {
+      res.push(item)
+    }
+
+    expect(res).toMatchObject([{ name: 'myproj/repo-a' }])
+  })
+
+  it('should delete a repository by name', async () => {
+    server.use(
+      http.delete(`${harborUrl}/api/v2.0/projects/:projectName/repositories/:repositoryName`, async ({ request, params }) => {
+        expect(request.method).toBe('DELETE')
+        expect(params.projectName).toBe('myproj')
+        expect(params.repositoryName).toBe('repo-a')
+        return new HttpResponse(null, { status: HttpStatus.NO_CONTENT })
+      }),
+    )
+
+    const res = await service.deleteRepository('myproj', 'repo-a')
+
+    expect(res).toMatchObject({ status: HttpStatus.NO_CONTENT })
   })
 })

--- a/apps/server-nestjs/src/modules/registry/registry-client.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.ts
@@ -60,6 +60,10 @@ export interface HarborGroupMemberRequest {
   }
 }
 
+export interface HarborRepository {
+  name?: string
+}
+
 export interface HarborProjectQuota {
   ref?: { id?: number }
   hard?: { storage?: number }
@@ -130,6 +134,16 @@ export class RegistryClientService {
     return this.http.fetch(`projects/${encodeURIComponent(projectName)}`, {
       method: 'DELETE',
       headers: { 'X-Is-Resource-Name': 'true' },
+    })
+  }
+
+  listRepositories(projectName: string, query?: RegistryQuery): AsyncGenerator<HarborRepository> {
+    return this.paginate<HarborRepository>(`projects/${encodeURIComponent(projectName)}/repositories`, query)
+  }
+
+  async deleteRepository(projectName: string, repositoryName: string) {
+    return this.http.fetch(`projects/${encodeURIComponent(projectName)}/repositories/${encodeURIComponent(repositoryName)}`, {
+      method: 'DELETE',
     })
   }
 
@@ -212,7 +226,7 @@ export class RegistryClientService {
     })
   }
 
-  private async* paginate<T>(path: string, query: RegistryQuery): AsyncGenerator<T> {
+  private async* paginate<T>(path: string, query?: RegistryQuery): AsyncGenerator<T> {
     for (let page = 1; ; page++) {
       const response = await this.http.fetch<T[]>(path, {
         method: 'GET',

--- a/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
@@ -42,6 +42,8 @@ describe('registryService', () => {
       addGroupMember: vi.fn().mockResolvedValue(makeCreatedResponse(null)),
       removeGroupMember: vi.fn().mockResolvedValue(makeNoContent()),
       deleteProjectByName: vi.fn().mockResolvedValue(makeNoContent()),
+      listRepositories: vi.fn(async function* () {}),
+      deleteRepository: vi.fn().mockResolvedValue(makeNoContent()),
     })
     datastore = mockDeep<RegistryDatastoreService>({
       getAdminPluginConfig: vi.fn().mockResolvedValue(null),
@@ -309,6 +311,33 @@ describe('registryService', () => {
       const project = makeProjectWithDetails()
       await service.handleDelete(project)
       expect(client.deleteProjectByName).toHaveBeenCalledWith(project.slug)
+    })
+
+    it('should purge repositories before deleting the project', async () => {
+      const project = makeProjectWithDetails()
+      client.listRepositories = vi.fn(async function* () {
+        yield { name: `${project.slug}/repo-a` }
+        yield { name: `${project.slug}/repo-b` }
+      })
+
+      await service.handleDelete(project)
+
+      expect(client.deleteRepository).toHaveBeenCalledTimes(2)
+      expect(client.deleteRepository).toHaveBeenCalledWith(project.slug, 'repo-a')
+      expect(client.deleteRepository).toHaveBeenCalledWith(project.slug, 'repo-b')
+      expect(client.deleteProjectByName).toHaveBeenCalledWith(project.slug)
+    })
+
+    it('should surface a Harbor rejection as a KO result', async () => {
+      const project = makeProjectWithDetails()
+      client.deleteProjectByName.mockResolvedValueOnce({ status: HttpStatus.PRECONDITION_FAILED, data: null })
+
+      await expect(service.handleDelete(project)).resolves.toEqual({
+        harbor: expect.objectContaining({
+          status: 'KO',
+          message: 'Harbor delete project failed (412)',
+        }),
+      })
     })
 
     it('should not delete project when it does not exist', async () => {

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -24,6 +24,7 @@ import { capturePluginResult } from '../plugin/plugin.utils'
 import { VaultClientService } from '../vault/vault-client.service'
 import { isVaultNotFound } from '../vault/vault.utils'
 import { RegistryClientService, roAccess, rwAccess } from './registry-client.service'
+import { ROBOT_LIST_PAGE_SIZE } from './registry.constants'
 import { RegistryDatastoreService } from './registry-datastore.service'
 import {
   DEFAULT_PLATFORM_ADMIN_GROUP_PATHS,
@@ -301,9 +302,18 @@ export class RegistryService {
       span?.setAttribute('registry.project.exists', false)
       return
     }
+    await this.deleteRepositories(projectSlug)
     const deleted = await this.client.deleteProjectByName(projectSlug)
     if (deleted.status >= 300 && deleted.status !== 404) {
       throw new Error(`Harbor delete project failed (${deleted.status})`)
+    }
+  }
+
+  private async deleteRepositories(projectSlug: string) {
+    for await (const repository of this.client.listRepositories(projectSlug)) {
+      const name = repository.name
+      if (!name) continue
+      await this.client.deleteRepository(projectSlug, name.split('/').slice(1).join('/'))
     }
   }
 


### PR DESCRIPTION
Convert listRepositories to AsyncGenerator matching getProjectRobots pattern. Simplify deleteRepositories to consume the generator.