### PR TITLE
fix: OpenCDS should have been enabled though plugin service not from main

### DIFF
--- a/apps/server-nestjs/src/main.module.ts
+++ b/apps/server-nestjs/src/main.module.ts
@@ -20,7 +20,6 @@ import { ProjectServicesModule } from './modules/project-services/project-servic
 import { ProjectModule } from './modules/project/project.module'
 import { RepositoryModule } from './modules/repository/repository.module'
 import { SystemConfigModule } from './modules/system-config/system-config.module'
-import { ServiceChainModule } from './modules/service-chain/service-chain.module'
 import { SystemSettingsModule } from './modules/system-settings/system-settings.module'
 import { VersionModule } from './modules/version/version.module'
 import { getDotenvPaths } from './utils/dotenv.utils'
@@ -50,7 +49,6 @@ import { getDotenvPaths } from './utils/dotenv.utils'
     RepositoryModule,
     ScheduleModule.forRoot(),
     SystemConfigModule,
-    ServiceChainModule,
     SystemSettingsModule,
     VersionModule,
   ],


### PR DESCRIPTION
## Issues liées

#2702

---------

## Quel est le comportement actuel ?

`ServiceChainModule` est importé et activé directement dans `MainModule` (`apps/server-nestjs/src/main.module.ts`) : le module des chaînes de services OpenCDS est chargé par le serveur NestJS indépendamment du plugin OpenCDS.

## Quel est le nouveau comportement ?

`ServiceChainModule` n'est plus activé depuis `MainModule` : l'activation des chaînes de services OpenCDS relève du plugin via le service de plugins.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Correctif limité à la suppression de l'import de `ServiceChainModule` dans `apps/server-nestjs/src/main.module.ts` (2 lignes).
