### PR TITLE
feat(server-nestjs): backfill Sécurité project role on existing projects

### DIFF
--- a/apps/server-nestjs/src/prisma/migrations/20260908155700_add_security_role/migration.sql
+++ b/apps/server-nestjs/src/prisma/migrations/20260908155700_add_security_role/migration.sql
@@ -1,0 +1,24 @@
+-- Backfill the project system role 'Sécurité' on existing projects.
+-- Mirrors the TS seeding in project.utils.ts (generateProjectCreateInput):
+--   permissions 832 = SEE_SECRETS(64) | LIST_ENVIRONMENTS(256) | LIST_REPOSITORIES(512)
+--   position 4 (after Lecture seule), oidcGroup = '/<project.slug>/console/security'
+-- Anti-join on slug+position makes the INSERT idempotent: a retry after a
+-- partial failure, or a project that already has the role, is a no-op.
+
+INSERT INTO "ProjectRole" ("id", "name", "permissions", "projectId", "position", "oidcGroup", "type")
+SELECT
+  gen_random_uuid(),
+  'Sécurité',
+  832, -- SEE_SECRETS(64) | LIST_ENVIRONMENTS(256) | LIST_REPOSITORIES(512)
+  p."id",
+  4,
+  '/' || p."slug" || '/console/security',
+  'system:managed'
+FROM "Project" p
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "ProjectRole" r
+  WHERE r."projectId" = p."id"
+    AND r."position" = 4
+    AND r."oidcGroup" = '/' || p."slug" || '/console/security'
+);


### PR DESCRIPTION
## Issues liées

Issues numéro:

#2676

---------

## Quel est le comportement actuel ?

Le rôle « Sécurité » n'est créé que pour les nouveaux projets lors de leur création : les projets existants n'en disposent pas.

## Quel est le nouveau comportement ?

Ajout d'une migration insérant le rôle « Sécurité » (type `system:managed`, position 4, permissions 832 = SEE_SECRETS | LIST_ENVIRONMENTS | LIST_REPOSITORIES, groupe OIDC `/<slug>/console/security`) pour chaque projet qui ne l'a pas encore, en miroir du seeding TS de `generateProjectCreateInput`.
L'insertion est idempotente (anti-jointure sur slug + oidcGroup + position) : les rôles personnalisés existants en position 4 sont préservés, aucune ligne dupliquée.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Migration validée sur PostgreSQL 16 : backfill d'un projet sans rôles, préservation d'un rôle personnalisé en position 4, absence de doublon quand le rôle existe déjà, ré-exécution sans effet.
