### PR TITLE
fix(server-nestjs): backfill default system roles on roleless projects

### DIFF
--- a/apps/server-nestjs/src/prisma/migrations/20260907170000_backfill_project_roles/migration.sql
+++ b/apps/server-nestjs/src/prisma/migrations/20260907170000_backfill_project_roles/migration.sql
@@ -1,0 +1,26 @@
+-- Backfill the 4 default system roles on projects that have none.
+-- Mirrors generateProjectCreateInput (apps/server-nestjs/src/modules/project/project.utils.ts):
+--   Administrateur  = MANAGE                                                       = 2
+--   DevOps          = MANAGE_ENVIRONMENTS | MANAGE_REPOSITORIES | REPLAY_HOOKS
+--                     | SEE_SECRETS | LIST_ENVIRONMENTS | LIST_REPOSITORIES        = 984
+--   Développeur     = MANAGE_REPOSITORIES | LIST_ENVIRONMENTS | LIST_REPOSITORIES = 784
+--   Lecture seule   = LIST_ENVIRONMENTS | LIST_REPOSITORIES                       = 768
+INSERT INTO "ProjectRole" ("id", "name", "permissions", "position", "oidcGroup", "type", "projectId")
+SELECT
+  gen_random_uuid(),
+  r."name",
+  r."permissions",
+  r."position",
+  '/' || p."slug" || r."groupSuffix",
+  'system:managed',
+  p."id"
+FROM "Project" p
+CROSS JOIN (VALUES
+  ('Administrateur', 2::bigint, 0, '/console/admin'),
+  ('DevOps', 984::bigint, 1, '/console/devops'),
+  ('Développeur', 784::bigint, 2, '/console/developer'),
+  ('Lecture seule', 768::bigint, 3, '/console/readonly')
+) AS r("name", "permissions", "position", "groupSuffix")
+WHERE NOT EXISTS (
+  SELECT 1 FROM "ProjectRole" existing WHERE existing."projectId" = p."id"
+);


### PR DESCRIPTION
## Issues liées

Refs #2684

## Quel est le comportement actuel ?

Les projets créés avant l'introduction de `generateProjectCreateInput` (`apps/server-nestjs/src/modules/project/project.utils.ts`) n'ont aucune ligne dans `ProjectRole` : leurs membres n'ont aucune permission et les groupes OIDC Keycloak correspondants sont absents.

## Quel est le nouveau comportement ?


Les projets disposant déjà d'au moins un rôle ne sont pas touchés ; la migration est idempotente (`WHERE NOT EXISTS`).

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Validée sur PostgreSQL 16 jetable : un projet sans rôle reçoit exactement 4 rôles (permissions, positions et oidcGroup conformes), un projet avec rôles reste inchangé, une seconde exécution insère 0 ligne (`INSERT 0 0`).

Refs #2684
