### PR TITLE
fix(vault): avoid double slash in KV list path for Vault 2.0

### DIFF
--- a/plugins/vault/src/vault-project-api.ts
+++ b/plugins/vault/src/vault-project-api.ts
@@ -58,8 +58,9 @@ export class VaultProjectApi extends VaultApi {
     if (!path.startsWith('/')) path = `/${path}`
 
     const listSecretPath: string[] = []
+    const normalizedPath = path.endsWith('/') ? path : `${path}/`
     const response = await this.axios({
-      url: `/v1/${this.coreKvName}/metadata/${this.projectRootDir}/${this.basePath}${path}/`,
+      url: `/v1/${this.coreKvName}/metadata/${this.projectRootDir}/${this.basePath}${normalizedPath}`,
       headers: {
         'X-Vault-Token': await this.getToken(),
       },


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?

`VaultProjectApi.list()` ajoute systématiquement un `/` final à l'URL de requête vers Vault, même quand le `path` fourni en contient déjà un (cas de l'argument par défaut `/`, et des appels récursifs sur les sous-dossiers renvoyés par la réponse LIST de Vault). L'URL générée contient alors un `//`.

Vault 1.21 tolère ça silencieusement, mais Vault 2.0 impose la canonicalisation des paths et rejette toute requête contenant `//`, `/./` ou `/../`.

Cette méthode est utilisée par `archiveDsoProject` (`functions.ts`) pour lister puis détruire tous les secrets sous le chemin KV d'un projet lors de son archivage. Sans correctif, ce nettoyage échouerait silencieusement dès le passage de la plateforme à Vault 2.0.

## Quel est le nouveau comportement ?

Le path est normalisé avant construction de l'URL pour ne jamais produire qu'un seul slash final, que le `path` en ait déjà un ou non. Le comportement fonctionnel de `list()` est inchangé (mêmes résultats retournés), seule l'URL générée est corrigée.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Correctif préventif préparé en amont de la mise à niveau de la plateforme verhelm` 0.34.1 /`imageVersion: "2.0.4"`, cf. PR associée sur le repo
`socle`).
