### PR TITLE
fix(server-nestjs): grant SonarQube project-admin permissions to the project owner

### DIFF
--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
@@ -175,6 +175,30 @@ describe('sonarqubeService', () => {
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: `/${project.slug}/console/developer`, permission: 'securityhotspotadmin' }))
     })
 
+    it('should grant the owner project-admin permissions on repositories when their SSO account exists', async () => {
+      const project = makeProjectWithDetails({ repositories: [{ internalRepoName: 'repo' }] })
+      client.generateUserToken.mockResolvedValue(makeUserToken({ login: project.slug }))
+      const ownerLogin = project.owner.email.split('@')[0]
+      client.searchUsers.mockImplementation(async function* () {
+        yield makeSonarqubeUser({ login: ownerLogin, email: project.owner.email })
+      })
+
+      await service.handleUpsert(project)
+
+      expect(client.addPermissionUser).toHaveBeenCalledWith(expect.objectContaining({ login: ownerLogin, permission: 'admin' }))
+      expect(client.addPermissionUser).toHaveBeenCalledWith(expect.objectContaining({ login: ownerLogin, permission: 'issueadmin' }))
+    })
+
+    it('should skip the owner permission grant without failing when the owner has no SonarQube account yet', async () => {
+      const project = makeProjectWithDetails({ repositories: [{ internalRepoName: 'repo' }] })
+      client.generateUserToken.mockResolvedValue(makeUserToken({ login: project.slug }))
+      client.searchUsers.mockImplementation(async function* () { yield* makeEmptyUsersResponse().users })
+
+      await service.handleUpsert(project)
+
+      expect(client.addPermissionUser).not.toHaveBeenCalledWith(expect.objectContaining({ login: project.owner.email }))
+    })
+
     it('should provision GitLab CI variables for each repository and the shared group token', async () => {
       const project = makeProjectWithDetails({ repositories: [{ internalRepoName: 'repo' }] })
       const groupId = 42

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
@@ -259,13 +259,23 @@ export class SonarqubeService implements OnModuleInit {
     span?.setAttribute('project.slug', project.slug)
     span?.setAttribute('repositories.count', project.repositories.length)
 
-    const [readonlyGroupPath, securityGroupPath, existingSonarProjects, sonarSecret, gitlabGroup] = await Promise.all([
+    const [readonlyGroupPath, securityGroupPath, existingSonarProjects, sonarSecret, gitlabGroup, ownerUser] = await Promise.all([
       this.getReadonlyGroupPath(),
       this.getSecurityGroupPath(),
       getAll(this.findProjectsForSlug(project.slug)),
       this.vault.readSonarqubeUser(project.slug),
       this.gitlab.getOrCreateProjectGroup(),
+      this.findUserByEmail(project.owner.email),
     ])
+
+    // The owner implicitly holds the project admin role. Groups come from Keycloak
+    // OIDC sync, but the owner is in no role group, so grant them directly (same
+    // spirit as GitLab's addMissingOwnerMember). Until the owner has signed in once
+    // (SSO provisioning) they don't exist in SonarQube: warn and skip, the next
+    // reconcile grants them.
+    if (!ownerUser) {
+      this.logger.warn(`Owner SonarQube account not found, skipping owner permission grant until first SSO sign-in (project=${project.slug}, email=${project.owner.email})`)
+    }
 
     // SONAR_TOKEN is shared across every repository of the project; expose it once at the group level.
     if (sonarSecret?.data?.SONAR_TOKEN) {
@@ -300,6 +310,11 @@ export class SonarqubeService implements OnModuleInit {
           this.logger.log(`Created SonarQube repository (key=${projectKey})`)
         }
         await this.ensureProjectPermissions(projectKey, project.slug, rolePaths, readonlyGroupPath, securityGroupPath)
+        if (ownerUser) {
+          await Promise.all(PROJECT_ADMIN_PERMISSIONS.map(permission =>
+            this.client.addPermissionUser({ projectKey, permission, login: ownerUser.login }),
+          ))
+        }
         this.logger.verbose(`Ensured permissions on SonarQube repository (key=${projectKey})`)
         await this.ensureGitlabCiVariables(project, repository, projectKey, sonarSecret)
       }),
@@ -448,6 +463,13 @@ export class SonarqubeService implements OnModuleInit {
   private async findUser(login: string): Promise<SonarqubeUser | undefined> {
     for await (const user of this.client.searchUsers({ q: login })) {
       if (user.login === login) return user
+    }
+    return undefined
+  }
+
+  private async findUserByEmail(email: string): Promise<SonarqubeUser | undefined> {
+    for await (const user of this.client.searchUsers({ q: email })) {
+      if (user.email.toLowerCase() === email.toLowerCase()) return user
     }
     return undefined
   }


### PR DESCRIPTION
## Issues liées

#2644

---------

## Quel est le comportement actuel ?

Le propriétaire d'un projet ne reçoit aucune permission SonarQube : l'accès y est dérivé des groupes OIDC Keycloak (`/{slug}/console/admin`, ...), or le propriétaire n'est membre d'aucun groupe de rôle (seul GitLab l'ajoute explicitement via `addMissingOwnerMember`). À la connexion SSO, il ne voit aucun projet.

## Quel est le nouveau comportement ?

À chaque réconciliation, le service SonarQube recherche le propriétaire par email et lui accorde directement le jeu de permissions project-admin (`admin`, `scan`, `user`, `codeviewer`, `issueadmin`, `securityhotspotadmin`) sur chaque dépôt, dans le même esprit que GitLab. Tant que le propriétaire ne s'est pas connecté une fois via SSO, il n'existe pas dans SonarQube : l'octroi est sauté avec un avertissement et la réconciliation suivante le complète. Aucun utilisateur n'est provisionné artificiellement (évite de reproduire la collision d'email #2510).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

- Portée limitée à SonarQube : les autres services (Vault, Nexus, ArgoCD, Harbor) restent pilotés par les groupes OIDC Keycloak, dont la partie propriétaire relève du ticket #2644 côté Keycloak ; Harbor suit la matrice ADR `014_Droits-fins` (project-admin → Developer), volontairement inchangée.