### PR TITLE
fix(server-nestjs): make the gitlab mirror rotation test deterministic

### DIFF
--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
@@ -589,7 +589,10 @@ describe('gitlabService', () => {
       const staleSecret = makeVaultSecret({
         data: { MIRROR_USER: accessToken.name, MIRROR_TOKEN: accessToken.token },
         metadata: {
-          created_time: faker.date.past({ years: 2 }).toISOString(),
+          // faker.date.past() alone can draw inside the 250-day rotation
+          // threshold and silently skip the rotation branch; a birthdate draw
+          // aged 1–2 years always lands past it.
+          created_time: faker.date.birthdate({ min: 1, max: 2, mode: 'age' }).toISOString(),
           custom_metadata: null,
           deletion_time: '',
           destroyed: false,


### PR DESCRIPTION
## Issues liées

#2706   (fermer délibérément après la fusion)

---------

## Quel est le comportement actuel ?

Le test `gitlabService > handleUpsert > proactively rotates the mirror token when the vault secret is older than the rotation threshold` est instable : `faker.date.past({ years: 2 })` tire uniformément dans [0 ; 730] jours et, avec le seuil de rotation par défaut de 250 jours, environ un tirage sur trois tombe sous le seuil. La branche de rotation ne se déclenche pas, `revokeProjectToken` reçoit zéro appel et l'assertion échoue — d'où les échecs intermittents du job unit-tests observés sur plusieurs PR.

## Quel est le nouveau comportement ?

L'âge du secret est tiré avec `faker.date.birthdate({ min: 1, max: 2, mode: 'age' })` : la valeur reste entièrement aléatoire et relative à maintenant, mais le tirage tombe toujours entre un et deux ans dans le passé, au-delà du seuil de rotation — la branche de rotation s'exécute de manière déterministe.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Validation : 9 exécutions consécutives du spec (24 tests) passent sur les variantes successives du correctif ; suite complète `apps/server-nestjs` verte (661 passed, 69 skipped) ; eslint vert sur le fichier.
