### PR TITLE
fix(ci): fall back to ghcr.io when the registry cache is unavailable

### DIFF
--- a/.github/workflows/job-playwright.yml
+++ b/.github/workflows/job-playwright.yml
@@ -46,8 +46,13 @@ jobs:
         run: |
           ./ci/scripts/init-env.sh
           for img in server nginx-strangler server-nestjs client opencds-mockoon; do
-            docker pull "${GHCR_CACHE}/cloud-pi-native/console/${img}:${{ inputs.TAG }}"
-            docker tag  "${GHCR_CACHE}/cloud-pi-native/console/${img}:${{ inputs.TAG }}" "dso-console/${img}:ci"
+            source="${GHCR_CACHE}/cloud-pi-native/console/${img}:${{ inputs.TAG }}"
+            if ! docker pull "${source}"; then
+              echo "::warning::registry cache ${GHCR_CACHE} unavailable for ${img}, falling back to ghcr.io"
+              source="ghcr.io/cloud-pi-native/console/${img}:${{ inputs.TAG }}"
+              docker pull "${source}"
+            fi
+            docker tag "${source}" "dso-console/${img}:ci"
           done
           docker compose -f ./docker/docker-compose.ci.yml up --no-build -d --remove-orphans
 


### PR DESCRIPTION
## Issues liées

#2694

---------

## Quel est le comportement actuel ?

L'étape `Initialize application environment for tests` du workflow Playwright tire les 5 images applicatives exclusivement depuis le registre de cache interne `registry-cache-ghcr:5000`.
Depuis le 2026-09-07, ce cache répond `500 Internal Server Error` au transfert des blobs : chaque run `Merge Queue` échoue sur les 4 shards, alors que la CI de branche reste verte et que `ghcr.io` sert les mêmes tags anonymement.

## Quel est le nouveau comportement ?

Chaque image est d'abord tirée depuis le cache ; en cas d'échec, un avertissement `::warning::` est émis et le pull est retenté directement sur `ghcr.io`, avant l'étiquetage `dso-console/<img>:ci` inchangé.
La file de merge se rétablit donc seule pendant que le cache est indisponible, et l'annotation rend chaque bascule visible dans les logs du job.
Le coût nominal est nul : en régime établi le cache répond et le comportement reste identique.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Le correctif est un containment côté workflow ; le rétablissement du service `registry-cache-ghcr` (pod + stockage) reste à instruire par les owners plateforme `githubrunners`, voir le commentaire d'analyse sur #2694.
