### PR TITLE
chore(server-nestjs): rename role readonly to reader

### DIFF
--- a/apps/server-nestjs/src/modules/argocd/argocd-plugin.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd-plugin.service.ts
@@ -8,8 +8,8 @@ import {
   EXTRA_REPOSITORIES_PLUGIN_KEY,
   PLATFORM_ADMIN_GROUP_PATH,
   PLATFORM_ADMIN_GROUP_PATH_PLUGIN_KEY,
-  PLATFORM_READONLY_GROUP_PATH,
-  PLATFORM_READONLY_GROUP_PATH_PLUGIN_KEY,
+  PLATFORM_READER_GROUP_PATH,
+  PLATFORM_READER_GROUP_PATH_PLUGIN_KEY,
   PLATFORM_SECURITY_GROUP_PATH,
   PROJECT_ADMIN_GROUP_PATH_SUFFIX,
   PROJECT_ADMIN_GROUP_PATH_SUFFIX_PLUGIN_KEY,
@@ -17,8 +17,8 @@ import {
   PROJECT_DEVELOPER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
   PROJECT_DEVOPS_GROUP_PATH_SUFFIX,
   PROJECT_DEVOPS_GROUP_PATH_SUFFIX_PLUGIN_KEY,
-  PROJECT_READONLY_GROUP_PATH_SUFFIX,
-  PROJECT_READONLY_GROUP_PATH_SUFFIX_PLUGIN_KEY,
+  PROJECT_READER_GROUP_PATH_SUFFIX,
+  PROJECT_READER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
   PROJECT_SECURITY_GROUP_PATH_SUFFIX,
 } from './argocd.constants'
 
@@ -59,15 +59,15 @@ export class ArgoCDPluginService {
           value: PLATFORM_ADMIN_GROUP_PATH,
           description: 'Chemin du groupe administrateur de plateforme',
         }, {
-          key: PLATFORM_READONLY_GROUP_PATH_PLUGIN_KEY,
+          key: PLATFORM_READER_GROUP_PATH_PLUGIN_KEY,
           kind: 'text',
           permissions: {
             admin: { read: true, write: true },
             user: { read: false, write: false },
           },
-          title: 'Platform Readonly Group Path',
-          value: PLATFORM_READONLY_GROUP_PATH,
-          description: 'Chemin du groupe lecture seule de plateforme',
+          title: 'Platform Reader Group Path',
+          value: PLATFORM_READER_GROUP_PATH,
+          description: 'Chemin du groupe lecteur de plateforme',
         }, {
           key: 'platformSecurityGroupPath',
           kind: 'text',
@@ -109,15 +109,15 @@ export class ArgoCDPluginService {
           value: PROJECT_DEVELOPER_GROUP_PATH_SUFFIX,
           description: 'Suffixe du chemin du groupe développeur de projet',
         }, {
-          key: PROJECT_READONLY_GROUP_PATH_SUFFIX_PLUGIN_KEY,
+          key: PROJECT_READER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
           kind: 'text',
           permissions: {
             admin: { read: true, write: true },
             user: { read: false, write: false },
           },
-          title: 'Project Readonly Group Path Suffix',
-          value: PROJECT_READONLY_GROUP_PATH_SUFFIX,
-          description: 'Suffixe du chemin du groupe lecture seule de projet',
+          title: 'Project Reader Group Path Suffix',
+          value: PROJECT_READER_GROUP_PATH_SUFFIX,
+          description: 'Suffixe du chemin du groupe lecteur de projet',
         }, {
           key: 'projectSecurityGroupPathSuffix',
           kind: 'text',

--- a/apps/server-nestjs/src/modules/argocd/argocd.constants.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.constants.ts
@@ -4,14 +4,14 @@ export const PLUGIN_NAME = 'argocd'
 // Platform-level group paths
 export const CONSOLE_ADMIN_GROUP_PATH = '/console/admin'
 export const PLATFORM_ADMIN_GROUP_PATH = '/console/admin'
-export const PLATFORM_READONLY_GROUP_PATH = '/console/readonly'
+export const PLATFORM_READER_GROUP_PATH = '/console/reader'
 export const PLATFORM_SECURITY_GROUP_PATH = '/console/security'
 
 // Suffix for project group path
 export const PROJECT_ADMIN_GROUP_PATH_SUFFIX = '/console/admin'
 export const PROJECT_DEVOPS_GROUP_PATH_SUFFIX = '/console/devops'
 export const PROJECT_DEVELOPER_GROUP_PATH_SUFFIX = '/console/developer'
-export const PROJECT_READONLY_GROUP_PATH_SUFFIX = '/console/readonly'
+export const PROJECT_READER_GROUP_PATH_SUFFIX = '/console/reader'
 export const PROJECT_SECURITY_GROUP_PATH_SUFFIX = '/console/security'
 
 // Default chart versions
@@ -21,10 +21,10 @@ export const DEFAULT_DSO_NS_CHART_VERSION = 'dso-ns-1.1.5'
 // Plugin configuration keys
 export const EXTRA_REPOSITORIES_PLUGIN_KEY = 'extraRepositories'
 export const PLATFORM_ADMIN_GROUP_PATH_PLUGIN_KEY = 'platformAdminGroupPath'
-export const PLATFORM_READONLY_GROUP_PATH_PLUGIN_KEY = 'platformReadonlyGroupPath'
+export const PLATFORM_READER_GROUP_PATH_PLUGIN_KEY = 'platformReaderGroupPath'
 export const PROJECT_ADMIN_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectAdminGroupPathSuffix'
 export const PROJECT_DEVOPS_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectDevopsGroupPathSuffix'
 export const PROJECT_DEVELOPER_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectDevelopperGroupPathSuffix'
-export const PROJECT_READONLY_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectReadonlyGroupPathSuffix'
+export const PROJECT_READER_GROUP_PATH_SUFFIX_PLUGIN_KEY = 'projectReaderGroupPathSuffix'
 export const DSO_ENV_CHART_VERSION_PLUGIN_KEY = 'dsoEnvChartVersion'
 export const DSO_NS_CHART_VERSION_PLUGIN_KEY = 'dsoNsChartVersion'

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
@@ -286,13 +286,13 @@ describe('argoCDService', () => {
               rwGroup: '/project-1/console/dev/RW',
               consoleAdminGroup: '/console/admin',
               platformAdminGroup: '/console/admin',
-              platformReadonlyGroup: '/console/readonly',
+              platformReaderGroup: '/console/reader',
               platformSecurityGroup: '/console/security',
               projectAdminGroup: '/project-1/console/admin',
               projectDevopsGroup: '/project-1/console/devops',
               projectDevelopperGroup: '/project-1/console/developer',
               projectSecurityGroup: '/project-1/console/security',
-              projectReadonlyGroup: '/project-1/console/readonly',
+              projectReaderGroup: '/project-1/console/reader',
             },
             application: {
               quota: {
@@ -361,13 +361,13 @@ describe('argoCDService', () => {
               rwGroup: '/project-1/console/prod/RW',
               consoleAdminGroup: '/console/admin',
               platformAdminGroup: '/console/admin',
-              platformReadonlyGroup: '/console/readonly',
+              platformReaderGroup: '/console/reader',
               platformSecurityGroup: '/console/security',
               projectAdminGroup: '/project-1/console/admin',
               projectDevopsGroup: '/project-1/console/devops',
               projectDevelopperGroup: '/project-1/console/developer',
               projectSecurityGroup: '/project-1/console/security',
-              projectReadonlyGroup: '/project-1/console/readonly',
+              projectReaderGroup: '/project-1/console/reader',
             },
             application: {
               quota: {
@@ -621,13 +621,13 @@ describe('argoCDService', () => {
               rwGroup: '/project-1/console/dev/RW',
               consoleAdminGroup: '/console/admin',
               platformAdminGroup: '/console/admin',
-              platformReadonlyGroup: '/console/readonly',
+              platformReaderGroup: '/console/reader',
               platformSecurityGroup: '/console/security',
               projectAdminGroup: '/project-1/console/admin',
               projectDevopsGroup: '/project-1/console/devops',
               projectDevelopperGroup: '/project-1/console/developer',
               projectSecurityGroup: '/project-1/console/security',
-              projectReadonlyGroup: '/project-1/console/readonly',
+              projectReaderGroup: '/project-1/console/reader',
             },
             application: {
               quota: {

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -19,12 +19,12 @@ import { ArgoCDDatastoreService } from './argocd-datastore.service'
 import {
   CONSOLE_ADMIN_GROUP_PATH,
   PLATFORM_ADMIN_GROUP_PATH,
-  PLATFORM_READONLY_GROUP_PATH,
+  PLATFORM_READER_GROUP_PATH,
   PLATFORM_SECURITY_GROUP_PATH,
   PROJECT_ADMIN_GROUP_PATH_SUFFIX,
   PROJECT_DEVELOPER_GROUP_PATH_SUFFIX,
   PROJECT_DEVOPS_GROUP_PATH_SUFFIX,
-  PROJECT_READONLY_GROUP_PATH_SUFFIX,
+  PROJECT_READER_GROUP_PATH_SUFFIX,
   PROJECT_SECURITY_GROUP_PATH_SUFFIX,
 } from './argocd.constants'
 
@@ -443,13 +443,13 @@ interface ValuesSchema {
     rwGroup: string
     consoleAdminGroup: string
     platformAdminGroup: string
-    platformReadonlyGroup: string
+    platformReaderGroup: string
     platformSecurityGroup: string
     projectAdminGroup: string
     projectDevopsGroup: string
     projectDevelopperGroup: string
     projectSecurityGroup: string
-    projectReadonlyGroup: string
+    projectReaderGroup: string
   }
   application: {
     quota: {
@@ -600,13 +600,13 @@ function formatEnvironmentValues(
     rwGroup,
     consoleAdminGroup: CONSOLE_ADMIN_GROUP_PATH,
     platformAdminGroup: PLATFORM_ADMIN_GROUP_PATH,
-    platformReadonlyGroup: PLATFORM_READONLY_GROUP_PATH,
+    platformReaderGroup: PLATFORM_READER_GROUP_PATH,
     platformSecurityGroup: PLATFORM_SECURITY_GROUP_PATH,
     projectAdminGroup: generateProjectConsoleGroupPath(project.slug, PROJECT_ADMIN_GROUP_PATH_SUFFIX),
     projectDevopsGroup: generateProjectConsoleGroupPath(project.slug, PROJECT_DEVOPS_GROUP_PATH_SUFFIX),
     projectDevelopperGroup: generateProjectConsoleGroupPath(project.slug, PROJECT_DEVELOPER_GROUP_PATH_SUFFIX),
     projectSecurityGroup: generateProjectConsoleGroupPath(project.slug, PROJECT_SECURITY_GROUP_PATH_SUFFIX),
-    projectReadonlyGroup: generateProjectConsoleGroupPath(project.slug, PROJECT_READONLY_GROUP_PATH_SUFFIX),
+    projectReaderGroup: generateProjectConsoleGroupPath(project.slug, PROJECT_READER_GROUP_PATH_SUFFIX),
   } satisfies ValuesSchema['environment']
 }
 

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.constants.ts
@@ -22,10 +22,10 @@ export const TOKEN_DESCRIPTION = 'mirroring-from-external-repo'
 
 // Default group paths for console roles
 export const DEFAULT_ADMIN_GROUP_PATH = '/console/admin'
-export const DEFAULT_AUDITOR_GROUP_PATH = '/console/readonly,/console/security'
+export const DEFAULT_AUDITOR_GROUP_PATH = '/console/reader,/console/security'
 export const DEFAULT_PROJECT_MAINTAINER_GROUP_PATH_SUFFIX = '/console/admin,/console/devops'
 export const DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX = '/console/developer'
-export const DEFAULT_PROJECT_REPORTER_GROUP_PATH_SUFFIX = '/console/readonly,/console/security'
+export const DEFAULT_PROJECT_REPORTER_GROUP_PATH_SUFFIX = '/console/reader,/console/security'
 
 // Plugin configuration keys
 export const ADMIN_GROUP_PATH_PLUGIN_KEY = 'adminGroupPath'

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
@@ -291,7 +291,7 @@ describe('gitlabService', () => {
       const project = makeProjectWithDetails({
         slug: 'project-1',
         roles: [
-          { id: 'r-reporter', oidcGroup: '/project-1/console/readonly' },
+          { id: 'r-reporter', oidcGroup: '/project-1/console/reader' },
           { id: 'r-developer', oidcGroup: '/project-1/console/developer' },
           { id: 'r-devops', oidcGroup: '/project-1/console/devops' },
           { id: 'r-maintainer', oidcGroup: '/project-1/console/admin' },
@@ -439,12 +439,12 @@ describe('gitlabService', () => {
 
       datastore.getAdminPluginConfig.mockImplementation(async (_pluginName: string, key: string) => {
         if (key === 'adminGroupPath') return '/console/admin'
-        if (key === 'auditorGroupPath') return '/console/readonly'
+        if (key === 'auditorGroupPath') return '/console/reader'
         return null
       })
       datastore.getAdminRolesByOidcGroups.mockResolvedValue([
         { id: 'admin-role-id', oidcGroup: '/console/admin' },
-        { id: 'auditor-role-id', oidcGroup: '/console/readonly' },
+        { id: 'auditor-role-id', oidcGroup: '/console/reader' },
       ])
 
       gitlab.getOrCreateProjectSubGroup.mockResolvedValue(group)

--- a/apps/server-nestjs/src/modules/nexus/nexus.constants.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.constants.ts
@@ -17,16 +17,16 @@ export const DEFAULT_NPM_WRITE_POLICY = 'allow'
 
 // Default group paths granting write and read access at the platform level
 export const DEFAULT_PLATFORM_WRITE_GROUP_PATHS = '/console/admin'
-export const DEFAULT_PLATFORM_READ_GROUP_PATHS = '/console/readonly,/console/security'
+export const DEFAULT_PLATFORM_READER_GROUP_PATHS = '/console/readonly,/console/security'
 
 // Default group path suffixes granting write and read access at the project level
 export const DEFAULT_PROJECT_WRITE_GROUP_PATH_SUFFIXES = '/console/admin,/console/devops'
-export const DEFAULT_PROJECT_READ_GROUP_PATH_SUFFIXES = '/console/readonly,/console/security,/console/developer'
+export const DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIXES = '/console/readonly,/console/security,/console/developer'
 
 // Plugin configuration keys for platform-level group paths
 export const PLATFORM_WRITE_GROUP_PATHS_PLUGIN_KEY = 'platformWriteGroupPaths'
-export const PLATFORM_READ_GROUP_PATHS_PLUGIN_KEY = 'platformReadGroupPaths'
+export const PLATFORM_READER_GROUP_PATHS_PLUGIN_KEY = 'platformReadGroupPaths'
 
 // Plugin configuration keys for project-level group path suffixes
 export const PROJECT_WRITE_GROUP_PATH_SUFFIXES_PLUGIN_KEY = 'projectWriteGroupPathSuffixes'
-export const PROJECT_READ_GROUP_PATH_SUFFIXES_PLUGIN_KEY = 'projectReadGroupPathSuffixes'
+export const PROJECT_READER_GROUP_PATH_SUFFIXES_PLUGIN_KEY = 'projectReadGroupPathSuffixes'

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.spec.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.spec.ts
@@ -16,10 +16,10 @@ import { makeProjectWithDetails } from './nexus-testing.utils'
 import {
   NEXUS_CONFIG_KEY_ACTIVATE_MAVEN_REPO,
   NEXUS_CONFIG_KEY_ACTIVATE_NPM_REPO,
-  PLATFORM_READ_GROUP_PATHS_PLUGIN_KEY,
+  PLATFORM_READER_GROUP_PATHS_PLUGIN_KEY,
   PLATFORM_WRITE_GROUP_PATHS_PLUGIN_KEY,
   PLUGIN_NAME,
-  PROJECT_READ_GROUP_PATH_SUFFIXES_PLUGIN_KEY,
+  PROJECT_READER_GROUP_PATH_SUFFIXES_PLUGIN_KEY,
   PROJECT_WRITE_GROUP_PATH_SUFFIXES_PLUGIN_KEY,
 } from './nexus.constants'
 import { NexusService } from './nexus.service'
@@ -123,7 +123,7 @@ describe('nexusService', () => {
     })
 
     datastore.getAdminPluginConfig.mockImplementation(async (_plugin, key) => {
-      if (key === PLATFORM_READ_GROUP_PATHS_PLUGIN_KEY) return ' '
+      if (key === PLATFORM_READER_GROUP_PATHS_PLUGIN_KEY) return ' '
       if (key === PLATFORM_WRITE_GROUP_PATHS_PLUGIN_KEY) return ' '
       return null
     })
@@ -148,7 +148,7 @@ describe('nexusService', () => {
     })
 
     datastore.getAdminPluginConfig.mockImplementation(async (_plugin, key) => {
-      if (key === PLATFORM_READ_GROUP_PATHS_PLUGIN_KEY) return ' '
+      if (key === PLATFORM_READER_GROUP_PATHS_PLUGIN_KEY) return ' '
       if (key === PLATFORM_WRITE_GROUP_PATHS_PLUGIN_KEY) return ' '
       return null
     })
@@ -211,12 +211,12 @@ describe('nexusService', () => {
       plugins: [
         { pluginName: PLUGIN_NAME, key: NEXUS_CONFIG_KEY_ACTIVATE_MAVEN_REPO, value: ENABLED },
         { pluginName: PLUGIN_NAME, key: PROJECT_WRITE_GROUP_PATH_SUFFIXES_PLUGIN_KEY, value: '/console/devops' },
-        { pluginName: PLUGIN_NAME, key: PROJECT_READ_GROUP_PATH_SUFFIXES_PLUGIN_KEY, value: '/console/devops' },
+        { pluginName: PLUGIN_NAME, key: PROJECT_READER_GROUP_PATH_SUFFIXES_PLUGIN_KEY, value: '/console/devops' },
       ],
     })
 
     datastore.getAdminPluginConfig.mockImplementation(async (_plugin, key) => {
-      if (key === PLATFORM_READ_GROUP_PATHS_PLUGIN_KEY) return ' '
+      if (key === PLATFORM_READER_GROUP_PATHS_PLUGIN_KEY) return ' '
       if (key === PLATFORM_WRITE_GROUP_PATHS_PLUGIN_KEY) return ' '
       return null
     })

--- a/apps/server-nestjs/src/modules/nexus/nexus.service.ts
+++ b/apps/server-nestjs/src/modules/nexus/nexus.service.ts
@@ -21,19 +21,19 @@ import {
   DEFAULT_MAVEN_RELEASE_WRITE_POLICY,
   DEFAULT_MAVEN_SNAPSHOT_WRITE_POLICY,
   DEFAULT_NPM_WRITE_POLICY,
-  DEFAULT_PLATFORM_READ_GROUP_PATHS,
+  DEFAULT_PLATFORM_READER_GROUP_PATHS,
   DEFAULT_PLATFORM_WRITE_GROUP_PATHS,
-  DEFAULT_PROJECT_READ_GROUP_PATH_SUFFIXES,
+  DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIXES,
   DEFAULT_PROJECT_WRITE_GROUP_PATH_SUFFIXES,
   NEXUS_CONFIG_KEY_ACTIVATE_MAVEN_REPO,
   NEXUS_CONFIG_KEY_ACTIVATE_NPM_REPO,
   NEXUS_CONFIG_KEY_MAVEN_RELEASE_WRITE_POLICY,
   NEXUS_CONFIG_KEY_MAVEN_SNAPSHOT_WRITE_POLICY,
   NEXUS_CONFIG_KEY_NPM_WRITE_POLICY,
-  PLATFORM_READ_GROUP_PATHS_PLUGIN_KEY,
+  PLATFORM_READER_GROUP_PATHS_PLUGIN_KEY,
   PLATFORM_WRITE_GROUP_PATHS_PLUGIN_KEY,
   PLUGIN_NAME,
-  PROJECT_READ_GROUP_PATH_SUFFIXES_PLUGIN_KEY,
+  PROJECT_READER_GROUP_PATH_SUFFIXES_PLUGIN_KEY,
   PROJECT_WRITE_GROUP_PATH_SUFFIXES_PLUGIN_KEY,
 } from './nexus.constants'
 import {
@@ -497,11 +497,11 @@ export class NexusService {
     const rawWriteSuffixes = await this.getOptionalConfigValue(project, PROJECT_WRITE_GROUP_PATH_SUFFIXES_PLUGIN_KEY)
       ?? DEFAULT_PROJECT_WRITE_GROUP_PATH_SUFFIXES
 
-    const rawReadSuffixes = await this.getOptionalConfigValue(project, PROJECT_READ_GROUP_PATH_SUFFIXES_PLUGIN_KEY)
-      ?? DEFAULT_PROJECT_READ_GROUP_PATH_SUFFIXES
+    const rawReadSuffixes = await this.getOptionalConfigValue(project, PROJECT_READER_GROUP_PATH_SUFFIXES_PLUGIN_KEY)
+      ?? DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIXES
 
     const writeGroupPaths = generateProjectRoleGroupPath(project, rawWriteSuffixes || DEFAULT_PROJECT_WRITE_GROUP_PATH_SUFFIXES)
-    const readGroupPaths = generateProjectRoleGroupPath(project, rawReadSuffixes || DEFAULT_PROJECT_READ_GROUP_PATH_SUFFIXES)
+    const readGroupPaths = generateProjectRoleGroupPath(project, rawReadSuffixes || DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIXES)
 
     const byId = generateRolePrivilegesMapping({
       readGroupPaths,
@@ -517,8 +517,8 @@ export class NexusService {
     const rawWriteGroupPaths = await this.datastore.getAdminPluginConfig(PLUGIN_NAME, PLATFORM_WRITE_GROUP_PATHS_PLUGIN_KEY)
       ?? DEFAULT_PLATFORM_WRITE_GROUP_PATHS
 
-    const rawReadGroupPaths = await this.datastore.getAdminPluginConfig(PLUGIN_NAME, PLATFORM_READ_GROUP_PATHS_PLUGIN_KEY)
-      ?? DEFAULT_PLATFORM_READ_GROUP_PATHS
+    const rawReadGroupPaths = await this.datastore.getAdminPluginConfig(PLUGIN_NAME, PLATFORM_READER_GROUP_PATHS_PLUGIN_KEY)
+      ?? DEFAULT_PLATFORM_READER_GROUP_PATHS
 
     const readonlyPrivileges = new Set<string>()
     const writePrivileges = new Set<string>()
@@ -529,7 +529,7 @@ export class NexusService {
     }
 
     const byId = generateRolePrivilegesMapping({
-      readGroupPaths: parseOidcGroupPaths(rawReadGroupPaths || DEFAULT_PLATFORM_READ_GROUP_PATHS),
+      readGroupPaths: parseOidcGroupPaths(rawReadGroupPaths || DEFAULT_PLATFORM_READER_GROUP_PATHS),
       writeGroupPaths: parseOidcGroupPaths(rawWriteGroupPaths || DEFAULT_PLATFORM_WRITE_GROUP_PATHS),
       readOnlyPrivileges: [...readonlyPrivileges],
       writePrivileges: [...writePrivileges],
@@ -550,12 +550,12 @@ export class NexusService {
     const rawWriteSuffixes = await this.getOptionalConfigValue(project, PROJECT_WRITE_GROUP_PATH_SUFFIXES_PLUGIN_KEY)
       ?? DEFAULT_PROJECT_WRITE_GROUP_PATH_SUFFIXES
 
-    const rawReadSuffixes = await this.getOptionalConfigValue(project, PROJECT_READ_GROUP_PATH_SUFFIXES_PLUGIN_KEY)
-      ?? DEFAULT_PROJECT_READ_GROUP_PATH_SUFFIXES
+    const rawReadSuffixes = await this.getOptionalConfigValue(project, PROJECT_READER_GROUP_PATH_SUFFIXES_PLUGIN_KEY)
+      ?? DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIXES
 
     const groupPaths = [
       ...generateProjectRoleGroupPath(project, rawWriteSuffixes || DEFAULT_PROJECT_WRITE_GROUP_PATH_SUFFIXES),
-      ...generateProjectRoleGroupPath(project, rawReadSuffixes || DEFAULT_PROJECT_READ_GROUP_PATH_SUFFIXES),
+      ...generateProjectRoleGroupPath(project, rawReadSuffixes || DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIXES),
     ]
 
     const ids = [...new Set(groupPaths.map(generateRoleId))]

--- a/apps/server-nestjs/src/modules/project/project.utils.ts
+++ b/apps/server-nestjs/src/modules/project/project.utils.ts
@@ -65,10 +65,10 @@ export function generateProjectCreateInput(
           type: 'system:managed',
         },
         {
-          name: 'Lecture seule',
+          name: 'Lecture',
           permissions: PROJECT_PERMS.LIST_ENVIRONMENTS | PROJECT_PERMS.LIST_REPOSITORIES,
           position: 3,
-          oidcGroup: `/${slug}/console/readonly`,
+          oidcGroup: `/${slug}/console/reader`,
           type: 'system:managed',
         },
       ],

--- a/apps/server-nestjs/src/modules/registry/registry.constants.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.constants.ts
@@ -7,13 +7,13 @@ export const REGISTRY_CONFIG_KEY_PUBLISH_PROJECT_ROBOT = 'publishProjectRobot'
 
 // Default platform-level group paths
 export const DEFAULT_PLATFORM_ADMIN_GROUP_PATHS = '/console/admin'
-export const DEFAULT_PLATFORM_GUEST_GROUP_PATHS = '/console/security,/console/readonly'
+export const DEFAULT_PLATFORM_GUEST_GROUP_PATHS = '/console/security,/console/reader'
 
 // Default project-level group path suffixes
 export const DEFAULT_PROJECT_ADMIN_GROUP_PATH_SUFFIXES = '/console/admin'
 export const DEFAULT_PROJECT_MAINTAINER_GROUP_PATH_SUFFIXES = '/console/devops'
 export const DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIXES = '/console/developer'
-export const DEFAULT_PROJECT_GUEST_GROUP_PATH_SUFFIXES = '/console/security,/console/readonly'
+export const DEFAULT_PROJECT_GUEST_GROUP_PATH_SUFFIXES = '/console/security,/console/reader'
 
 // Platform group path plugin configuration keys
 export const PLATFORM_ADMIN_GROUP_PATH_PLUGIN_KEY = 'platformAdminGroupPath'

--- a/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
+++ b/apps/server-nestjs/src/modules/registry/registry.service.spec.ts
@@ -103,9 +103,9 @@ describe('registryService', () => {
       const expected = [
         { groupName: `/${project.slug}`, roleId: 5 },
         { groupName: '/console/admin', roleId: 1 },
-        { groupName: '/console/readonly', roleId: 3 },
+        { groupName: '/console/reader', roleId: 3 },
         { groupName: '/console/security', roleId: 3 },
-        { groupName: `/${project.slug}/console/readonly`, roleId: 3 },
+        { groupName: `/${project.slug}/console/reader`, roleId: 3 },
         { groupName: `/${project.slug}/console/security`, roleId: 3 },
         { groupName: `/${project.slug}/console/developer`, roleId: 3 },
         { groupName: `/${project.slug}/console/devops`, roleId: 3 },

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.constants.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.constants.ts
@@ -17,14 +17,14 @@ export const PROJECT_ADMIN_PERMISSIONS = ['admin', 'scan', 'user', 'codeviewer',
 export const PROJECT_DEVOPS_PERMISSIONS = ['scan', 'user', 'codeviewer', 'issueadmin', 'securityhotspotadmin'] as const
 export const PROJECT_DEVELOPER_PERMISSIONS = ['scan', 'user', 'codeviewer', 'issueadmin', 'securityhotspotadmin'] as const
 export const PROJECT_SECURITY_PERMISSIONS = ['scan', 'user', 'codeviewer', 'issueadmin', 'securityhotspotadmin'] as const
-export const PROJECT_READONLY_PERMISSIONS = ['user', 'codeviewer'] as const
+export const PROJECT_READER_PERMISSIONS = ['user', 'codeviewer'] as const
 
 // CI robot/service account — needs Execute Analysis + Browse + See Source Code
 export const ROBOT_PROJECT_PERMISSIONS = ['scan', 'user', 'codeviewer'] as const
 
 // Default platform-wide Keycloak group paths
 export const DEFAULT_ADMIN_GROUP_PATH = '/console/admin'
-export const DEFAULT_READONLY_GROUP_PATH = '/console/readonly'
+export const DEFAULT_READER_GROUP_PATH = '/console/reader'
 export const DEFAULT_SECURITY_GROUP_PATH = '/console/security'
 
 // Default project role group path suffixes (appended to /{projectSlug})
@@ -32,17 +32,17 @@ export const DEFAULT_PROJECT_ADMIN_SUFFIX = '/console/admin'
 export const DEFAULT_PROJECT_DEVOPS_SUFFIX = '/console/devops'
 export const DEFAULT_PROJECT_DEVELOPER_SUFFIX = '/console/developer'
 export const DEFAULT_PROJECT_SECURITY_SUFFIX = '/console/security'
-export const DEFAULT_PROJECT_READONLY_SUFFIX = '/console/readonly'
+export const DEFAULT_PROJECT_READER_SUFFIX = '/console/reader'
 
 // Admin plugin config keys for overriding defaults
 export const ADMIN_GROUP_PATH_PLUGIN_KEY = 'adminGroupPath'
-export const READONLY_GROUP_PATH_PLUGIN_KEY = 'readonlyGroupPath'
+export const READER_GROUP_PATH_PLUGIN_KEY = 'readerGroupPath'
 export const SECURITY_GROUP_PATH_PLUGIN_KEY = 'securityGroupPath'
 export const PROJECT_ADMIN_SUFFIX_PLUGIN_KEY = 'projectAdminSuffix'
 export const PROJECT_DEVOPS_SUFFIX_PLUGIN_KEY = 'projectDevopsSuffix'
 export const PROJECT_DEVELOPER_SUFFIX_PLUGIN_KEY = 'projectDeveloperSuffix'
 export const PROJECT_SECURITY_SUFFIX_PLUGIN_KEY = 'projectSecuritySuffix'
-export const PROJECT_READONLY_SUFFIX_PLUGIN_KEY = 'projectReadonlySuffix'
+export const PROJECT_READER_SUFFIX_PLUGIN_KEY = 'projectReaderSuffix'
 
 // SonarQube project qualifier identifiers
 export const SONARQUBE_PROJECT_QUALIFIER_APPLICATION = 'APP'

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.spec.ts
@@ -106,9 +106,9 @@ describe('sonarqubeService', () => {
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: '/console/admin' }))
     })
 
-    it('should create /console/readonly and /console/security platform groups', async () => {
+    it('should create /console/reader and /console/security platform groups', async () => {
       await service.init()
-      expect(client.createUserGroup).toHaveBeenCalledWith(expect.objectContaining({ name: '/console/readonly' }))
+      expect(client.createUserGroup).toHaveBeenCalledWith(expect.objectContaining({ name: '/console/reader' }))
       expect(client.createUserGroup).toHaveBeenCalledWith(expect.objectContaining({ name: '/console/security' }))
     })
 
@@ -143,7 +143,7 @@ describe('sonarqubeService', () => {
       expect(client.createUserGroup).toHaveBeenCalledWith(expect.objectContaining({ name: `/${project.slug}/console/devops` }))
       expect(client.createUserGroup).toHaveBeenCalledWith(expect.objectContaining({ name: `/${project.slug}/console/developer` }))
       expect(client.createUserGroup).toHaveBeenCalledWith(expect.objectContaining({ name: `/${project.slug}/console/security` }))
-      expect(client.createUserGroup).toHaveBeenCalledWith(expect.objectContaining({ name: `/${project.slug}/console/readonly` }))
+      expect(client.createUserGroup).toHaveBeenCalledWith(expect.objectContaining({ name: `/${project.slug}/console/reader` }))
     })
 
     it('should create a new user and write vault credentials', async () => {
@@ -169,7 +169,7 @@ describe('sonarqubeService', () => {
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: `/${project.slug}/console/admin` }))
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: `/${project.slug}/console/devops` }))
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: `/${project.slug}/console/developer` }))
-      expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: '/console/readonly' }))
+      expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: '/console/reader' }))
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: '/console/security' }))
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: `/${project.slug}/console/developer`, permission: 'issueadmin' }))
       expect(client.addPermissionGroup).toHaveBeenCalledWith(expect.objectContaining({ groupName: `/${project.slug}/console/developer`, permission: 'securityhotspotadmin' }))

--- a/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
+++ b/apps/server-nestjs/src/modules/sonarqube/sonarqube.service.ts
@@ -23,9 +23,9 @@ import {
   DEFAULT_PROJECT_ADMIN_SUFFIX,
   DEFAULT_PROJECT_DEVELOPER_SUFFIX,
   DEFAULT_PROJECT_DEVOPS_SUFFIX,
-  DEFAULT_PROJECT_READONLY_SUFFIX,
+  DEFAULT_PROJECT_READER_SUFFIX,
   DEFAULT_PROJECT_SECURITY_SUFFIX,
-  DEFAULT_READONLY_GROUP_PATH,
+  DEFAULT_READER_GROUP_PATH,
   DEFAULT_SECURITY_GROUP_PATH,
   DEFAULT_TEMPLATE_PERMISSIONS,
   GLOBAL_ADMIN_PERMISSIONS,
@@ -36,11 +36,11 @@ import {
   PROJECT_DEVELOPER_SUFFIX_PLUGIN_KEY,
   PROJECT_DEVOPS_PERMISSIONS,
   PROJECT_DEVOPS_SUFFIX_PLUGIN_KEY,
-  PROJECT_READONLY_PERMISSIONS,
-  PROJECT_READONLY_SUFFIX_PLUGIN_KEY,
+  PROJECT_READER_PERMISSIONS,
+  PROJECT_READER_SUFFIX_PLUGIN_KEY,
   PROJECT_SECURITY_PERMISSIONS,
   PROJECT_SECURITY_SUFFIX_PLUGIN_KEY,
-  READONLY_GROUP_PATH_PLUGIN_KEY,
+  READER_GROUP_PATH_PLUGIN_KEY,
   ROBOT_PROJECT_PERMISSIONS,
   SECURITY_GROUP_PATH_PLUGIN_KEY,
 } from './sonarqube.constants'
@@ -50,7 +50,7 @@ interface SonarqubeRolePaths {
   devops: string[]
   developer: string[]
   security: string[]
-  readonly: string[]
+  reader: string[]
 }
 
 @Injectable()
@@ -75,14 +75,14 @@ export class SonarqubeService implements OnModuleInit {
   async init(): Promise<void> {
     this.logger.log('Initializing SonarQube platform configuration')
     const adminGroupPath = await this.getAdminGroupPath()
-    const [readonlyGroupPath, securityGroupPath] = await Promise.all([
-      this.getReadonlyGroupPath(),
+    const [readerGroupPath, securityGroupPath] = await Promise.all([
+      this.getReaderGroupPath(),
       this.getSecurityGroupPath(),
     ])
     await this.ensureDefaultPermissionTemplate()
     await Promise.all([
       this.ensureGroupWithGlobalPermissions(adminGroupPath, GLOBAL_ADMIN_PERMISSIONS),
-      this.ensureGroup(readonlyGroupPath),
+      this.ensureGroup(readerGroupPath),
       this.ensureGroup(securityGroupPath),
     ])
     this.logger.log('SonarQube platform configuration initialized')
@@ -248,7 +248,7 @@ export class SonarqubeService implements OnModuleInit {
       ...rolePaths.devops,
       ...rolePaths.developer,
       ...rolePaths.security,
-      ...rolePaths.readonly,
+      ...rolePaths.reader,
     ]
     await Promise.all(allGroups.map(group => this.ensureGroup(group)))
   }
@@ -259,8 +259,8 @@ export class SonarqubeService implements OnModuleInit {
     span?.setAttribute('project.slug', project.slug)
     span?.setAttribute('repositories.count', project.repositories.length)
 
-    const [readonlyGroupPath, securityGroupPath, existingSonarProjects, sonarSecret, gitlabGroup] = await Promise.all([
-      this.getReadonlyGroupPath(),
+    const [readerGroupPath, securityGroupPath, existingSonarProjects, sonarSecret, gitlabGroup] = await Promise.all([
+      this.getReaderGroupPath(),
       this.getSecurityGroupPath(),
       getAll(this.findProjectsForSlug(project.slug)),
       this.vault.readSonarqubeUser(project.slug),
@@ -299,7 +299,7 @@ export class SonarqubeService implements OnModuleInit {
           })
           this.logger.log(`Created SonarQube repository (key=${projectKey})`)
         }
-        await this.ensureProjectPermissions(projectKey, project.slug, rolePaths, readonlyGroupPath, securityGroupPath)
+        await this.ensureProjectPermissions(projectKey, project.slug, rolePaths, readerGroupPath, securityGroupPath)
         this.logger.verbose(`Ensured permissions on SonarQube repository (key=${projectKey})`)
         await this.ensureGitlabCiVariables(project, repository, projectKey, sonarSecret)
       }),
@@ -336,14 +336,14 @@ export class SonarqubeService implements OnModuleInit {
     projectKey: string,
     login: string,
     rolePaths: SonarqubeRolePaths,
-    readonlyGroupPath: string,
+    readerGroupPath: string,
     securityGroupPath: string,
   ): Promise<void> {
     await Promise.all([
       ...ROBOT_PROJECT_PERMISSIONS.map(permission =>
         this.client.addPermissionUser({ projectKey, permission, login }),
       ),
-      ...buildGroupPermissions(rolePaths, readonlyGroupPath, securityGroupPath).flatMap(({ groupName, permissions }) =>
+      ...buildGroupPermissions(rolePaths, readerGroupPath, securityGroupPath).flatMap(({ groupName, permissions }) =>
         permissions.map(permission => this.client.addPermissionGroup({ projectKey, permission, groupName })),
       ),
     ])
@@ -383,9 +383,9 @@ export class SonarqubeService implements OnModuleInit {
     return config ?? DEFAULT_ADMIN_GROUP_PATH
   }
 
-  private async getReadonlyGroupPath(): Promise<string> {
-    const config = await this.getAdminPluginConfig(READONLY_GROUP_PATH_PLUGIN_KEY)
-    return config ?? DEFAULT_READONLY_GROUP_PATH
+  private async getReaderGroupPath(): Promise<string> {
+    const config = await this.getAdminPluginConfig(READER_GROUP_PATH_PLUGIN_KEY)
+    return config ?? DEFAULT_READER_GROUP_PATH
   }
 
   private async getSecurityGroupPath(): Promise<string> {
@@ -400,14 +400,14 @@ export class SonarqubeService implements OnModuleInit {
   }
 
   private async getProjectRoleGroupPaths(project: ProjectWithDetails): Promise<SonarqubeRolePaths> {
-    const [admin, devops, developer, security, readonly] = await Promise.all([
+    const [admin, devops, developer, security, reader] = await Promise.all([
       this.getProjectAdminGroupPaths(project),
       this.getProjectDevopsGroupPaths(project),
       this.getProjectDeveloperGroupPaths(project),
       this.getProjectSecurityGroupPaths(project),
-      this.getProjectReadonlyGroupPaths(project),
+      this.getProjectReaderGroupPaths(project),
     ])
-    return { admin, devops, developer, security, readonly }
+    return { admin, devops, developer, security, reader }
   }
 
   private async getProjectAdminGroupPaths(project: ProjectWithDetails): Promise<string[]> {
@@ -438,10 +438,10 @@ export class SonarqubeService implements OnModuleInit {
     return generateProjectRoleGroupPath(project.slug, raw)
   }
 
-  private async getProjectReadonlyGroupPaths(project: ProjectWithDetails): Promise<string[]> {
-    const projectConfig = getProjectPluginConfig(project, PROJECT_READONLY_SUFFIX_PLUGIN_KEY)
-    const globalConfig = await this.getAdminOrProjectPluginConfig(project, PROJECT_READONLY_SUFFIX_PLUGIN_KEY)
-    const raw = projectConfig ?? globalConfig ?? DEFAULT_PROJECT_READONLY_SUFFIX
+  private async getProjectReaderGroupPaths(project: ProjectWithDetails): Promise<string[]> {
+    const projectConfig = getProjectPluginConfig(project, PROJECT_READER_SUFFIX_PLUGIN_KEY)
+    const globalConfig = await this.getAdminOrProjectPluginConfig(project, PROJECT_READER_SUFFIX_PLUGIN_KEY)
+    const raw = projectConfig ?? globalConfig ?? DEFAULT_PROJECT_READER_SUFFIX
     return generateProjectRoleGroupPath(project.slug, raw)
   }
 
@@ -473,7 +473,7 @@ function generateProjectRoleGroupPath(projectSlug: string, rawGroupPathSuffixes:
 
 function buildGroupPermissions(
   rolePaths: SonarqubeRolePaths,
-  readonlyGroupPath: string,
+  readerGroupPath: string,
   securityGroupPath: string,
 ): { groupName: string, permissions: readonly string[] }[] {
   return [
@@ -481,9 +481,9 @@ function buildGroupPermissions(
     ...rolePaths.devops.map(groupName => ({ groupName, permissions: PROJECT_DEVOPS_PERMISSIONS })),
     ...rolePaths.developer.map(groupName => ({ groupName, permissions: PROJECT_DEVELOPER_PERMISSIONS })),
     ...rolePaths.security.map(groupName => ({ groupName, permissions: PROJECT_SECURITY_PERMISSIONS })),
-    ...rolePaths.readonly.map(groupName => ({ groupName, permissions: PROJECT_READONLY_PERMISSIONS })),
+    ...rolePaths.reader.map(groupName => ({ groupName, permissions: PROJECT_READER_PERMISSIONS })),
     { groupName: securityGroupPath, permissions: PROJECT_SECURITY_PERMISSIONS },
-    { groupName: readonlyGroupPath, permissions: PROJECT_READONLY_PERMISSIONS },
+    { groupName: readerGroupPath, permissions: PROJECT_READER_PERMISSIONS },
   ]
 }
 

--- a/apps/server-nestjs/src/modules/vault/vault.constants.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.constants.ts
@@ -3,24 +3,24 @@ export const PLUGIN_NAME = 'vault'
 
 // Platform-level policy names for RBAC
 export const PLATFORM_ADMIN_POLICY_NAME = 'platform--admin'
-export const PLATFORM_READONLY_POLICY_NAME = 'platform--readonly'
+export const PLATFORM_READER_POLICY_NAME = 'platform--reader'
 export const PLATFORM_SECURITY_POLICY_NAME = 'platform--security'
 
 // Console group names for user role assignment
 export const CONSOLE_ADMIN_GROUP_NAME = 'console-admin'
-export const CONSOLE_READONLY_GROUP_NAME = 'console-readonly'
+export const CONSOLE_READER_GROUP_NAME = 'console-reader'
 export const CONSOLE_SECURITY_GROUP_NAME = 'console-security'
 
 // Default LDAP/AD group paths for console access
 export const DEFAULT_ADMIN_GROUP_PATH = '/console/admin'
-export const DEFAULT_AUDITOR_GROUP_PATH = '/console/readonly'
+export const DEFAULT_AUDITOR_GROUP_PATH = '/console/reader'
 export const DEFAULT_SECURITY_GROUP_PATH = '/console/security'
 
 // Default suffixes for project-scoped group paths
 export const DEFAULT_PROJECT_MAINTAINER_GROUP_PATH_SUFFIX = '/console/admin'
 export const DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX = '/console/developer'
 export const DEFAULT_PROJECT_DEVOPS_GROUP_PATH_SUFFIX = '/console/devops'
-export const DEFAULT_PROJECT_REPORTER_GROUP_PATH_SUFFIX = '/console/readonly'
+export const DEFAULT_PROJECT_REPORTER_GROUP_PATH_SUFFIX = '/console/reader'
 export const DEFAULT_PROJECT_SECURITY_GROUP_PATH_SUFFIX = '/console/security'
 
 // Plugin configuration keys for custom group paths

--- a/apps/server-nestjs/src/modules/vault/vault.service.spec.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.service.spec.ts
@@ -11,7 +11,7 @@ import { VaultDatastoreService } from './vault-datastore.service'
 import { makeProjectWithDetails, makeVaultSecret, makeZoneWithDetails } from './vault-testing.utils'
 import { VaultService } from './vault.service'
 
-const projectRoleGroupNameRegex = /^project-(.*)-(admin|devops|developer|readonly|security)$/
+const projectRoleGroupNameRegex = /^project-(.*)-(admin|devops|developer|reader|security)$/
 
 describe('vaultService', () => {
   let service: VaultService
@@ -92,7 +92,7 @@ describe('vaultService', () => {
       }
 
       if (groupName === 'console-admin') return { data: { id: 'gid', name: groupName, alias: { name: '/console/admin' } } }
-      if (groupName === 'console-readonly') return { data: { id: 'gid', name: groupName, alias: { name: '/console/readonly' } } }
+      if (groupName === 'console-reader') return { data: { id: 'gid', name: groupName, alias: { name: '/console/reader' } } }
       if (groupName === 'console-security') return { data: { id: 'gid', name: groupName, alias: { name: '/console/security' } } }
 
       return { data: { id: 'gid', name: groupName } }
@@ -105,25 +105,25 @@ describe('vaultService', () => {
     expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`tech--${project.slug}--ro`, expect.any(Object))
     expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--devops`, expect.any(Object))
     expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--developer`, expect.any(Object))
-    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--readonly`, expect.any(Object))
+    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--reader`, expect.any(Object))
     expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--security`, expect.any(Object))
     expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith('platform--admin', expect.any(Object))
-    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith('platform--readonly', expect.any(Object))
+    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith('platform--reader', expect.any(Object))
     expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith('platform--security', expect.any(Object))
     expect(client.upsertIdentityGroupName).toHaveBeenCalledWith('console-admin', expect.any(Object))
-    expect(client.upsertIdentityGroupName).toHaveBeenCalledWith('console-readonly', expect.any(Object))
+    expect(client.upsertIdentityGroupName).toHaveBeenCalledWith('console-reader', expect.any(Object))
     expect(client.upsertIdentityGroupName).toHaveBeenCalledWith('console-security', expect.any(Object))
     expect(client.upsertIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-admin`, expect.any(Object))
     expect(client.upsertIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-devops`, expect.any(Object))
     expect(client.upsertIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-developer`, expect.any(Object))
-    expect(client.upsertIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-readonly`, expect.any(Object))
+    expect(client.upsertIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-reader`, expect.any(Object))
     expect(client.upsertIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-security`, expect.any(Object))
     expect(client.createIdentityGroupAlias).not.toHaveBeenCalled()
 
     expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--developer`, {
       policy: `path "${project.slug}/data/*" { capabilities = ["list"] }`,
     })
-    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--readonly`, {
+    expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--reader`, {
       policy: `path "${project.slug}/data/*" { capabilities = ["list"] }`,
     })
     expect(client.upsertSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--security`, {
@@ -147,13 +147,13 @@ describe('vaultService', () => {
     expect(client.deleteSysPoliciesAcl).toHaveBeenCalledWith(`tech--${project.slug}--ro`)
     expect(client.deleteSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--devops`)
     expect(client.deleteSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--developer`)
-    expect(client.deleteSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--readonly`)
+    expect(client.deleteSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--reader`)
     expect(client.deleteSysPoliciesAcl).toHaveBeenCalledWith(`project--${project.slug}--security`)
     expect(client.deleteAuthApproleRole).toHaveBeenCalledWith(project.slug)
     expect(client.deleteIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-admin`)
     expect(client.deleteIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-devops`)
     expect(client.deleteIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-developer`)
-    expect(client.deleteIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-readonly`)
+    expect(client.deleteIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-reader`)
     expect(client.deleteIdentityGroupName).toHaveBeenCalledWith(`project-${project.slug}-security`)
   })
 })

--- a/apps/server-nestjs/src/modules/vault/vault.service.ts
+++ b/apps/server-nestjs/src/modules/vault/vault.service.ts
@@ -15,7 +15,7 @@ import {
   ADMIN_GROUP_PATH_PLUGIN_KEY,
   AUDITOR_GROUP_PATH_PLUGIN_KEY,
   CONSOLE_ADMIN_GROUP_NAME,
-  CONSOLE_READONLY_GROUP_NAME,
+  CONSOLE_READER_GROUP_NAME,
   CONSOLE_SECURITY_GROUP_NAME,
   DEFAULT_ADMIN_GROUP_PATH,
   DEFAULT_AUDITOR_GROUP_PATH,
@@ -26,7 +26,7 @@ import {
   DEFAULT_PROJECT_SECURITY_GROUP_PATH_SUFFIX,
   DEFAULT_SECURITY_GROUP_PATH,
   PLATFORM_ADMIN_POLICY_NAME,
-  PLATFORM_READONLY_POLICY_NAME,
+  PLATFORM_READER_POLICY_NAME,
   PLATFORM_SECURITY_POLICY_NAME,
   PLUGIN_NAME,
   PROJECT_DEVELOPER_GROUP_PATH_SUFFIX_PLUGIN_KEY,
@@ -38,7 +38,7 @@ import {
 } from './vault.constants'
 import { generateProjectPath, isVaultBadRequest, isVaultNotFound } from './vault.utils'
 
-type ProjectScope = 'admin' | 'devops' | 'developer' | 'readonly' | 'security'
+type ProjectScope = 'admin' | 'devops' | 'developer' | 'reader' | 'security'
 
 @Injectable()
 export class VaultService {
@@ -251,7 +251,7 @@ export class VaultService {
     const span = trace.getActiveSpan()
     span?.setAttribute('zone.name', zoneName)
     span?.setAttribute('vault.kv.name', kvName)
-    const policyName = generateZoneTechReadOnlyPolicyName(zoneName)
+    const policyName = generateZoneTechReaderPolicyName(zoneName)
 
     await this.upsertMount(kvName)
     await this.client.upsertSysPoliciesAcl(policyName, {
@@ -266,7 +266,7 @@ export class VaultService {
     const span = trace.getActiveSpan()
     span?.setAttribute('zone.name', zoneName)
     span?.setAttribute('vault.kv.name', kvName)
-    const policyName = generateZoneTechReadOnlyPolicyName(zoneName)
+    const policyName = generateZoneTechReaderPolicyName(zoneName)
     const roleName = kvName
 
     await this.deleteMount(kvName)
@@ -290,10 +290,10 @@ export class VaultService {
     span?.setAttribute('project.slug', project.slug)
     span?.setAttribute('vault.kv.name', project.slug)
     const appPolicyName = generateAppAdminPolicyName(project)
-    const techPolicyName = generateTechReadOnlyPolicyName(project)
+    const techPolicyName = generateTechReaderPolicyName(project)
     const projectDevopsPolicyName = generateProjectPolicyName(project, 'devops')
     const projectDeveloperPolicyName = generateProjectPolicyName(project, 'developer')
-    const projectReadOnlyPolicyName = generateProjectPolicyName(project, 'readonly')
+    const projectReaderPolicyName = generateProjectPolicyName(project, 'reader')
     const projectSecurityPolicyName = generateProjectPolicyName(project, 'security')
     await this.upsertMount(project.slug)
 
@@ -320,21 +320,21 @@ export class VaultService {
     const projectAdminGroupPaths = generateProjectRoleGroupPaths(project, maintainerGroupPathSuffix)
     const projectDevopsGroupPaths = generateProjectRoleGroupPaths(project, devopsGroupPathSuffix)
     const projectDeveloperGroupPaths = generateProjectRoleGroupPaths(project, developerGroupPathSuffix)
-    const projectReadOnlyGroupPaths = generateProjectRoleGroupPaths(project, reporterGroupPathSuffix)
+    const projectReaderGroupPaths = generateProjectRoleGroupPaths(project, reporterGroupPathSuffix)
     const projectSecurityGroupPaths = generateProjectRoleGroupPaths(project, securityGroupPathSuffix)
 
     await Promise.all([
       this.ensureAppAdminPolicy(appPolicyName, project.slug),
-      this.ensureTechReadOnlyPolicy(techPolicyName, project.slug),
+      this.ensureTechReaderPolicy(techPolicyName, project.slug),
       this.ensureProjectDevopsPolicy(projectDevopsPolicyName, project.slug),
-      this.ensureProjectReadOnlyPolicy(projectDeveloperPolicyName, project.slug),
-      this.ensureProjectReadOnlyPolicy(projectReadOnlyPolicyName, project.slug),
+      this.ensureProjectReaderPolicy(projectDeveloperPolicyName, project.slug),
+      this.ensureProjectReaderPolicy(projectReaderPolicyName, project.slug),
       this.createProjectSecurityPolicy(projectSecurityPolicyName, project.slug),
       this.ensurePlatformAdminPolicy(PLATFORM_ADMIN_POLICY_NAME),
-      this.ensurePlatformReadOnlyPolicy(PLATFORM_READONLY_POLICY_NAME),
+      this.ensurePlatformReaderPolicy(PLATFORM_READER_POLICY_NAME),
       this.ensurePlatformSecurityPolicy(PLATFORM_SECURITY_POLICY_NAME),
       this.ensureIdentityGroup(CONSOLE_ADMIN_GROUP_NAME, [PLATFORM_ADMIN_POLICY_NAME], adminGroupPath),
-      this.ensureIdentityGroup(CONSOLE_READONLY_GROUP_NAME, [PLATFORM_READONLY_POLICY_NAME], auditorGroupPath),
+      this.ensureIdentityGroup(CONSOLE_READER_GROUP_NAME, [PLATFORM_READER_POLICY_NAME], auditorGroupPath),
       this.ensureIdentityGroup(CONSOLE_SECURITY_GROUP_NAME, [PLATFORM_SECURITY_POLICY_NAME], securityGroupPath),
       ...projectAdminGroupPaths.map(groupPath =>
         this.ensureIdentityGroup(generateProjectGroupName(project, 'admin'), [appPolicyName], groupPath)),
@@ -342,8 +342,8 @@ export class VaultService {
         this.ensureIdentityGroup(generateProjectGroupName(project, 'devops'), [projectDevopsPolicyName], groupPath)),
       ...projectDeveloperGroupPaths.map(groupPath =>
         this.ensureIdentityGroup(generateProjectGroupName(project, 'developer'), [projectDeveloperPolicyName], groupPath)),
-      ...projectReadOnlyGroupPaths.map(groupPath =>
-        this.ensureIdentityGroup(generateProjectGroupName(project, 'readonly'), [projectReadOnlyPolicyName], groupPath)),
+      ...projectReaderGroupPaths.map(groupPath =>
+        this.ensureIdentityGroup(generateProjectGroupName(project, 'reader'), [projectReaderPolicyName], groupPath)),
       ...projectSecurityGroupPaths.map(groupPath =>
         this.ensureIdentityGroup(generateProjectGroupName(project, 'security'), [projectSecurityPolicyName], groupPath)),
       this.client.upsertAuthApproleRole(project.slug, generateApproleRoleBody([techPolicyName, appPolicyName])),
@@ -356,10 +356,10 @@ export class VaultService {
     span?.setAttribute('project.slug', project.slug)
     span?.setAttribute('vault.kv.name', project.slug)
     const appPolicyName = generateAppAdminPolicyName(project)
-    const techPolicyName = generateTechReadOnlyPolicyName(project)
+    const techPolicyName = generateTechReaderPolicyName(project)
     const projectDevopsPolicyName = generateProjectPolicyName(project, 'devops')
     const projectDeveloperPolicyName = generateProjectPolicyName(project, 'developer')
-    const projectReadOnlyPolicyName = generateProjectPolicyName(project, 'readonly')
+    const projectReaderPolicyName = generateProjectPolicyName(project, 'reader')
     const projectSecurityPolicyName = generateProjectPolicyName(project, 'security')
 
     await this.deleteMount(project.slug)
@@ -369,13 +369,13 @@ export class VaultService {
       this.client.deleteSysPoliciesAcl(techPolicyName),
       this.client.deleteSysPoliciesAcl(projectDevopsPolicyName),
       this.client.deleteSysPoliciesAcl(projectDeveloperPolicyName),
-      this.client.deleteSysPoliciesAcl(projectReadOnlyPolicyName),
+      this.client.deleteSysPoliciesAcl(projectReaderPolicyName),
       this.client.deleteSysPoliciesAcl(projectSecurityPolicyName),
       this.client.deleteAuthApproleRole(project.slug),
       this.client.deleteIdentityGroupName(generateProjectGroupName(project, 'admin')),
       this.client.deleteIdentityGroupName(generateProjectGroupName(project, 'devops')),
       this.client.deleteIdentityGroupName(generateProjectGroupName(project, 'developer')),
-      this.client.deleteIdentityGroupName(generateProjectGroupName(project, 'readonly')),
+      this.client.deleteIdentityGroupName(generateProjectGroupName(project, 'reader')),
       this.client.deleteIdentityGroupName(generateProjectGroupName(project, 'security')),
     ])
     for (const result of settled) {
@@ -446,7 +446,7 @@ export class VaultService {
     })
   }
 
-  async ensureProjectReadOnlyPolicy(name: string, projectSlug: string): Promise<void> {
+  async ensureProjectReaderPolicy(name: string, projectSlug: string): Promise<void> {
     await this.client.upsertSysPoliciesAcl(name, {
       policy: `path "${projectSlug}/data/*" { capabilities = ["list"] }`,
     })
@@ -467,7 +467,7 @@ export class VaultService {
     })
   }
 
-  async ensurePlatformReadOnlyPolicy(name: string): Promise<void> {
+  async ensurePlatformReaderPolicy(name: string): Promise<void> {
     await this.client.upsertSysPoliciesAcl(name, {
       policy: [
         `path "sys/health" { capabilities = ["read"] }`,
@@ -492,7 +492,7 @@ export class VaultService {
     })
   }
 
-  async ensureTechReadOnlyPolicy(name: string, projectSlug: string): Promise<void> {
+  async ensureTechReaderPolicy(name: string, projectSlug: string): Promise<void> {
     const robotSecretPath = generateProjectPath(this.baseConfig.projectsRootDir, `${projectSlug}/REGISTRY/ro-robot`)
     await this.client.upsertSysPoliciesAcl(name, {
       policy: `path "${this.vaultConfig.kvName}/data/${robotSecretPath}" { capabilities = ["read"] }`,
@@ -549,7 +549,7 @@ export class VaultService {
   }
 }
 
-function generateTechReadOnlyPolicyName(project: ProjectWithDetails) {
+function generateTechReaderPolicyName(project: ProjectWithDetails) {
   return `tech--${project.slug}--ro`
 }
 
@@ -577,7 +577,7 @@ function generateZoneName(name: string) {
   return `zone-${name}`
 }
 
-function generateZoneTechReadOnlyPolicyName(zoneName: string) {
+function generateZoneTechReaderPolicyName(zoneName: string) {
   return `tech--${generateZoneName(zoneName)}--ro`
 }
 

--- a/apps/server-nestjs/src/prisma/migrations/20260615100000_rename_role_readonly_to_reader/migration.sql
+++ b/apps/server-nestjs/src/prisma/migrations/20260615100000_rename_role_readonly_to_reader/migration.sql
@@ -1,0 +1,20 @@
+-- Rename the system-managed 'readonly'/'Lecture seule' role to 'reader'/'Lecteur' across AdminRole and ProjectRole
+
+-- Rename ProjectRole: 'Lecture seule' -> 'Lecteur', '/console/readonly' -> '/console/reader'
+UPDATE "ProjectRole"
+SET
+  "name" = 'Lecteur',
+  "oidcGroup" = REPLACE("oidcGroup", '/console/readonly', '/console/reader')
+WHERE "name" = 'Lecture seule' OR "oidcGroup" LIKE '%/console/readonly';
+
+-- Rename AdminRole: 'Lecture Seule Plateforme' -> 'Lecteur Plateforme', '/readonly' -> '/reader', '/console/readonly' -> '/console/reader'
+UPDATE "AdminRole"
+SET
+  "name" = 'Lecteur Plateforme',
+  "oidcGroup" = '/reader'
+WHERE "name" = 'Lecture Seule Plateforme' OR "oidcGroup" = '/readonly';
+
+-- Ensure any remaining '/console/readonly' paths are renamed to '/console/reader'
+UPDATE "AdminRole"
+SET "oidcGroup" = '/console/reader'
+WHERE "oidcGroup" = '/console/readonly';

--- a/apps/server/src/resources/project/queries.ts
+++ b/apps/server/src/resources/project/queries.ts
@@ -288,10 +288,10 @@ export function initializeProject(params: CreateProjectParams) {
             type: 'system:managed',
           },
           {
-            name: 'Lecture seule',
+            name: 'Lecture',
             permissions: PROJECT_PERMS.LIST_ENVIRONMENTS | PROJECT_PERMS.LIST_REPOSITORIES,
             position: 4,
-            oidcGroup: `/${params.slug}/console/readonly`,
+            oidcGroup: `/${params.slug}/console/reader`,
             type: 'system:managed',
           },
         ],

--- a/packages/shared/src/utils/permissions.ts
+++ b/packages/shared/src/utils/permissions.ts
@@ -239,8 +239,8 @@ export const adminPermsDetails: PermDetails<AdminPermsKeys> = [{
     hint: 'Administration globale de toute la console et de ses ressources',
   }, {
     key: 'LIST',
-    label: 'Lecture seule globale',
-    hint: 'Accès en lecture seule à toute la console et ses ressources',
+    label: 'Lecture globale',
+    hint: 'Accès en lecture à toute la console et ses ressources',
   }],
 }, {
   name: 'Gestion des utilisateurs',

--- a/plugins/argocd/src/functions.spec.ts
+++ b/plugins/argocd/src/functions.spec.ts
@@ -144,11 +144,11 @@ describe('argocd functions', () => {
         roGroup: '/ro',
         rwGroup: '/rw',
         platformAdminGroup: '/console/admin',
-        platformReadonlyGroup: '/console/readonly',
+        platformReaderGroup: '/console/reader',
         projectAdminGroup: `/${mockProject.slug}/console/admin`,
         projectDevopsGroup: `/${mockProject.slug}/console/devops`,
         projectDevelopperGroup: `/${mockProject.slug}/console/developer`,
-        projectReadonlyGroup: `/${mockProject.slug}/console/readonly`,
+        projectReaderGroup: `/${mockProject.slug}/console/reader`,
       },
       application: {
         quota: {

--- a/plugins/argocd/src/functions.ts
+++ b/plugins/argocd/src/functions.ts
@@ -14,11 +14,11 @@ import {
   DEFAULT_DSO_ENV_CHART_VERSION,
   DEFAULT_DSO_NS_CHART_VERSION,
   DEFAULT_PLATFORM_ADMIN_GROUP_PATH,
-  DEFAULT_PLATFORM_READONLY_GROUP_PATH,
+  DEFAULT_PLATFORM_READER_GROUP_PATH,
   DEFAULT_PROJECT_ADMIN_GROUP_PATH_SUFFIX,
   DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX,
   DEFAULT_PROJECT_DEVOPS_GROUP_PATH_SUFFIX,
-  DEFAULT_PROJECT_READONLY_GROUP_PATH_SUFFIX,
+  DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIX,
 } from './infos.js'
 import { logger } from './logger.js'
 import { generateAppProjectName, getConfig } from './utils.js'
@@ -124,11 +124,11 @@ async function ensureInfraEnvValues(
   config: Config,
 ) {
   const platformAdminGroupPath = config.argocd?.platformAdminGroupPath ?? DEFAULT_PLATFORM_ADMIN_GROUP_PATH
-  const platformReadonlyGroupPath = config.argocd?.platformReadonlyGroupPath ?? DEFAULT_PLATFORM_READONLY_GROUP_PATH
+  const platformReaderGroupPath = config.argocd?.platformReaderGroupPath ?? DEFAULT_PLATFORM_READER_GROUP_PATH
   const projectAdminGroupSuffix = config.argocd?.projectAdminGroupPathSuffix ?? DEFAULT_PROJECT_ADMIN_GROUP_PATH_SUFFIX
   const projectDevopsGroupSuffix = config.argocd?.projectDevopsGroupPathSuffix ?? DEFAULT_PROJECT_DEVOPS_GROUP_PATH_SUFFIX
   const projectDevelopperGroupSuffix = config.argocd?.projectDevelopperGroupPathSuffix ?? DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX
-  const projectReadonlyGroupSuffix = config.argocd?.projectReadonlyGroupPathSuffix ?? DEFAULT_PROJECT_READONLY_GROUP_PATH_SUFFIX
+  const projectReaderGroupSuffix = config.argocd?.projectReaderGroupPathSuffix ?? DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIX
   const cluster = getCluster(project, environment)
   const infraProject = await gitlabApi.getProjectById(repoId)
   const valueFilePath = getValueFilePath(project, cluster, environment)
@@ -176,11 +176,11 @@ async function ensureInfraEnvValues(
       roGroup,
       rwGroup,
       platformAdminGroup: platformAdminGroupPath,
-      platformReadonlyGroup: platformReadonlyGroupPath,
+      platformReaderGroup: platformReaderGroupPath,
       projectAdminGroup: `/${project.slug}${projectAdminGroupSuffix}`,
       projectDevopsGroup: `/${project.slug}${projectDevopsGroupSuffix}`,
       projectDevelopperGroup: `/${project.slug}${projectDevelopperGroupSuffix}`,
-      projectReadonlyGroup: `/${project.slug}${projectReadonlyGroupSuffix}`,
+      projectReaderGroup: `/${project.slug}${projectReaderGroupSuffix}`,
     },
     application: {
       quota: {

--- a/plugins/argocd/src/infos.ts
+++ b/plugins/argocd/src/infos.ts
@@ -3,11 +3,11 @@ import type { ServiceInfos } from '@cpn-console/hooks'
 const extraRepositoriesDesc = 'appproject.spec.sourceRepos supplémentaires, séparés par des virgules (https://a.com/repo.git,https://b.com/'
 
 export const DEFAULT_PLATFORM_ADMIN_GROUP_PATH = '/console/admin'
-export const DEFAULT_PLATFORM_READONLY_GROUP_PATH = '/console/readonly'
+export const DEFAULT_PLATFORM_READER_GROUP_PATH = '/console/reader'
 export const DEFAULT_PROJECT_ADMIN_GROUP_PATH_SUFFIX = '/console/admin'
 export const DEFAULT_PROJECT_DEVOPS_GROUP_PATH_SUFFIX = '/console/devops'
 export const DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX = '/console/developer'
-export const DEFAULT_PROJECT_READONLY_GROUP_PATH_SUFFIX = '/console/readonly'
+export const DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIX = '/console/reader'
 
 export const DEFAULT_DSO_ENV_CHART_VERSION = 'dso-env-1.6.0'
 export const DEFAULT_DSO_NS_CHART_VERSION = 'dso-ns-1.1.5'
@@ -44,15 +44,15 @@ const infos = {
       value: DEFAULT_PLATFORM_ADMIN_GROUP_PATH,
       description: 'Chemin du groupe administrateur de plateforme',
     }, {
-      key: 'platformReadonlyGroupPath',
+      key: 'platformReaderGroupPath',
       kind: 'text',
       permissions: {
         admin: { read: true, write: true },
         user: { read: false, write: false },
       },
-      title: 'Platform Readonly Group Path',
-      value: DEFAULT_PLATFORM_READONLY_GROUP_PATH,
-      description: 'Chemin du groupe lecture seule de plateforme',
+      title: 'Platform Reader Group Path',
+      value: DEFAULT_PLATFORM_READER_GROUP_PATH,
+      description: 'Chemin du groupe lecteur de plateforme',
     }, {
       key: 'projectAdminGroupPathSuffix',
       kind: 'text',
@@ -84,15 +84,15 @@ const infos = {
       value: DEFAULT_PROJECT_DEVELOPER_GROUP_PATH_SUFFIX,
       description: 'Suffixe du chemin du groupe développeur de projet',
     }, {
-      key: 'projectReadonlyGroupPathSuffix',
+      key: 'projectReaderGroupPathSuffix',
       kind: 'text',
       permissions: {
         admin: { read: true, write: true },
         user: { read: false, write: false },
       },
-      title: 'Project Readonly Group Path Suffix',
-      value: DEFAULT_PROJECT_READONLY_GROUP_PATH_SUFFIX,
-      description: 'Suffixe du chemin du groupe lecture seule de projet',
+      title: 'Project Reader Group Path Suffix',
+      value: DEFAULT_PROJECT_READER_GROUP_PATH_SUFFIX,
+      description: 'Suffixe du chemin du groupe lecteur de projet',
     }],
     project: [{
       key: 'extraRepositories',


### PR DESCRIPTION
## Issues liées

Aucune

## Quel est le comportement actuel ?

Les rôles de type `readonly` utilisent les chemins OIDC suivants :
- `/console/readonly` pour les rôles de projet
- `/readonly` pour les rôles admin de plateforme

Les constantes sont nommées `READONLY_*` et les libellés français utilisent
"lecture seule".

## Quel est le nouveau comportement ?

Les rôles sont renommés de `readonly` à `reader` :
- Les chemins OIDC passent de `/console/readonly` à `/console/reader` et de
  `/readonly` à `/reader`
- Les constantes `READONLY_*` deviennent `READER_*`
- Les libellés français passent de "lecture seule" à "lecteur"
- Le nom du rôle AdminRole `Lecture Seule Plateforme` devient `Lecteur Plateforme`
- Le nom du rôle ProjectRole `Lecture seule` devient `Lecture` (cohérent avec le
  serveur legacy)
- Une migration Prisma renomme les rôles existantes en base de données

**Fichiers modifiés (22) :**
- `apps/server-nestjs/` : constantes, services, specs, utils pour tous les
  modules (argocd, gitlab, nexus, registry, sonarqube, vault, project)
- `apps/server-nestjs/src/prisma/migrations/20260615100000_rename_role_readonly_to_reader/migration.sql` : migration DB
- `apps/server/src/resources/project/queries.ts` : cohérence serveur legacy
- `packages/shared/src/utils/permissions.ts` : libellés partagés
- `plugins/argocd/src/infos.ts` : plugin externe

## Cette PR introduit-elle un breaking change ?

**Oui** — Les chemins OIDC `/console/readonly` et `/readonly` sont renommés en
`/console/reader` et `/reader`. Les groupes Keycloak correspondants, les
politiques Vault, et les configurations de plugins externes (ArgoCD, Nexus,
SonarQube, Registry, GitLab) doivent être réconciliés. La migration Prisma
gère la mise à jour des rôles existants en base, mais les groupes externes
(Keycloak, Vault) seront synchronisés automatiquement par les jobs de
réconciliation des plugins.

**Procédure de migration :**
1. Appliquer la migration Prisma (`20260615100000_rename_role_readonly_to_reader`)
2. Relancer la réconciliation des plugins (cron) pour synchroniser les groupes
   OIDC externes avec les nouveaux chemins
3. Mettre à jour toute configuration personnalisée référençant `readonly` vers
   `reader`

## Autres informations

- 615 tests unitaires passent (vitest)
- ESLint clean
- La migration est idempotente (utilise `WHERE` sur les anciennes valeurs)