### PR TITLE
feat(server-nestjs): add Sécurité role to project system

### DIFF
--- a/apps/server-nestjs/src/modules/project/project.service.spec.ts
+++ b/apps/server-nestjs/src/modules/project/project.service.spec.ts
@@ -76,7 +76,7 @@ describe('projectService', () => {
       prisma.$transaction.mockImplementation(async cb => cb(tx))
 
       const pwd = makeProjectWithDetails({ slug: expectedSlug })
-      pwd.roles = Array.from({ length: 4 }, (_, index) => ({
+      pwd.roles = Array.from({ length: 5 }, (_, index) => ({
         id: faker.string.uuid(),
         name: `role-${index}`,
         permissions: 0n,
@@ -100,7 +100,7 @@ describe('projectService', () => {
         userId,
         requestId,
       })
-      expect(logs.addLog).toHaveBeenCalledTimes(4)
+      expect(logs.addLog).toHaveBeenCalledTimes(5)
       expect(result).toBeDefined()
       expect(result.slug).toBe(expectedSlug)
     })

--- a/apps/server-nestjs/src/modules/project/project.utils.ts
+++ b/apps/server-nestjs/src/modules/project/project.utils.ts
@@ -71,6 +71,15 @@ export function generateProjectCreateInput(
           oidcGroup: `/${slug}/console/readonly`,
           type: 'system:managed',
         },
+        {
+          name: 'Sécurité',
+          permissions: PROJECT_PERMS.SEE_SECRETS
+            | PROJECT_PERMS.LIST_ENVIRONMENTS
+            | PROJECT_PERMS.LIST_REPOSITORIES,
+          position: 4,
+          oidcGroup: `/${slug}/console/security`,
+          type: 'system:managed',
+        },
       ],
     },
   }


### PR DESCRIPTION
## Issues liées

#2676

---------

## Quel est le comportement actuel ?

Le système de rôles de projet n'a pas de rôle « Sécurité » dédié aux tâches de sécurité (audit, monitoring des secrets).
Les rôles existants sont :
- **Développeur** (position 2) : accès gestion des dépôts
- **Lecture seule** (position 3) : accès lecture seule

## Quel est le nouveau comportement ?

- Ajout d'un rôle **Sécurité** en dernière position (position 4) avec les permissions : `SEE_SECRETS | LIST_ENVIRONMENTS | LIST_REPOSITORIES`
- Mise à jour du groupe OIDC : `/${slug}/console/security`
- Les rôles existants ne bougent pas : Développeur reste en position 2, Lecture seule en position 3

Ce rôle permet aux équipes de sécurité d'accéder aux informations sensibles nécessaires à l'audit et au monitoring sans avoir accès aux opérations de développement.

## Cette PR introduit-elle un breaking change ?

Non. Cette PR est rétrocompatible, les rôles existants conservent leurs permissions et leurs positions.

## Autres informations

**Tests :** Les 61 tests du module projet (8 fichiers) passent.
**Migration :** Aucune migration requise pour les projets existants.
