### PR TITLE
fix: normalize Cluster label to lowercase

### DIFF
--- a/packages/shared/src/schemas/cluster.ts
+++ b/packages/shared/src/schemas/cluster.ts
@@ -8,7 +8,8 @@ export const CleanedClusterSchema = z.object({
     .uuid(),
   label: z.string()
     .regex(/^[a-z0-9-]+$/i)
-    .max(50),
+    .max(50)
+    .transform(value => value.toLowerCase()),
   infos: z.string()
     .max(1000)
     .optional()


### PR DESCRIPTION
## Issues liées

Issues numéro: #2712

---------

## Quel est le comportement actuel ?

Le champ `label` d'un `Cluster` est validé avec une regex insensible à la casse (`/^[a-z0-9-]+$/i`), donc la Console accepte des majuscules dans le nom d'un cluster sans avertissement. Ce `label` est ensuite réutilisé tel quel comme nom de ressource Kubernetes dans le chart `dso-argocd-zone` (`VaultStaticSecret`), qui doit respecter la RFC 1123 (minuscules uniquement). 

Résultat : le sync ArgoCD échoue silencieusement avec une erreur peu explicite, bien après la création du cluster, sans lien évident avec la cause pour l'utilisateur.

## Quel est le nouveau comportement ?

Ajout d'un `.transform(value => value.toLowerCase())` sur  `CleanedClusterSchema.label` (`packages/shared/src/schemas/cluster.ts`) — le nom saisi est normalisé en minuscules à la validation, avant d'être stocké/réutilisé.

## Cette PR introduit-elle un breaking change ?

Non 

## Autres informations

Il est aussi possible d'inciter l'utisateur à enregistrer avec tout en miniscule. Faite moi savoir si cette option est plus interessante. 