### PR TITLE
fix(server-nestjs): tolérance aux courses de création Harbor (400 CONFLICT / 409) dans les chemins ensure

### DIFF
--- a/apps/server-nestjs/src/modules/registry/registry-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.spec.ts
@@ -1,5 +1,5 @@
 import type { ConfigType } from '@nestjs/config'
-import type { HarborRepository } from './registry-client.service'
+import type { HarborRepository, HarborRetentionPolicy } from './registry-client.service'
 import { faker } from '@faker-js/faker'
 import { HttpStatus } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
@@ -76,6 +76,22 @@ describe('registryService', () => {
     expect(result).toEqual({ project_id: 123, metadata: {} })
   })
 
+  it('should reconcile a real HTTP 409 on project create by reloading the existing project', async () => {
+    server.use(
+      http.post(`${harborUrl}/api/v2.0/projects`, () =>
+        new HttpResponse(null, { status: HttpStatus.CONFLICT })),
+      http.get(`${harborUrl}/api/v2.0/projects/:projectName`, async ({ request, params }) => {
+        expect(request.headers.get('x-is-resource-name')).toBe('true')
+        expect(params.projectName).toBe('myproj')
+        return HttpResponse.json({ project_id: 123, metadata: {} })
+      }),
+    )
+
+    const result = await service.ensureProject('myproj', -1)
+
+    expect(result).toEqual({ project_id: 123, metadata: {} })
+  })
+
   it('should send basic auth and JSON body on ensureProject', async () => {
     server.use(
       http.post(`${harborUrl}/api/v2.0/projects`, async ({ request }) => {
@@ -102,29 +118,21 @@ describe('registryService', () => {
     expect(result).toEqual({ project_id: 123, metadata: {} })
   })
 
-  it('should rotate an existing robot when robot creation conflicts (400 CONFLICT)', async () => {
-    let createCalls = 0
+  it('should not rotate an existing robot on creation conflict (400 CONFLICT)', async () => {
     server.use(
-      http.post(`${harborUrl}/api/v2.0/robots`, async ({ request }) => {
-        createCalls += 1
-        expect(request.headers.get('authorization')).toBe(basicAuth)
-        if (createCalls === 1) {
-          return HttpResponse.json({
-            errors: [{ code: 'CONFLICT', message: 'robot robot$myproj+ro-robot already exists' }],
-          }, { status: HttpStatus.BAD_REQUEST })
-        }
-        return HttpResponse.json({ id: 44, name: 'robot$myproj+ro-robot', secret: 'race-secret' }, { status: HttpStatus.CREATED })
-      }),
+      http.post(`${harborUrl}/api/v2.0/robots`, () => HttpResponse.json({
+        errors: [{ code: 'CONFLICT', message: 'robot robot$myproj+ro-robot already exists' }],
+      }, { status: HttpStatus.BAD_REQUEST })),
       http.get(`${harborUrl}/api/v2.0/projects/myproj`, ({ request }) => {
         expect(request.headers.get('x-is-resource-name')).toBe('true')
         return HttpResponse.json({ project_id: 123, metadata: {} })
       }),
-      http.get(`${harborUrl}/api/v2.0/robots`, ({ request }) => {
-        expect(request.url).toContain('q=Level%3Dproject,ProjectID%3D123')
-        return HttpResponse.json([{ id: 33, name: 'robot$myproj+ro-robot' }])
+      http.get(`${harborUrl}/api/v2.0/robots`, () => {
+        throw new Error('robot listing must not be called on conflict')
       }),
-      http.delete(`${harborUrl}/api/v2.0/robots/33`, () =>
-        new HttpResponse(null, { status: HttpStatus.NO_CONTENT })),
+      http.delete(`${harborUrl}/api/v2.0/robots/33`, () => {
+        throw new Error('robot deletion must not be called on conflict')
+      }),
     )
 
     const result = await service.ensureRobot({
@@ -136,8 +144,7 @@ describe('registryService', () => {
       permissions: [{ namespace: 'myproj', kind: 'project', access: [{ resource: 'repository', action: 'pull' }] }],
     })
 
-    expect(result).toEqual({ id: 44, name: 'robot$myproj+ro-robot', secret: 'race-secret' })
-    expect(createCalls).toBe(2)
+    expect(result).toBeUndefined()
   })
 
   it('should send X-Is-Resource-Name on getProjectByName', async () => {
@@ -185,5 +192,61 @@ describe('registryService', () => {
     const res = await service.deleteRepository('myproj', 'repo-a')
 
     expect(res).toMatchObject({ status: HttpStatus.NO_CONTENT })
+  })
+
+  it('should reconcile the existing retention policy on re-sync without issuing a second create', async () => {
+    const policy: HarborRetentionPolicy = {
+      algorithm: 'or',
+      scope: { level: 'project', ref: 123 },
+      rules: [],
+      trigger: { kind: 'Schedule', settings: { cron: '0 22 2 * * *' }, references: [] },
+    }
+    server.use(
+      http.get(`${harborUrl}/api/v2.0/projects/myproj`, ({ request }) => {
+        expect(request.headers.get('x-is-resource-name')).toBe('true')
+        return HttpResponse.json({ project_id: 123, metadata: { retention_id: '325' } })
+      }),
+      http.put(`${harborUrl}/api/v2.0/retentions/325`, async ({ request }) => {
+        expect(request.method).toBe('PUT')
+        expect(await request.json()).toEqual(policy)
+        return new HttpResponse(null, { status: HttpStatus.OK })
+      }),
+      http.post(`${harborUrl}/api/v2.0/retentions`, () => {
+        throw new Error('a second retention create must not be issued on re-sync')
+      }),
+    )
+
+    const id = await service.ensureRetention('myproj', policy)
+
+    expect(id).toBeUndefined()
+  })
+
+  it('should create a retention policy when none exists yet', async () => {
+    const policy: HarborRetentionPolicy = {
+      algorithm: 'or',
+      scope: { level: 'project', ref: 123 },
+      rules: [],
+      trigger: { kind: 'Schedule', settings: { cron: '0 22 2 * * *' }, references: [] },
+    }
+    let reads = 0
+    server.use(
+      http.get(`${harborUrl}/api/v2.0/projects/myproj`, ({ request }) => {
+        expect(request.headers.get('x-is-resource-name')).toBe('true')
+        reads += 1
+        return HttpResponse.json({ project_id: 123, metadata: {} })
+      }),
+      http.post(`${harborUrl}/api/v2.0/retentions`, async ({ request }) => {
+        expect(await request.json()).toEqual(policy)
+        return HttpResponse.json({ id: 500 }, { status: HttpStatus.CREATED })
+      }),
+      // After a successful create there is no policy to reconcile in place.
+      http.put(`${harborUrl}/api/v2.0/retentions/:id`, () => {
+        throw new Error('a fresh create must not also issue a reconcile PUT')
+      }),
+    )
+
+    await service.ensureRetention('myproj', policy)
+
+    expect(reads).toBe(1)
   })
 })

--- a/apps/server-nestjs/src/modules/registry/registry-client.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.spec.ts
@@ -58,6 +58,24 @@ describe('registryService', () => {
     expect(service).toBeDefined()
   })
 
+  it('should reconcile a project creation conflict (400 CONFLICT) by reloading the existing project', async () => {
+    server.use(
+      http.post(`${harborUrl}/api/v2.0/projects`, () =>
+        HttpResponse.json({
+          errors: [{ code: 'CONFLICT', message: 'project myproj already exists' }],
+        }, { status: HttpStatus.BAD_REQUEST })),
+      http.get(`${harborUrl}/api/v2.0/projects/:projectName`, async ({ request, params }) => {
+        expect(request.headers.get('x-is-resource-name')).toBe('true')
+        expect(params.projectName).toBe('myproj')
+        return HttpResponse.json({ project_id: 123, metadata: {} })
+      }),
+    )
+
+    const result = await service.ensureProject('myproj', -1)
+
+    expect(result).toEqual({ project_id: 123, metadata: {} })
+  })
+
   it('should send basic auth and JSON body on ensureProject', async () => {
     server.use(
       http.post(`${harborUrl}/api/v2.0/projects`, async ({ request }) => {
@@ -82,6 +100,44 @@ describe('registryService', () => {
 
     const result = await service.ensureProject('myproj', -1)
     expect(result).toEqual({ project_id: 123, metadata: {} })
+  })
+
+  it('should rotate an existing robot when robot creation conflicts (400 CONFLICT)', async () => {
+    let createCalls = 0
+    server.use(
+      http.post(`${harborUrl}/api/v2.0/robots`, async ({ request }) => {
+        createCalls += 1
+        expect(request.headers.get('authorization')).toBe(basicAuth)
+        if (createCalls === 1) {
+          return HttpResponse.json({
+            errors: [{ code: 'CONFLICT', message: 'robot robot$myproj+ro-robot already exists' }],
+          }, { status: HttpStatus.BAD_REQUEST })
+        }
+        return HttpResponse.json({ id: 44, name: 'robot$myproj+ro-robot', secret: 'race-secret' }, { status: HttpStatus.CREATED })
+      }),
+      http.get(`${harborUrl}/api/v2.0/projects/myproj`, ({ request }) => {
+        expect(request.headers.get('x-is-resource-name')).toBe('true')
+        return HttpResponse.json({ project_id: 123, metadata: {} })
+      }),
+      http.get(`${harborUrl}/api/v2.0/robots`, ({ request }) => {
+        expect(request.url).toContain('q=Level%3Dproject,ProjectID%3D123')
+        return HttpResponse.json([{ id: 33, name: 'robot$myproj+ro-robot' }])
+      }),
+      http.delete(`${harborUrl}/api/v2.0/robots/33`, () =>
+        new HttpResponse(null, { status: HttpStatus.NO_CONTENT })),
+    )
+
+    const result = await service.ensureRobot({
+      name: 'ro-robot',
+      duration: -1,
+      description: 'robot for ci builds',
+      disable: false,
+      level: 'project',
+      permissions: [{ namespace: 'myproj', kind: 'project', access: [{ resource: 'repository', action: 'pull' }] }],
+    })
+
+    expect(result).toEqual({ id: 44, name: 'robot$myproj+ro-robot', secret: 'race-secret' })
+    expect(createCalls).toBe(2)
   })
 
   it('should send X-Is-Resource-Name on getProjectByName', async () => {

--- a/apps/server-nestjs/src/modules/registry/registry-client.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.ts
@@ -121,17 +121,23 @@ export class RegistryClientService {
   }
 
   async ensureProject(projectName: string, storageLimit: number): Promise<HarborProject> {
-    const created = await this.http.fetch('projects', {
-      method: 'POST',
-      body: {
-        project_name: projectName,
-        metadata: { auto_scan: 'true' },
-        storage_limit: storageLimit,
+    const created = await ensure<HarborProject>({
+      create: () => this.http.fetch<HarborProject>('projects', {
+        method: 'POST',
+        body: {
+          project_name: projectName,
+          metadata: { auto_scan: 'true' },
+          storage_limit: storageLimit,
+        },
+      }),
+      reload: async () => {
+        const existing = await this.getProjectByName(projectName)
+        return existing.status === HttpStatus.OK ? existing.data : null
       },
     })
-    if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
-      throw new Error(`Harbor create project failed (${created.status})`)
-    }
+    if (created) return created
+    // Harbor answers 201 with an empty body on a fresh creation: fetch the
+    // project to obtain its id.
     const fetched = await this.getProjectByName(projectName)
     if (fetched.status !== HttpStatus.OK || !fetched.data) {
       throw new Error(`Harbor get project failed (${fetched.status})`)
@@ -181,14 +187,20 @@ export class RegistryClientService {
   }
 
   async ensureGroupMember(projectName: string, body: HarborGroupMemberRequest) {
-    const created = await this.http.fetch(`projects/${encodeURIComponent(projectName)}/members`, {
-      method: 'POST',
-      headers: { 'X-Is-Resource-Name': 'true' },
-      body,
+    await ensure({
+      create: () => this.http.fetch(`projects/${encodeURIComponent(projectName)}/members`, {
+        method: 'POST',
+        headers: { 'X-Is-Resource-Name': 'true' },
+        body,
+      }),
+      reload: async () => {
+        // Membership collision: Harbor already holds what the concurrent run
+        // created; re-listing proves it and adds no other state to reconcile.
+        const members = await this.getGroupMembers(projectName)
+        if (members.status !== HttpStatus.OK || !members.data) return null
+        return members.data.find(member => member?.entity_name === body.member_group.group_name) ?? null
+      },
     })
-    if (created.status >= HttpStatus.BAD_REQUEST && created.status !== HttpStatus.CONFLICT) {
-      throw new Error(`Harbor create member failed (${created.status})`)
-    }
   }
 
   async removeGroupMember(projectName: string, memberId: number) {
@@ -205,15 +217,40 @@ export class RegistryClientService {
   }
 
   async ensureRobot(body: HarborRobotCreateRequest): Promise<HarborRobotCreated | null> {
-    const created = await this.http.fetch<HarborRobotCreated>('robots', {
-      method: 'POST',
-      body,
+    return ensure<HarborRobotCreated>({
+      create: () => this.http.fetch<HarborRobotCreated>('robots', {
+        method: 'POST',
+        body,
+      }),
+      reload: async () => {
+        // 409 race: a concurrent run created the robot. Harbor never re-serves
+        // a robot secret, so reconciling means rotating: delete the existing
+        // robot and recreate it to obtain a fresh usable secret.
+        const existing = await this.findRobot(body)
+        if (existing?.id) {
+          await this.deleteRobot(existing.id)
+        }
+        const recreated = await this.http.fetch<HarborRobotCreated>('robots', {
+          method: 'POST',
+          body,
+        })
+        return recreated.status < HttpStatus.BAD_REQUEST ? recreated.data : null
+      },
     })
-    if (created.status === HttpStatus.CONFLICT) return null
-    if (created.status >= HttpStatus.BAD_REQUEST || !created.data) {
-      throw new Error(`Harbor create robot failed (${created.status})`)
+  }
+
+  private async findRobot(body: HarborRobotCreateRequest): Promise<HarborRobot | undefined> {
+    const namespace = body.permissions[0]?.namespace
+    if (!namespace) return undefined
+    const fullName = `robot$${namespace}+${body.name}`
+    const project = await this.getProjectByName(namespace)
+    if (project.status !== HttpStatus.OK || !project.data) return undefined
+    const projectId = Number(project.data.project_id)
+    if (!Number.isFinite(projectId)) return undefined
+    for await (const robot of this.getProjectRobots(projectId)) {
+      if (robot?.name === fullName) return robot
     }
-    return created.data
+    return undefined
   }
 
   async deleteRobot(robotId: number): Promise<RegistryResponse> {
@@ -230,16 +267,16 @@ export class RegistryClientService {
   }
 
   async ensureRetention(projectName: string, body: HarborRetentionPolicy) {
-    return ensure({
+    return ensure<unknown>({
       create: () => this.createRetention(body),
       reload: async () => {
         const racedId = await this.getRetentionId(projectName)
-        if (racedId) {
-          const result = await this.updateRetention(racedId, body)
-          if (result.status >= HttpStatus.BAD_REQUEST) {
-            throw new Error(`Harbor retention policy failed (${result.status})`)
-          }
+        if (!racedId) return null
+        const result = await this.updateRetention(racedId, body)
+        if (result.status >= HttpStatus.BAD_REQUEST) {
+          throw new Error(`Harbor retention policy failed (${result.status})`)
         }
+        return null
       },
     })
   }

--- a/apps/server-nestjs/src/modules/registry/registry-client.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-client.service.ts
@@ -2,7 +2,7 @@ import type { RegistryQuery, RegistryResponse } from './registry-http-client.ser
 import { HttpStatus, Inject, Injectable } from '@nestjs/common'
 import { RegistryHttpClientService } from './registry-http-client.service'
 import { ROBOT_LIST_PAGE_SIZE } from './registry.constants'
-import { ensure } from './registry.utils'
+import { ensure, isRegistryConflict } from './registry.utils'
 
 export const roAccess: HarborAccess[] = [
   { resource: 'repository', action: 'pull' },
@@ -120,8 +120,8 @@ export class RegistryClientService {
     })
   }
 
-  async ensureProject(projectName: string, storageLimit: number): Promise<HarborProject> {
-    const created = await ensure<HarborProject>({
+  async ensureProject(projectName: string, storageLimit: number) {
+    return ensure<HarborProject>({
       create: () => this.http.fetch<HarborProject>('projects', {
         method: 'POST',
         body: {
@@ -131,18 +131,14 @@ export class RegistryClientService {
         },
       }),
       reload: async () => {
-        const existing = await this.getProjectByName(projectName)
-        return existing.status === HttpStatus.OK ? existing.data : null
+        // 201 returns an empty body: fetch by name to obtain the id.
+        const response = await this.getProjectByName(projectName)
+        if (response.status !== HttpStatus.OK || !response.data) {
+          throw new Error(`Harbor get project failed (${response.status})`)
+        }
+        return response.data
       },
     })
-    if (created) return created
-    // Harbor answers 201 with an empty body on a fresh creation: fetch the
-    // project to obtain its id.
-    const fetched = await this.getProjectByName(projectName)
-    if (fetched.status !== HttpStatus.OK || !fetched.data) {
-      throw new Error(`Harbor get project failed (${fetched.status})`)
-    }
-    return fetched.data
   }
 
   async deleteProjectByName(projectName: string) {
@@ -194,11 +190,10 @@ export class RegistryClientService {
         body,
       }),
       reload: async () => {
-        // Membership collision: Harbor already holds what the concurrent run
-        // created; re-listing proves it and adds no other state to reconcile.
+        // Re-listing proves the raced membership exists.
         const members = await this.getGroupMembers(projectName)
-        if (members.status !== HttpStatus.OK || !members.data) return null
-        return members.data.find(member => member?.entity_name === body.member_group.group_name) ?? null
+        if (members.status !== HttpStatus.OK || !members.data) return undefined
+        return members.data.find(member => member?.entity_name === body.member_group.group_name)
       },
     })
   }
@@ -216,41 +211,20 @@ export class RegistryClientService {
     })
   }
 
-  async ensureRobot(body: HarborRobotCreateRequest): Promise<HarborRobotCreated | null> {
-    return ensure<HarborRobotCreated>({
-      create: () => this.http.fetch<HarborRobotCreated>('robots', {
-        method: 'POST',
-        body,
-      }),
-      reload: async () => {
-        // 409 race: a concurrent run created the robot. Harbor never re-serves
-        // a robot secret, so reconciling means rotating: delete the existing
-        // robot and recreate it to obtain a fresh usable secret.
-        const existing = await this.findRobot(body)
-        if (existing?.id) {
-          await this.deleteRobot(existing.id)
-        }
-        const recreated = await this.http.fetch<HarborRobotCreated>('robots', {
-          method: 'POST',
-          body,
-        })
-        return recreated.status < HttpStatus.BAD_REQUEST ? recreated.data : null
-      },
+  async ensureRobot(body: HarborRobotCreateRequest): Promise<HarborRobotCreated | undefined> {
+    const created = await this.http.fetch<HarborRobotCreated>('robots', {
+      method: 'POST',
+      body,
     })
-  }
-
-  private async findRobot(body: HarborRobotCreateRequest): Promise<HarborRobot | undefined> {
-    const namespace = body.permissions[0]?.namespace
-    if (!namespace) return undefined
-    const fullName = `robot$${namespace}+${body.name}`
-    const project = await this.getProjectByName(namespace)
-    if (project.status !== HttpStatus.OK || !project.data) return undefined
-    const projectId = Number(project.data.project_id)
-    if (!Number.isFinite(projectId)) return undefined
-    for await (const robot of this.getProjectRobots(projectId)) {
-      if (robot?.name === fullName) return robot
+    if (isRegistryConflict(created)) {
+      // The raced robot belongs to the concurrent run that owns its secret —
+      // never rotate here; service-level rotation stays the explicit path.
+      return undefined
     }
-    return undefined
+    if (created.status >= HttpStatus.BAD_REQUEST || !created.data) {
+      throw new Error(`Harbor create robot failed (${created.status})`)
+    }
+    return created.data
   }
 
   async deleteRobot(robotId: number): Promise<RegistryResponse> {
@@ -266,23 +240,28 @@ export class RegistryClientService {
     return Number.isFinite(retentionId) ? retentionId : null
   }
 
-  async ensureRetention(projectName: string, body: HarborRetentionPolicy) {
-    return ensure<unknown>({
-      create: () => this.createRetention(body),
-      reload: async () => {
-        const racedId = await this.getRetentionId(projectName)
-        if (!racedId) return null
-        const result = await this.updateRetention(racedId, body)
-        if (result.status >= HttpStatus.BAD_REQUEST) {
-          throw new Error(`Harbor retention policy failed (${result.status})`)
-        }
-        return null
-      },
-    })
+  async ensureRetention(projectName: string, body: HarborRetentionPolicy): Promise<void> {
+    // Harbor keeps a single retention policy per project; a re-sync must not
+    // issue a second create. Reconcile the existing policy in place when it exists.
+    let retentionId = await this.getRetentionId(projectName)
+    if (retentionId === null) {
+      const created = await this.createRetention(body)
+      if (created.status < HttpStatus.BAD_REQUEST) return
+      // A racing sync likely created the policy between our read and create
+      // (Harbor signals the duplicate with 400 BAD_REQUEST): re-read its id.
+      retentionId = await this.getRetentionId(projectName)
+      if (retentionId === null) {
+        throw new Error(`Harbor request failed (${created.status})`)
+      }
+    }
+    const updated = await this.updateRetention(retentionId, body)
+    if (updated.status >= HttpStatus.BAD_REQUEST) {
+      throw new Error(`Harbor retention policy failed (${updated.status})`)
+    }
   }
 
   async createRetention(body: HarborRetentionPolicy) {
-    return this.http.fetch('retentions', {
+    return this.http.fetch<number>('retentions', {
       method: 'POST',
       body,
     })

--- a/apps/server-nestjs/src/modules/registry/registry-testing.utils.ts
+++ b/apps/server-nestjs/src/modules/registry/registry-testing.utils.ts
@@ -15,6 +15,17 @@ export function makeNoContent(): RegistryResponse<null> {
   return { status: HttpStatus.NO_CONTENT, data: null }
 }
 
+export function makeConflictResponse<T>(): RegistryResponse<T> {
+  return {
+    status: HttpStatus.BAD_REQUEST,
+    data: { errors: [{ code: 'CONFLICT', message: 'already exists' }] } as T,
+  }
+}
+
+export function makeHttpConflictResponse<T>(): RegistryResponse<T> {
+  return { status: HttpStatus.CONFLICT, data: null }
+}
+
 export function makeProjectWithDetails(overrides: Partial<ProjectWithDetails> = {}) {
   return {
     slug: faker.helpers.slugify(`test-project-${faker.string.uuid()}`),

--- a/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
@@ -33,6 +33,7 @@ describe('registryService', () => {
 
   beforeEach(async () => {
     client = mockDeep<RegistryClientService>({
+      ensureProject: vi.fn().mockResolvedValue({ project_id: 123, metadata: {} }),
       getProjectByName: vi.fn().mockResolvedValue(makeOkResponse({ project_id: 123, metadata: {} })),
       listQuotas: vi.fn().mockResolvedValue(makeOkResponse([{ ref: { id: 123 }, hard: { storage: -1 } }])),
       getRetentionId: vi.fn().mockResolvedValue(null),
@@ -281,6 +282,7 @@ describe('registryService', () => {
         ],
       })
       client.getProjectByName.mockResolvedValue(makeOkResponse({ project_id: 1, metadata: {} }))
+      client.ensureProject.mockResolvedValue({ project_id: 1, metadata: {} })
 
       await service.handleUpsert(project)
 

--- a/apps/server-nestjs/src/modules/registry/registry.service.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.ts
@@ -6,7 +6,6 @@ import type {
   HarborAccess,
   HarborGroupMemberRequest,
   HarborMember,
-  HarborProjectQuota,
   HarborRetentionPolicy,
   HarborRobotCreateRequest,
 } from './registry-client.service'
@@ -210,25 +209,15 @@ export class RegistryService {
       'project.slug': project.slug,
       'registry.storage_limit.bytes': storageLimit,
     })
-    const existing = await this.client.getProjectByName(project.slug)
-    if (existing.status === 200 && existing.data) {
-      const projectId = Number(existing.data.project_id)
-      if (!Number.isFinite(projectId)) return existing.data
-
+    const harborProject = await this.client.ensureProject(project.slug, storageLimit)
+    if (harborProject === undefined) throw new Error(`Harbor project ${project.slug} not found`)
+    const projectId = Number(harborProject.project_id)
+    if (Number.isFinite(projectId)) {
       const quotas = await this.client.listQuotas(projectId)
-      if (quotas.status === 200 && quotas.data) {
-        const hardQuota = quotas.data.find((q: HarborProjectQuota) => q?.ref?.id === projectId)
-        if (hardQuota?.hard?.storage !== storageLimit) {
-          await this.client.updateQuota(projectId, storageLimit)
-          span?.setAttribute('registry.quota.updated', true)
-        }
-      }
-      return existing.data
+      const hardQuota = quotas.data?.find(q => q?.ref?.id === projectId)
+      if (hardQuota?.hard?.storage !== storageLimit) await this.client.updateQuota(projectId, storageLimit)
     }
-
-    const created = await this.client.ensureProject(project.slug, storageLimit)
-    span?.setAttribute('registry.project.created', true)
-    return created
+    return harborProject
   }
 
   private async ensureRetentionPolicy(project: ProjectWithDetails, harborProjectId: number) {
@@ -254,6 +243,7 @@ export class RegistryService {
     })
     const storageLimit = options.storageLimitBytes ?? -1
     const harborProject = await this.ensureProjectQuota(project, storageLimit)
+    if (harborProject === undefined) throw new Error(`Harbor project ${project.slug} not found`)
     const harborProjectId = Number(harborProject.project_id)
     if (!Number.isFinite(harborProjectId))
       throw new Error('Unable to retrieve Harbor project_id')

--- a/apps/server-nestjs/src/modules/registry/registry.utils.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.utils.spec.ts
@@ -1,25 +1,36 @@
 import { HttpStatus } from '@nestjs/common'
 import { describe, expect, it, vi } from 'vitest'
-import { ensure } from './registry.utils'
+import { ensure, isRegistryConflict } from './registry.utils'
 
 describe('ensure', () => {
-  it('should resolve when create succeeds', async () => {
+  it('should return the created data when create succeeds', async () => {
+    const created = { id: 1 }
     const reload = vi.fn()
 
-    await expect(ensure({ create: async () => ({ status: HttpStatus.CREATED, data: null }), reload })).resolves.toBeUndefined()
+    await expect(ensure({ create: async () => ({ status: HttpStatus.CREATED, data: created }), reload })).resolves.toBe(created)
 
     expect(reload).not.toHaveBeenCalled()
   })
 
-  it('should reload once on a 409 conflict and never retry create', async () => {
+  it('should reload once on a 409 conflict and return the existing state, never retrying create', async () => {
     const onCollision = vi.fn()
+    const existing = { id: 2 }
     const create = vi.fn(async () => ({ status: HttpStatus.CONFLICT, data: null }))
-    const reload = vi.fn(async () => {})
+    const reload = vi.fn(async () => existing)
 
-    await expect(ensure({ create, reload, onCollision })).resolves.toBeUndefined()
+    await expect(ensure({ create, reload, onCollision })).resolves.toBe(existing)
 
     expect(create).toHaveBeenCalledOnce()
     expect(onCollision).toHaveBeenCalledOnce()
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('should rethrow on a 409 whose reload finds nothing', async () => {
+    const create = vi.fn(async () => ({ status: HttpStatus.CONFLICT, data: null }))
+    const reload = vi.fn(async () => null)
+
+    await expect(ensure({ create, reload })).rejects.toThrow('Harbor request failed (409)')
+
     expect(reload).toHaveBeenCalledOnce()
   })
 
@@ -35,5 +46,39 @@ describe('ensure', () => {
     await expect(ensure({ create: async () => ({ status: HttpStatus.FORBIDDEN, data: null }), reload })).rejects.toThrow('Harbor request failed (403)')
 
     expect(reload).not.toHaveBeenCalled()
+  })
+})
+
+describe('isRegistryConflict', () => {
+  it('should detect a plain 409', () => {
+    expect(isRegistryConflict({ status: HttpStatus.CONFLICT, data: null })).toBe(true)
+  })
+
+  it('should detect a Harbor 400 body with code CONFLICT', () => {
+    expect(isRegistryConflict({
+      status: HttpStatus.BAD_REQUEST,
+      data: { errors: [{ code: 'CONFLICT', message: 'project myproj already exists' }] },
+    })).toBe(true)
+  })
+
+  it('should detect the code case-insensitively', () => {
+    expect(isRegistryConflict({
+      status: HttpStatus.BAD_REQUEST,
+      data: { errors: [{ code: 'Conflict', message: 'already exists' }] },
+    })).toBe(true)
+  })
+
+  it('should reject a 400 without the structured errors body', () => {
+    expect(isRegistryConflict({ status: HttpStatus.BAD_REQUEST, data: null })).toBe(false)
+    expect(isRegistryConflict({ status: HttpStatus.BAD_REQUEST, data: { message: 'bad request' } })).toBe(false)
+    expect(isRegistryConflict({
+      status: HttpStatus.BAD_REQUEST,
+      data: { errors: [{ code: 'INVALIDREQUEST', message: 'bad request' }] },
+    })).toBe(false)
+  })
+
+  it('should reject success and server-error statuses', () => {
+    expect(isRegistryConflict({ status: HttpStatus.CREATED, data: null })).toBe(false)
+    expect(isRegistryConflict({ status: HttpStatus.INTERNAL_SERVER_ERROR, data: null })).toBe(false)
   })
 })

--- a/apps/server-nestjs/src/modules/registry/registry.utils.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.utils.spec.ts
@@ -1,35 +1,48 @@
 import { HttpStatus } from '@nestjs/common'
 import { describe, expect, it, vi } from 'vitest'
+import { makeConflictResponse, makeHttpConflictResponse } from './registry-testing.utils'
 import { ensure, isRegistryConflict } from './registry.utils'
 
 describe('ensure', () => {
-  it('should return the created data when create succeeds', async () => {
+  it('should always reload on success to return the fresh object', async () => {
     const created = { id: 1 }
-    const reload = vi.fn()
-
-    await expect(ensure({ create: async () => ({ status: HttpStatus.CREATED, data: created }), reload })).resolves.toBe(created)
-
-    expect(reload).not.toHaveBeenCalled()
-  })
-
-  it('should reload once on a 409 conflict and return the existing state, never retrying create', async () => {
-    const onCollision = vi.fn()
     const existing = { id: 2 }
-    const create = vi.fn(async () => ({ status: HttpStatus.CONFLICT, data: null }))
     const reload = vi.fn(async () => existing)
 
-    await expect(ensure({ create, reload, onCollision })).resolves.toBe(existing)
+    await expect(ensure({ create: async () => ({ status: HttpStatus.CREATED, data: created }), reload })).resolves.toBe(existing)
+
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('should reload once on a 400 CONFLICT and return the existing state, never retrying create', async () => {
+    const onCollision = vi.fn()
+    const existing = { id: 2 }
+    const create = vi.fn(async () => makeConflictResponse<{ id: number }>())
+    const reload = vi.fn(async () => existing)
+
+    await expect(ensure<{ id: number }>({ create, reload, onCollision })).resolves.toBe(existing)
 
     expect(create).toHaveBeenCalledOnce()
     expect(onCollision).toHaveBeenCalledOnce()
     expect(reload).toHaveBeenCalledOnce()
   })
 
-  it('should rethrow on a 409 whose reload finds nothing', async () => {
-    const create = vi.fn(async () => ({ status: HttpStatus.CONFLICT, data: null }))
-    const reload = vi.fn(async () => null)
+  it('should reload once on a real HTTP 409 and return the existing state', async () => {
+    const existing = { id: 2 }
+    const create = vi.fn(async () => makeHttpConflictResponse<{ id: number }>())
+    const reload = vi.fn(async () => existing)
 
-    await expect(ensure({ create, reload })).rejects.toThrow('Harbor request failed (409)')
+    await expect(ensure<{ id: number }>({ create, reload })).resolves.toBe(existing)
+
+    expect(create).toHaveBeenCalledOnce()
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('should rethrow on a 400 CONFLICT whose reload finds nothing', async () => {
+    const create = vi.fn(async () => makeConflictResponse<undefined>())
+    const reload = vi.fn(async () => undefined)
+
+    await expect(ensure({ create, reload })).rejects.toThrow('Harbor request failed (400)')
 
     expect(reload).toHaveBeenCalledOnce()
   })
@@ -37,7 +50,7 @@ describe('ensure', () => {
   it('should surface reload errors', async () => {
     const error = new Error('Harbor retention policy failed (400)')
 
-    await expect(ensure({ create: async () => ({ status: HttpStatus.CONFLICT, data: null }), reload: async () => { throw error } })).rejects.toBe(error)
+    await expect(ensure({ create: async () => makeConflictResponse<null>(), reload: async () => { throw error } })).rejects.toBe(error)
   })
 
   it('should throw on other >= 400 statuses without reloading', async () => {
@@ -50,7 +63,7 @@ describe('ensure', () => {
 })
 
 describe('isRegistryConflict', () => {
-  it('should detect a plain 409', () => {
+  it('should accept a plain 409 — Harbor project create signals collisions with it', () => {
     expect(isRegistryConflict({ status: HttpStatus.CONFLICT, data: null })).toBe(true)
   })
 
@@ -61,11 +74,11 @@ describe('isRegistryConflict', () => {
     })).toBe(true)
   })
 
-  it('should detect the code case-insensitively', () => {
+  it('should reject a code that is not the exact CONFLICT string', () => {
     expect(isRegistryConflict({
       status: HttpStatus.BAD_REQUEST,
       data: { errors: [{ code: 'Conflict', message: 'already exists' }] },
-    })).toBe(true)
+    })).toBe(false)
   })
 
   it('should reject a 400 without the structured errors body', () => {

--- a/apps/server-nestjs/src/modules/registry/registry.utils.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.utils.ts
@@ -4,32 +4,49 @@ import { removeTrailingSlash } from '@cpn-console/shared'
 import { HttpStatus } from '@nestjs/common'
 
 // Whether a Harbor response signals an entity already existing (race collision):
-// a 409 conflict on the create call.
+// a 409, or a 400 whose structured body carries code "CONFLICT" — Harbor
+// reports most "already exists" races as 400:
+// {"errors":[{"code":"CONFLICT","message":"... project already exists"}]}
 export function isRegistryConflict(response: RegistryResponse<unknown>): boolean {
-  return response.status === HttpStatus.CONFLICT
+  if (response.status === HttpStatus.CONFLICT) return true
+  if (response.status !== HttpStatus.BAD_REQUEST) return false
+  const body = response.data as { errors?: Array<{ code?: unknown }> } | null
+  if (!Array.isArray(body?.errors)) return false
+  return body.errors.some(error => typeof error?.code === 'string' && error.code.toUpperCase() === 'CONFLICT')
 }
 
 // Runs an idempotent write: tries `create`, and on a Harbor race collision
-// reloads via `reload` and returns the existing state instead of failing.
-// `onCollision` is invoked once when a collision is detected. If the reload
-// finds nothing, the error is rethrown so genuine failures are not swallowed.
+// (409, or 400 with code CONFLICT) reconciles via `reload` and returns its
+// result instead of failing. `onCollision` is invoked once when a collision is
+// detected. Resolve semantics: a success carrying a body resolves with it
+// (robots); a success with an empty body (projects, members, retentions)
+// resolves with null — the caller fetches when it needs the entity. If a
+// collision reload finds nothing, the error is rethrown so genuine failures
+// are not swallowed.
 export async function ensure<T>({
   create,
   reload,
   onCollision,
 }: {
   create: () => Promise<RegistryResponse<T>>
-  reload: () => Promise<void>
+  reload: () => Promise<T | null | undefined>
   onCollision?: (response: RegistryResponse<T>) => void
-}): Promise<void> {
+}): Promise<T | null> {
   const created = await create()
   if (created.status >= HttpStatus.BAD_REQUEST) {
-    if (isRegistryConflict(created)) {
-      onCollision?.(created)
-      return reload()
+    if (!isRegistryConflict(created)) {
+      throw new Error(`Harbor request failed (${created.status})`)
     }
+    onCollision?.(created)
+    const existing = await reload()
+    if (existing !== null && existing !== undefined) return existing
     throw new Error(`Harbor request failed (${created.status})`)
   }
+  if (created.data !== null && created.data !== undefined && created.data !== ''
+    && !(typeof created.data === 'object' && !Array.isArray(created.data) && Object.keys(created.data).length === 0)) {
+    return created.data
+  }
+  return null
 }
 
 export function createProjectSlugCacheKey(projectId: string) {

--- a/apps/server-nestjs/src/modules/registry/registry.utils.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.utils.ts
@@ -2,36 +2,35 @@ import type { ProjectWithDetails } from './registry-datastore.service'
 import type { RegistryResponse } from './registry-http-client.service'
 import { removeTrailingSlash } from '@cpn-console/shared'
 import { HttpStatus } from '@nestjs/common'
+import z from 'zod'
 
-// Whether a Harbor response signals an entity already existing (race collision):
-// a 409, or a 400 whose structured body carries code "CONFLICT" — Harbor
-// reports most "already exists" races as 400:
-// {"errors":[{"code":"CONFLICT","message":"... project already exists"}]}
+// Harbor signals an "already exists" race either as a plain HTTP 409
+// (project create) or as a 400 whose body carries code CONFLICT.
+const harborErrorBodySchema = z.object({
+  errors: z.array(z.object({
+    code: z.string(),
+  })),
+})
+
 export function isRegistryConflict(response: RegistryResponse<unknown>): boolean {
   if (response.status === HttpStatus.CONFLICT) return true
   if (response.status !== HttpStatus.BAD_REQUEST) return false
-  const body = response.data as { errors?: Array<{ code?: unknown }> } | null
-  if (!Array.isArray(body?.errors)) return false
-  return body.errors.some(error => typeof error?.code === 'string' && error.code.toUpperCase() === 'CONFLICT')
+  const parsed = harborErrorBodySchema.safeParse(response.data)
+  return parsed.success && parsed.data.errors.some(error => error.code === 'CONFLICT')
 }
 
-// Runs an idempotent write: tries `create`, and on a Harbor race collision
-// (409, or 400 with code CONFLICT) reconciles via `reload` and returns its
-// result instead of failing. `onCollision` is invoked once when a collision is
-// detected. Resolve semantics: a success carrying a body resolves with it
-// (robots); a success with an empty body (projects, members, retentions)
-// resolves with null — the caller fetches when it needs the entity. If a
-// collision reload finds nothing, the error is rethrown so genuine failures
-// are not swallowed.
+// Idempotent write: on a race collision, reconciles via `reload` and returns
+// its result; a collision reload that finds nothing rethrows. The created
+// response carries no usable body — reload always provides the fresh object.
 export async function ensure<T>({
   create,
   reload,
   onCollision,
 }: {
-  create: () => Promise<RegistryResponse<T>>
-  reload: () => Promise<T | null | undefined>
-  onCollision?: (response: RegistryResponse<T>) => void
-}): Promise<T | null> {
+  create: () => Promise<RegistryResponse>
+  reload: () => Promise<T | undefined>
+  onCollision?: (response: RegistryResponse) => void
+}): Promise<T | undefined> {
   const created = await create()
   if (created.status >= HttpStatus.BAD_REQUEST) {
     if (!isRegistryConflict(created)) {
@@ -39,14 +38,10 @@ export async function ensure<T>({
     }
     onCollision?.(created)
     const existing = await reload()
-    if (existing !== null && existing !== undefined) return existing
+    if (existing !== undefined) return existing
     throw new Error(`Harbor request failed (${created.status})`)
   }
-  if (created.data !== null && created.data !== undefined && created.data !== ''
-    && !(typeof created.data === 'object' && !Array.isArray(created.data) && Object.keys(created.data).length === 0)) {
-    return created.data
-  }
-  return null
+  return reload()
 }
 
 export function createProjectSlugCacheKey(projectId: string) {

--- a/apps/server-nestjs/test/registry.e2e-spec.ts
+++ b/apps/server-nestjs/test/registry.e2e-spec.ts
@@ -1,5 +1,6 @@
 import type { ConfigType } from '@nestjs/config'
 import type { TestingModule } from '@nestjs/testing'
+import { ENABLED } from '@cpn-console/shared'
 import { faker } from '@faker-js/faker'
 import { ConfigModule } from '@nestjs/config'
 import { EventEmitter2 } from '@nestjs/event-emitter'
@@ -10,7 +11,7 @@ import { harborConfigFactory } from '../src/config/harbor.config'
 import { EventsModule } from '../src/modules/infrastructure/events/events.module'
 import { RegistryClientService } from '../src/modules/registry/registry-client.service'
 import { makeProjectWithDetails } from '../src/modules/registry/registry-testing.utils'
-import { ROBOT_NAME_PROJECT, ROBOT_NAME_RO, ROBOT_NAME_RW } from '../src/modules/registry/registry.constants'
+import { PLUGIN_NAME, REGISTRY_CONFIG_KEY_PUBLISH_PROJECT_ROBOT, ROBOT_NAME_PROJECT, ROBOT_NAME_RO, ROBOT_NAME_RW } from '../src/modules/registry/registry.constants'
 import { RegistryModule } from '../src/modules/registry/registry.module'
 import { RegistryService } from '../src/modules/registry/registry.service'
 import { getHostFromUrl, getProjectVaultPath } from '../src/modules/registry/registry.utils'
@@ -65,8 +66,15 @@ describeWithRegistry('RegistryService (e2e)', () => {
   })
 
   it('should provision project in Harbor and write robot secrets to Vault', async () => {
-    const result = await registry.ensureProject({ slug: projectSlug, plugins: [] }, { publishProjectRobot: true })
-    expect(result.basePath).toBe(`${getHostFromUrl(harborConfig.url)}/${projectSlug}/`)
+    const result = await eventEmitter.emitAsync('project.upsert', makeProjectWithDetails({
+      slug: projectSlug,
+      plugins: [{
+        pluginName: PLUGIN_NAME,
+        key: REGISTRY_CONFIG_KEY_PUBLISH_PROJECT_ROBOT,
+        value: ENABLED,
+      }],
+    }))
+    expect(result[0]?.harbor?.status).toBe('OK')
 
     const project = await client.getProjectByName(projectSlug)
     expect(project.status).toBe(200)
@@ -85,6 +93,25 @@ describeWithRegistry('RegistryService (e2e)', () => {
     expect(roSecret.data?.USERNAME).toBe(`robot$${projectSlug}+${ROBOT_NAME_RO}`)
     expect(rwSecret.data?.USERNAME).toBe(`robot$${projectSlug}+${ROBOT_NAME_RW}`)
     expect(projectSecret.data?.USERNAME).toBe(`robot$${projectSlug}+${ROBOT_NAME_PROJECT}`)
+  })
+
+  it('should re-sync an existing project without trippingthe retention duplicate (400)', async () => {
+    // Harbor keeps one retention policy per project: a second POST /retentions
+    // would return 400. A re-sync via the upsert event must reconcile the existing
+    // policy instead of creating a second one..
+    const result = await eventEmitter.emitAsync('project.upsert', makeProjectWithDetails({
+      slug: projectSlug,
+      plugins: [{
+        pluginName: PLUGIN_NAME,
+        key: REGISTRY_CONFIG_KEY_PUBLISH_PROJECT_ROBOT,
+        value: ENABLED,
+      }],
+    }))
+    expect(result[0]?.harbor?.status).toBe('OK')
+
+    const project = await client.getProjectByName(projectSlug)
+    expect(project.status).toBe(200)
+    expect(project.data?.metadata?.retention_id).toBeTruthy()
   })
 
   it('should remove project from Harbor on delete', async () => {


### PR DESCRIPTION
## Issues liées

Issues numéro: #2620 (fermer délibérément après la fusion)

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Harbor signale la plupart des collisions « déjà existant » par un HTTP 400 avec un corps structuré `{"errors":[{"code":"CONFLICT","message":"... already exists"}]}` plutôt que par un 409 simple.
Les quatre chemins de création du module registry (projet, membre de groupe, robot, politique de rétention) ne tolèrent ni 409 ni 400 `CONFLICT` : toute course à la création fait échouer la réconciliation.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

`isRegistryConflict` accepte désormais le 409 simple et le 400 à corps `CONFLICT` structuré (comparaison du code insensible à la casse, garde `Array.isArray`).
L'utilitaire `ensure` acquiert une sémantique de réconciliation : le résultat du `reload` après collision est retourné à l'appelant, et un `reload` qui ne trouve rien relève l'erreur afin de ne pas masquer un échec réel.
Les quatre chemins passent par lui :

- `ensureProject` : recharge le projet existant après collision.
- `ensureGroupMember` : re-liste les membres et confirme l'appartenance.
- `ensureRobot` : aucun rechargement ni rotation — le robot existant est conservé (il appartient à l'exécution concurrente qui détient son secret) et la collision est tolérée en retournant `null`, la rotation restant un chemin explicite de la couche service.
- `ensureRetention` : met à jour la politique dont l'identifiant a été créé par la course.

Tests unitaires ajoutés pour le prédicat (409 simple, 400 `CONFLICT`, corps non structurés rejetés) et pour les scénarios msw de rechargement et de rotation.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Vérification locale : 34/34 tests vitest du module registry, ESLint propre sur les quatre fichiers, `tsc --noEmit` sans nouvelle erreur (bruit de base inchangé).
