### PR TITLE
fix(client): clarify values file path hint per value source type

### DIFF
--- a/apps/client/src/components/DeploymentValueSourceOption.vue
+++ b/apps/client/src/components/DeploymentValueSourceOption.vue
@@ -43,6 +43,13 @@ type ValueSourcePatch = Partial<Pick<Extract<UpdateDeploymentValueSource, { type
 function update(patch: ValueSourcePatch): void {
   model.value = { ...model.value, ...patch }
 }
+
+// An internal source lives in the deployed repository: its path is resolved from the
+// deployed directory, like the legacy value files. An external source points to another
+// repository, whose root is the only reference available.
+const pathHint = computed(() => model.value.type === 'external'
+  ? 'Chemin du fichier relatif à la racine du dépôt de valeurs sélectionné.'
+  : 'Chemin du fichier relatif au répertoire à déployer.')
 </script>
 
 <template>
@@ -137,7 +144,7 @@ function update(patch: ValueSourcePatch): void {
       label="Chemin du fichier de valeurs"
       label-visible
       placeholder="values.yaml"
-      hint="Chemin du fichier relatif à la racine du dépôt."
+      :hint="pathHint"
       required
       :disabled="props.disabled"
       :error-message="props.isDirty && !model.path ? 'Le chemin du fichier est requis' : undefined"


### PR DESCRIPTION
## Issues liées

Issues numéro: #2714

---------

## Quel est le comportement actuel ?

Le champ « Chemin du fichier de valeurs » affiche toujours « Chemin du fichier relatif à la racine du dépôt », ce qui pousse à répéter le répertoire à déployer pour une source interne.

## Quel est le nouveau comportement ?

Le texte d'aide dépend du type de source :
- interne : chemin relatif au répertoire à déployer
- externe : chemin relatif à la racine du dépôt de valeurs sélectionné

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Changement de libellé uniquement.
