### PR TITLE
fix: disable workspace package injection to restore link: layout

### DIFF
--- a/apps/server-nestjs/Dockerfile
+++ b/apps/server-nestjs/Dockerfile
@@ -74,7 +74,7 @@ RUN pnpm --filter @cpn-console/server-nestjs install --frozen-lockfile
 RUN pnpm --filter @cpn-console/server-nestjs run build
 
 # Export @cpn-console/server-nestjs to target build directory
-RUN pnpm --filter @cpn-console/server-nestjs --prod deploy build
+RUN pnpm --filter @cpn-console/server-nestjs --prod deploy --legacy build
 
 # Prod stage -----------------------------------------------------------------------
 FROM docker.io/node:26.7.0-bullseye-slim AS prod

--- a/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
+++ b/apps/server-nestjs/src/modules/gitlab/gitlab.service.spec.ts
@@ -589,7 +589,7 @@ describe('gitlabService', () => {
       const staleSecret = makeVaultSecret({
         data: { MIRROR_USER: accessToken.name, MIRROR_TOKEN: accessToken.token },
         metadata: {
-          created_time: faker.date.past({ years: 2 }).toISOString(),
+          created_time: faker.date.birthdate({ min: 1, max: 2, mode: 'age' }).toISOString(),
           custom_metadata: null,
           deletion_time: '',
           destroyed: false,

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -45,7 +45,7 @@ RUN pnpm run build
 # Build @cpn-console/server
 RUN pnpm --filter @cpn-console/server run build
 # Export @cpn-console/server to target build directory
-RUN pnpm --filter @cpn-console/server --prod deploy build
+RUN pnpm --filter @cpn-console/server --prod deploy --legacy build
 
 
 # Prod stage -----------------------------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
-  injectWorkspacePackages: true
 
 catalogs:
   build:
@@ -1177,7 +1176,7 @@ importers:
         version: link:../../packages/hooks
       '@cpn-console/keycloak-plugin':
         specifier: workspace:^
-        version: link:../../plugins/keycloak
+        version: link:../keycloak
       '@cpn-console/logger':
         specifier: workspace:^
         version: link:../../packages/logger
@@ -1290,7 +1289,7 @@ importers:
         version: link:../../packages/hooks
       '@cpn-console/keycloak-plugin':
         specifier: workspace:^
-        version: link:../../plugins/keycloak
+        version: link:../keycloak
       '@cpn-console/logger':
         specifier: workspace:^
         version: link:../../packages/logger
@@ -1452,7 +1451,7 @@ importers:
         version: link:../../packages/hooks
       '@cpn-console/keycloak-plugin':
         specifier: workspace:^
-        version: link:../../plugins/keycloak
+        version: link:../keycloak
       '@cpn-console/logger':
         specifier: workspace:^
         version: link:../../packages/logger
@@ -2932,10 +2931,6 @@ packages:
 
   '@keycloak/keycloak-admin-client@26.7.0':
     resolution: {integrity: sha512-QEsX19sFCvknBzV2zelEkZ7waglCqzayY1zDtoRQinHuUiAe2f7q+xXT6R8XNukn+rShB41TOlG4QR2Bt6hxhw==}
-    engines: {node: '>=18'}
-
-  '@keycloak/keycloak-admin-client@26.7.3':
-    resolution: {integrity: sha512-y9wbqcaoRjCvTF+XKaCDTBbHjuFZPbDKS/BRUzIwEBG/prHJ7YuCIsN61FzWzAVAQpvjed5YZ8x9C1/ijGV3mw==}
     engines: {node: '>=18'}
 
   '@keyv/bigmap@1.3.1':
@@ -11288,17 +11283,6 @@ snapshots:
   '@js-sdsl/ordered-map@4.4.2': {}
 
   '@keycloak/keycloak-admin-client@26.7.0':
-    dependencies:
-      '@microsoft/kiota-abstractions': 1.0.0-preview.103
-      '@microsoft/kiota-http-fetchlibrary': 1.0.0-preview.103
-      '@microsoft/kiota-serialization-form': 1.0.0-preview.103
-      '@microsoft/kiota-serialization-json': 1.0.0-preview.103
-      '@microsoft/kiota-serialization-multipart': 1.0.0-preview.103
-      '@microsoft/kiota-serialization-text': 1.0.0-preview.103
-      camelize-ts: 3.0.0
-      url-template: 3.1.1
-
-  '@keycloak/keycloak-admin-client@26.7.3':
     dependencies:
       '@microsoft/kiota-abstractions': 1.0.0-preview.103
       '@microsoft/kiota-http-fetchlibrary': 1.0.0-preview.103

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ allowBuilds:
   vue-demi: true
 allowUnusedPatches: true
 autoInstallPeers: true
-injectWorkspacePackages: true
+injectWorkspacePackages: false
 # minimum number of minutes that must pass after a version is published before
 # pnpm will install it. This applies to all dependencies, including transitive ones.
 minimumReleaseAge: 1440 # 1 day


### PR DESCRIPTION
## Quel est le comportement actuel ?

Le lockfile de main (après le revert lockfile-only) embarque `injectWorkspacePackages: true` dans son bloc `settings` : pnpm 11 persiste ce drapeau dans `pnpm-lock.yaml`, donc toutes les installations (locale, CI, Docker) restent en mode copies injectées. Les copies `file:` des packages workspace sont prises à l'install et ne contiennent pas les `types/` générés à la construction — le build Docker de `apps/server` échoue sur un store froid (`TS2307 types/class.js` via sonarqube, `TS2339` harbor sur arm64).

## Quel est le nouveau comportement ?

`injectWorkspacePackages: false` dans `pnpm-workspace.yaml` + lockfile régénéré : les importers repassent en `link:` (symlinks vivants), le bloc `settings` du lockfile enregistre le drapeau à `false`. Séquence CI exacte validée localement : `pnpm install --frozen-lockfile` OK, `pnpm --filter "./packages/**" build` OK, `pnpm --filter "./plugins/**" build` OK (sonarqube + harbor inclus). Les bumps de sécurité de fa0677c2 sont conservés.

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Un revert lockfile-only seul ne suffit pas : le drapeau vit dans le lockfile lui-même et se ré-applique à chaque résolution.