### PR TITLE
docs: record recurring agent rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,8 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - Strict type safety: no `as` casts (including `as any`), no `any`, and no
   unchecked escapes of `unknown` — anything that breaks the type-checking
   chain. Narrow with `if` type guards (include the offending identifier in the
-  error message); validate external data at the boundary instead of casting it.
+  error message). Parse, don't validate: parse external data at the input
+  boundary into precise types, so nothing downstream re-checks.
 - Helpers return new objects; do not mutate inputs.
 
 ## Main commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ pnpm monorepo. Node >= 26, pnpm v11.8
 ## Server architecture (Fastify)
 
 Resource-based organization in `apps/server/src/resources/`. Each resource follows a 3-file pattern:
+
 - `router.ts` : route handlers (auth, permissions, delegates to business)
 - `business.ts` : business logic, orchestrates queries + hook calls
 - `queries.ts` : Prisma database queries
@@ -74,6 +75,10 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - Stylelint for CSS/Vue in client
 - Husky hooks: pre-commit (lint-staged), commit-msg (commitlint), pre-push (unit tests)
 - Conventional commits enforced: `feat`, `fix`, `chore`, `docs`, `refactor`, `revert`, `build`
+- Fix at the shared source all callers route through, not a guard duplicated in
+  every caller.
+- Before reporting done, format: `pnpm format`, then run the gates — `pnpm lint`
+  plus the targeted vitest specs.
 
 ## TypeScript
 
@@ -100,8 +105,3 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - Branches: `main` (protected) + `hotfix/*`
 - Release Please for automated versioning, changelogs, npm publish, Docker images, Helm chart updates
 - PR template: `.github/PULL_REQUEST_TEMPLATE.md`
-
-- Fix at the shared source all callers route through, not a guard duplicated in
-  every caller.
-- Before reporting done, format: `pnpm format`, then run the gates — `pnpm lint`
-  plus the targeted vitest specs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,10 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - Strict type safety: no `as` casts (including `as any`), no `any`, and no
   unchecked escapes of `unknown` — anything that breaks the type-checking
   chain. Narrow with `if` type guards (include the offending identifier in the
-  error message). Parse, don't validate: parse external data at the input
-  boundary into precise types, so nothing downstream re-checks.
+  error message). Parse, don't validate: at the input boundary, turn external
+  data into the most precise type it allows — the returned type is the proof —
+  so nothing downstream re-checks; a check-and-throw that returns nothing
+  preserves nothing.
 - Helpers return new objects; do not mutate inputs.
 
 ## Main commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,5 +104,5 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - `ci/scripts/init-env.sh` copies `*-example` to active equivalents (non-destructive)
 - Fix at the shared source all callers route through, not a guard duplicated in
   every caller.
-- Never report done without running the gates: `pnpm lint` plus the targeted
-  vitest specs.
+- Before reporting done, format: `pnpm format`, then run the gates — `pnpm lint`
+  plus the targeted vitest specs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - Commands: `pnpm test` (all unit), `pnpm playwright:test`
 - Deterministic tests: a faker draw must never be able to cross a branch
   threshold (pin the draw window), otherwise CI flakes.
-- server-nestjs unit specs use `mockDeep` for Prisma/config and no
-  describe-scope calls.
+- Tests: always prefer `mockDeep` for mocks (type safety over plain
+  `vi.fn()`/hand-rolled mocks); no describe-scope calls.
 
 ## Code quality
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Resource-based organization in `apps/server/src/resources/`. Each resource follo
 API contracts defined in `@cpn-console/shared`, shared with client via @ts-rest.
 Auth: Keycloak + Fastify session. Permissions: BigInt bitmasks (`ProjectAuthorized`, `AdminAuthorized`).
 
-Services receive configuration via injection
+server-nestjs services receive configuration via injection
 (`@Inject(xxxConfigFactory.KEY)` + `ConfigType<typeof xxxConfigFactory>`),
 never `process.env`.
 
@@ -53,9 +53,10 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 ## Environment config
 
 - Files: `.env`, `.env.docker`, `.env.integ` in `apps/client/`, `apps/server/`, `apps/server-nestjs/`
-- Templates: `*-example` suffix (git-tracked), active files gitignored
+- Templates: `*-example` suffix (not `.example`; git-tracked), active files gitignored
 - Override chain (weakest to strongest): `.env` < `.env.docker` (if DOCKER=true) < `.env.integ` (if INTEGRATION=true) < explicit env vars
 - Server loading: `apps/server/src/utils/env.ts` | Client: `apps/client/vite.config.ts`
+- `ci/scripts/init-env.sh` copies `*-example` to active equivalents (non-destructive)
 
 ## Testing
 
@@ -64,7 +65,7 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - Commands: `pnpm test` (all unit), `pnpm playwright:test`
 - Deterministic tests: a faker draw must never be able to cross a branch
   threshold (pin the draw window), otherwise CI flakes.
-- Tests: always prefer `mockDeep` for mocks (type safety over plain
+- Always prefer `mockDeep` for mocks (type safety over plain
   `vi.fn()`/hand-rolled mocks); no describe-scope calls.
 
 ## Code quality
@@ -100,10 +101,6 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - Release Please for automated versioning, changelogs, npm publish, Docker images, Helm chart updates
 - PR template: `.github/PULL_REQUEST_TEMPLATE.md`
 
-## Conventions
-
-- Template env files use `-example` suffix (not `.example`)
-- `ci/scripts/init-env.sh` copies `*-example` to active equivalents (non-destructive)
 - Fix at the shared source all callers route through, not a guard duplicated in
   every caller.
 - Before reporting done, format: `pnpm format`, then run the gates — `pnpm lint`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,10 @@ always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cas
 - Server: extends shared base, uses `ts-patch`/`tspc` for path transform in emitted JS
 - Client: does NOT extend shared base, uses `Bundler` module resolution
 - server-nestjs: standalone config with `emitDecoratorMetadata` + `experimentalDecorators`
-- No `as` casts (including `as any`) to narrow an unknown or optional value —
-  use `if` type guards; include the offending identifier in the error message.
+- Strict type safety: no `as` casts (including `as any`), no `any`, and no
+  unchecked escapes of `unknown` — anything that breaks the type-checking
+  chain. Narrow with `if` type guards (include the offending identifier in the
+  error message); validate external data at the boundary instead of casting it.
 - Helpers return new objects; do not mutate inputs.
 
 ## Main commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@ pnpm monorepo. Node >= 26, pnpm v11.8
 
 - `apps/client` : Vue 3 + Vite + vue-dsfr (French gov design system), Pinia, UnoCSS
 - `apps/server` : Fastify 4 + Prisma 6 (PostgreSQL), contract-first API via @ts-rest
-- `apps/server-nestjs` : NestJS rewrite (in progress)
+- `apps/server-nestjs` : NestJS rewrite (in progress) — the only modifiable
+  backend target; `apps/server` is frozen (read-only reference)
 - `plugins/*` : argocd, gitlab, harbor, keycloak, kubernetes, nexus, sonarqube, vault
 - `packages/shared` : API contracts (@ts-rest), types, permissions (BigInt bitmasks)
 - `packages/hooks` : plugin hook system (core of plugin architecture)
@@ -26,6 +27,10 @@ Resource-based organization in `apps/server/src/resources/`. Each resource follo
 API contracts defined in `@cpn-console/shared`, shared with client via @ts-rest.
 Auth: Keycloak + Fastify session. Permissions: BigInt bitmasks (`ProjectAuthorized`, `AdminAuthorized`).
 
+Services receive configuration via injection
+(`@Inject(xxxConfigFactory.KEY)` + `ConfigType<typeof xxxConfigFactory>`),
+never `process.env`.
+
 ## Plugin / Hook system
 
 Hook lifecycle: `pre` -> `main` -> `post` (sequential steps, parallel plugin execution). On failure: `revert`.
@@ -33,10 +38,17 @@ Plugins are statically imported in `apps/server/src/plugins.ts`, then external p
 Each plugin: `index.ts` (Plugin interface), `infos.ts` (metadata/config), `functions.ts` (hook handlers).
 Plugins use TS module augmentation to extend `ProjectStore` and `Config` interfaces.
 
+server-nestjs parity: every `eventEmitter.emitAsync('<entity>.<verb>')` must
+have a matching `@OnEvent` consumer bridging to `capturePluginResult`, or
+Keycloak/GitLab group syncs silently stop at cutover.
+
 ## Database (Prisma)
 
 Multi-file schema in `apps/server/src/prisma/schema/*.prisma` (project, user, token, admin, topography).
 Migrations: standard Prisma Migrate. Major version data migrations in `migrations/v9/`.
+
+`deleteMany`/`updateMany` with an `undefined` filter value matches ALL rows —
+always filter by concrete id. `ProjectRole`/`Repository` foreign keys do not cascade.
 
 ## Environment config
 
@@ -50,6 +62,10 @@ Migrations: standard Prisma Migrate. Major version data migrations in `migration
 - **Vitest**: unit tests everywhere (server, client, packages, plugins) — colocated `*.spec.ts` files
 - **Playwright**: E2E in `playwright/` (Chromium + Firefox, parallel)
 - Commands: `pnpm test` (all unit), `pnpm playwright:test`
+- Deterministic tests: a faker draw must never be able to cross a branch
+  threshold (pin the draw window), otherwise CI flakes.
+- server-nestjs unit specs use `mockDeep` for Prisma/config and no
+  describe-scope calls.
 
 ## Code quality
 
@@ -64,6 +80,9 @@ Migrations: standard Prisma Migrate. Major version data migrations in `migration
 - Server: extends shared base, uses `ts-patch`/`tspc` for path transform in emitted JS
 - Client: does NOT extend shared base, uses `Bundler` module resolution
 - server-nestjs: standalone config with `emitDecoratorMetadata` + `experimentalDecorators`
+- No `as` casts (including `as any`) to narrow an unknown or optional value —
+  use `if` type guards; include the offending identifier in the error message.
+- Helpers return new objects; do not mutate inputs.
 
 ## Main commands
 
@@ -83,3 +102,7 @@ Migrations: standard Prisma Migrate. Major version data migrations in `migration
 
 - Template env files use `-example` suffix (not `.example`)
 - `ci/scripts/init-env.sh` copies `*-example` to active equivalents (non-destructive)
+- Fix at the shared source all callers route through, not a guard duplicated in
+  every caller.
+- Never report done without running the gates: `pnpm lint` plus the targeted
+  vitest specs.


### PR DESCRIPTION
## Issues liées

#2708   (fermer délibérément après la fusion)

---------

## Quel est le comportement actuel ?

`AGENTS.md` décrit la structure, l'architecture et les commandes, mais les règles que les agents doivent appliquer (casts interdits, injection de configuration, gel d'`apps/server`, parité de migration, filtres Prisma, tests déterministes, gates) ne sont consignées nulle part : chaque session d'agent les réapprend — ou les viole avant correction.

## Quel est le nouveau comportement ?

Les règles sont distillées dans les sections existantes d'`AGENTS.md`, chacune dans la section qui possède déjà son sujet — aucune section dédiée : gel d'`apps/server` dans Structure, injection de configuration dans Server architecture, parité `emitAsync`/`@OnEvent` → `capturePluginResult` dans Plugin/Hook system, filtres Prisma et FK non-cascades dans Database, tirages faker déterministes + `mockDeep` dans Testing, interdiction des casts `as` (type guard `if` avec l'identifiant fautif) et absence de mutation d'entrées dans TypeScript, correction à la source partagée et gates avant « terminé » dans Conventions.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Documentation seule : un seul fichier `.md`, aucun code ni dépendance. La liste des règles a été consolidée depuis les corrections réellement reçues lors des revues et des runs CI, consolidées dans l'issue.
