### PR TITLE
revert: restrict deployment visibility to console admins

### DIFF
--- a/apps/client/src/components/ProjectResources.vue
+++ b/apps/client/src/components/ProjectResources.vue
@@ -63,7 +63,7 @@ const projectClusters = computed(() => ([
 
 const canManageEnvs = computed(() => !props.project.locked && props.asProfile === 'user' && ProjectAuthorized.ManageEnvironments({ projectPermissions: props.project.myPerms }))
 const canManageRepos = computed(() => !props.project.locked && props.asProfile === 'user' && ProjectAuthorized.ManageRepositories({ projectPermissions: props.project.myPerms }))
-const canListDeploy = computed(() => AdminAuthorized.Manage(userStore.adminPerms) && ProjectAuthorized.ListDeployments({ projectPermissions: props.project.myPerms }))
+const canListDeploy = computed(() => ProjectAuthorized.ListDeployments({ projectPermissions: props.project.myPerms }))
 
 watch(selectedRepo, async () => {
   branchName.value = defaultBranchName

--- a/apps/client/src/components/ProjectRoleForm.vue
+++ b/apps/client/src/components/ProjectRoleForm.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import type { Member, ProjectRoleBigint, ProjectV2 } from '@cpn-console/shared'
 import {
-  AdminAuthorized,
   isManagedRoleType,
   isSystemRoleType,
   PROJECT_PERMS,
@@ -9,7 +8,6 @@ import {
   shallowEqual,
 } from '@cpn-console/shared'
 import { computed, ref } from 'vue'
-import { useUserStore } from '@/stores/user'
 
 const props = defineProps<{
   id: string
@@ -28,8 +26,6 @@ defineEmits<{
   save: [value: Omit<ProjectRoleBigint, 'position' | 'projectId'>]
   cancel: []
 }>()
-
-const userStore = useUserStore()
 const router = useRouter()
 const role = ref({
   ...props,
@@ -41,7 +37,6 @@ const role = ref({
 
 const isSystem = computed(() => isSystemRoleType(role.value.type))
 const isManaged = computed(() => isManagedRoleType(role.value.type))
-const isUserAdmin = computed(() => AdminAuthorized.Manage(userStore.adminPerms))
 
 const isUpdated = computed(() => {
   if (role.value.isEveryone)
@@ -96,30 +91,27 @@ function updateChecked(checked: boolean, value: bigint) {
       />
       <h6>Permissions de la Console</h6>
       <div v-for="scope in projectPermsDetails" :key="scope.name">
-        <!-- Déploiements is only visible to admin users -->
-        <template v-if="(scope.name !== 'Déploiements') || isUserAdmin ">
-          <p class="mb-3 ml-2 font-bold font-underline">
-            {{ scope.name }}
-          </p>
-          <DsfrCheckbox
-            v-for="perm in scope.perms"
-            :id="`${perm.key}-cbx`"
-            :key="perm.key"
-            value=""
-            :model-value="!!(PROJECT_PERMS[perm.key] & role.permissions)"
-            :label="perm?.label"
-            :hint="perm?.hint"
-            :name="perm.key"
-            :disabled="
-              isSystem
-                || (role.permissions & PROJECT_PERMS.MANAGE && perm.key !== 'MANAGE')
-            "
-            @update:model-value="
-              (checked: boolean) =>
-                updateChecked(checked, PROJECT_PERMS[perm.key])
-            "
-          />
-        </template>
+        <p class="mb-3 ml-2 font-bold font-underline">
+          {{ scope.name }}
+        </p>
+        <DsfrCheckbox
+          v-for="perm in scope.perms"
+          :id="`${perm.key}-cbx`"
+          :key="perm.key"
+          value=""
+          :model-value="!!(PROJECT_PERMS[perm.key] & role.permissions)"
+          :label="perm?.label"
+          :hint="perm?.hint"
+          :name="perm.key"
+          :disabled="
+            isSystem
+              || (role.permissions & PROJECT_PERMS.MANAGE && perm.key !== 'MANAGE')
+          "
+          @update:model-value="
+            (checked: boolean) =>
+              updateChecked(checked, PROJECT_PERMS[perm.key])
+          "
+        />
       </div>
       <DsfrButton
         label="Enregistrer"


### PR DESCRIPTION
## Issues liées

Issues numéro: #2462

---------

## Quel est le comportement actuel ?

Le déploiement n'est visible que pour les administrateurs de la console. Dans `ProjectResources.vue`, la permission projet `ListDeployments` est doublée d'un `AdminAuthorized.Manage`, et le scope « Déploiements » est masqué dans le formulaire de rôles projet pour les non-admins.

## Quel est le nouveau comportement ?

La visibilité dépend uniquement de la permission projet `ListDeployments`. Un membre de projet qui a cette permission accède au déploiement, et les mainteneurs peuvent l'attribuer depuis le formulaire de rôles.

Ce commit revert la restriction introduite par la PR #2331.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Changement front uniquement, l'API n'a jamais porté cette restriction admin.
