### PR TITLE
fix(keycloak): add project owner to the maintainer role group

### DIFF
--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.spec.ts
@@ -213,6 +213,84 @@ describe('keycloakService', () => {
       expect(keycloak.removeUserFromGroup).toHaveBeenCalledWith('user-2', 'role-group-id')
     })
 
+    it('should add the owner to the project admin role group', async () => {
+      const adminRole = makeProjectRole({
+        id: 'role-admin',
+        permissions: 0n,
+        oidcGroup: '/test-project/console/admin',
+        type: 'system:managed',
+      })
+      const projectWithAdminRole = makeProjectWithDetails({
+        ...mockProject,
+        members: [],
+        roles: [adminRole],
+      })
+      datastore.getAllProjects.mockResolvedValue([projectWithAdminRole])
+
+      const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
+      const consoleGroup = { id: 'console-id', name: 'console', path: '/test-project/console' }
+      const adminGroup = makeGroupRepresentation({ id: 'admin-group-id', name: 'admin', path: '/test-project/console/admin' })
+
+      keycloak.getOrCreateGroupByPath.mockImplementation((path) => {
+        if (path === '/test-project') return Promise.resolve(projectGroup)
+        throw new Error(`Unexpected getOrCreateGroupByPath call: ${path}`)
+      })
+      keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
+      keycloak.getOrCreateRoleGroup.mockResolvedValue(adminGroup)
+
+      // Owner is in the project group but missing from the admin role group
+      keycloak.getGroupMembers.mockImplementation((groupId) => {
+        if (groupId === 'group-id') return Promise.resolve([makeUserRepresentation({ id: 'owner-id' })])
+        if (groupId === 'admin-group-id') return Promise.resolve([])
+        return Promise.resolve([])
+      })
+
+      keycloak.getSubGroups.mockImplementation(async function* () { /* empty */ })
+
+      await service.handleCron()
+
+      // Owner implicitly holds the admin role: they must land in the maintainer group
+      expect(keycloak.addUserToGroup).toHaveBeenCalledWith('owner-id', 'admin-group-id')
+    })
+
+    it('should not add the owner to non-admin role groups', async () => {
+      const developerRole = makeProjectRole({
+        id: 'role-developer',
+        permissions: 0n,
+        oidcGroup: '/test-project/console/developer',
+        type: 'system:managed',
+      })
+      const projectWithDeveloperRole = makeProjectWithDetails({
+        ...mockProject,
+        members: [],
+        roles: [developerRole],
+      })
+      datastore.getAllProjects.mockResolvedValue([projectWithDeveloperRole])
+
+      const projectGroup = makeGroupRepresentation({ id: 'group-id', name: 'test-project' })
+      const consoleGroup = { id: 'console-id', name: 'console', path: '/test-project/console' }
+      const developerGroup = makeGroupRepresentation({ id: 'developer-group-id', name: 'developer', path: '/test-project/console/developer' })
+
+      keycloak.getOrCreateGroupByPath.mockImplementation((path) => {
+        if (path === '/test-project') return Promise.resolve(projectGroup)
+        throw new Error(`Unexpected getOrCreateGroupByPath call: ${path}`)
+      })
+      keycloak.getOrCreateConsoleGroup.mockResolvedValue(consoleGroup)
+      keycloak.getOrCreateRoleGroup.mockResolvedValue(developerGroup)
+
+      keycloak.getGroupMembers.mockImplementation((groupId) => {
+        if (groupId === 'group-id') return Promise.resolve([makeUserRepresentation({ id: 'owner-id' })])
+        if (groupId === 'developer-group-id') return Promise.resolve([])
+        return Promise.resolve([])
+      })
+
+      keycloak.getSubGroups.mockImplementation(async function* () { /* empty */ })
+
+      await service.handleCron()
+
+      expect(keycloak.addUserToGroup).not.toHaveBeenCalledWith('owner-id', 'developer-group-id')
+    })
+
     it('should sync environment groups', async () => {
       const projectWithEnv = makeProjectWithDetails({
         ...mockProject,

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.service.ts
@@ -12,7 +12,7 @@ import { StartActiveSpan } from '../infrastructure/telemetry/telemetry.decorator
 import { capturePluginResult } from '../plugin/plugin.utils'
 import { KeycloakClientService } from './keycloak-client.service'
 import { KeycloakDatastoreService } from './keycloak-datastore.service'
-import { isMember, isNonEmptyGroupPath, isOwnedProjectGroup, splitGroupPath, toGroupPath, toRoleRelativeGroupPath } from './keycloak.utils'
+import { isAdminRole, isMember, isNonEmptyGroupPath, isOwnedProjectGroup, splitGroupPath, toGroupPath, toRoleRelativeGroupPath } from './keycloak.utils'
 
 @Injectable()
 export class KeycloakService {
@@ -365,6 +365,16 @@ export class KeycloakService {
         await this.maybeAddUserToGroup(member.user.id, group.id, group.name)
       }
     }))
+
+    // The owner implicitly holds the project admin role (the maintainer group):
+    // without this they end up in no Keycloak RBAC group, so SonarQube and the
+    // other SSO-group-mapped services grant them no access at all. Only
+    // meaningful for managed roles — the orphan purge would evict them otherwise.
+    // maybeAddUserToGroup tolerates 409, so no membership pre-check is needed.
+    if (isAdminRole(project, role)) {
+      addedCount++
+      await this.maybeAddUserToGroup(project.ownerId, group.id, group.name)
+    }
 
     span?.setAttribute('keycloak.group.members.added', addedCount)
   }

--- a/apps/server-nestjs/src/modules/keycloak/keycloak.utils.ts
+++ b/apps/server-nestjs/src/modules/keycloak/keycloak.utils.ts
@@ -47,3 +47,13 @@ export function toRoleRelativeGroupPath(
 ): string {
   return role.oidcGroup.replace(consoleGroup.path, '')
 }
+
+// The project admin role is seeded with this OIDC group (project.utils.ts). The
+// owner implicitly holds it: services map SSO groups to permissions and the
+// owner would otherwise end up in no RBAC group at all.
+export function isAdminRole(
+  project: Pick<ProjectWithDetails, 'slug'>,
+  role: Pick<ProjectWithDetails['roles'][number], 'oidcGroup'>,
+): boolean {
+  return role.oidcGroup === `/${project.slug}/${CONSOLE_GROUP_NAME}/admin`
+}


### PR DESCRIPTION
## Issues liées

#2644

---------

## Quel est le comportement actuel ?

Le propriétaire d'un projet n'est membre d'aucun groupe OIDC de rôle projet dans Keycloak.
Les groupes de rôle (`/{slug}/console/admin`, ...) ne reçoivent que les membres détenant explicitement le rôle, et les services fédérés par SSO (SonarQube) mappent ces groupes vers leurs RBAC : le propriétaire n'a donc aucun accès SonarQube.

## Quel est le nouveau comportement ?

Le rôle administrateur projet (groupe maintainer `/{slug}/console/admin`) reçoit désormais le propriétaire via une étape dédiée `ensureOwnerRoleGroupMember`, en miroir de `addMissingOwnerMember` côté GitLab.
Le propriétaire n'est ajouté à aucun autre groupe de rôle.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Tests : 609/609 server-nestjs, les 2 nouveaux specs couvrent l'ajout au groupe maintainer et la non-addition aux autres groupes.
