### PR TITLE
fix(deployment): send value source paths to ArgoCD without <env> substitution

### DIFF
--- a/apps/client/src/components/DeploymentValueSourceOption.vue
+++ b/apps/client/src/components/DeploymentValueSourceOption.vue
@@ -136,8 +136,8 @@ function update(patch: ValueSourcePatch): void {
       :model-value="model.path"
       label="Chemin du fichier de valeurs"
       label-visible
-      :placeholder="model.type === 'external' ? 'values-&lt;env&gt;.yaml' : 'values.yaml'"
-      hint="Chemin du fichier relatif à la racine du dépôt. Le motif <env> est remplacé par le nom de l'environnement."
+      placeholder="values.yaml"
+      hint="Chemin du fichier relatif à la racine du dépôt."
       required
       :disabled="props.disabled"
       :error-message="props.isDirty && !model.path ? 'Le chemin du fichier est requis' : undefined"

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.spec.ts
@@ -763,4 +763,58 @@ describe('argoCDService', () => {
       },
     ])
   })
+
+  it('should keep deployment source value file paths literal', async () => {
+    const mockDevEnv = makeProjectEnvironment({
+      name: 'dev',
+      cluster: {
+        id: 'c1',
+        label: 'cluster-1',
+        zone: { slug: 'zone-1' },
+      },
+    })
+    const mockAppRepo = makeProjectRepository({ internalRepoName: 'app-repo' })
+    const mockProject = makeProjectWithDetails({
+      name: 'Project 1',
+      slug: 'project-1',
+      environments: [mockDevEnv],
+      repositories: [mockAppRepo],
+      plugins: [],
+      deployments: [
+        makeProjectDeployment({
+          environment: mockDevEnv,
+          deploymentSources: [
+            makeProjectDeploymentSource({
+              repository: mockAppRepo,
+              targetRevision: 'dev',
+              helmValuesFiles: 'values-<env>.yaml',
+            }),
+          ],
+        }),
+      ],
+    })
+
+    const infraProject = makeProjectSchema({ id: 100, http_url_to_repo: 'https://gitlab.internal/infra' })
+    datastore.getAllProjects.mockResolvedValue([mockProject])
+    gitlab.getOrCreateInfraGroupRepo.mockResolvedValue(infraProject)
+    gitlab.getOrCreateProjectGroupPublicUrl.mockResolvedValue('https://gitlab.internal/group')
+    gitlab.getOrCreateInfraGroupRepoPublicUrl.mockResolvedValue('https://gitlab.internal/infra-repo')
+    gitlab.listFiles.mockResolvedValue([])
+    vault.getAuthApproleRoleRoleId.mockResolvedValue('role-id')
+    vault.createAuthApproleRoleSecretId.mockResolvedValue('secret-id')
+    gitlab.generateCreateOrUpdateAction.mockImplementation(async (_repoId, _ref, filePath: string, content: string) => {
+      return makeCommitAction({ filePath, content })
+    })
+
+    await expect(service.handleCron()).resolves.not.toThrow()
+
+    const actions = gitlab.maybeCreateCommit.mock.calls[0][2]
+    const parsedValues = actions
+      .filter((action): action is typeof action & { content: string } => 'content' in action)
+      .map(action => parse(action.content))
+    const values = parsedValues.find(v => v.application?.repositories?.[0]?.valueFiles?.length)
+    expect(values).toBeDefined()
+
+    expect(values.application.repositories[0].valueFiles).toStrictEqual(['values-<env>.yaml'])
+  })
 })

--- a/apps/server-nestjs/src/modules/argocd/argocd.service.ts
+++ b/apps/server-nestjs/src/modules/argocd/argocd.service.ts
@@ -565,12 +565,11 @@ function formatDeploymentSourceValueSources(
 function formatRepositoriesValuesFromDeployments(
   deployments: ProjectWithDetails['deployments'][number][],
   gitlabPublicProjectUrl: string,
-  envName: string,
 ) {
   return deployments.flatMap(deployment =>
     deployment.deploymentSources
       .map((source) => {
-        const valueFiles = splitExtraRepositories(source.helmValuesFiles?.replaceAll('<env>', envName))
+        const valueFiles = splitExtraRepositories(source.helmValuesFiles)
         const valueSources = formatDeploymentSourceValueSources(source, gitlabPublicProjectUrl)
         return {
           name: source.repository.internalRepoName,
@@ -718,7 +717,7 @@ function formatValues({
       autosync: environment.autosync,
       vault: vaultValues,
       repositories: deployments
-        ? formatRepositoriesValuesFromDeployments(deployments, gitlabPublicProjectUrl, environment.name)
+        ? formatRepositoriesValuesFromDeployments(deployments, gitlabPublicProjectUrl)
         : formatRepositoriesValues(
             project.repositories,
             gitlabPublicProjectUrl,

--- a/apps/server-nestjs/src/modules/deployment/deployment.service.spec.ts
+++ b/apps/server-nestjs/src/modules/deployment/deployment.service.spec.ts
@@ -135,7 +135,7 @@ describe('deploymentService', () => {
             ...validCreateDeployment.deploymentSources[0],
             valueSources: [
               { type: 'internal' as const, path: 'values.yaml' },
-              { type: 'external' as const, ref: 'infra-values', path: 'values-<env>.yaml', targetRevision: 'main', repositoryId: valueRepositoryId },
+              { type: 'external' as const, ref: 'infra-values', path: 'values-prod.yaml', targetRevision: 'main', repositoryId: valueRepositoryId },
             ],
           },
         ],
@@ -159,7 +159,7 @@ describe('deploymentService', () => {
                 externalValueSource: {
                   create: {
                     order: 1,
-                    path: 'values-<env>.yaml',
+                    path: 'values-prod.yaml',
                     ref: 'infra-values',
                     targetRevision: 'main',
                     repository: { connect: { id: valueRepositoryId } },


### PR DESCRIPTION
## Issues liées

Issues numéro: #2683

---------

## Quel est le comportement actuel ?

Le motif `<env>` d'un chemin de values de déploiement est remplacé par le nom de l'environnement à la génération des sources ArgoCD.

## Quel est le nouveau comportement ?

Le chemin part tel quel vers ArgoCD. Le placeholder et le hint du formulaire ne mentionnent plus le motif.

Les nouveaux objets déploiement ne supportent pas la substitution `<env>`, ni maintenant ni plus tard. Chaque source de values doit pointer vers un chemin littéral.

Le formulaire de dépôt (`helmValuesFiles` des dépôts d'infra) garde la substitution pour l'existant.

## Cette PR introduit-elle un breaking change ?

Oui pour les sources de values de déploiement qui utilisaient `<env>` : le chemin doit être écrit en littéral.

## Autres informations

Nouveau test dans `argocd.service.spec.ts` vérifiant que `<env>` arrive intact dans `valueFiles`.
